### PR TITLE
libnghttp2.pc: use full name, fix Libs.private

### DIFF
--- a/lib/libnghttp2.pc.in
+++ b/lib/libnghttp2.pc.in
@@ -1,6 +1,6 @@
 # nghttp2 - HTTP/2.0 C Library
 
-# Copyright (c) 2012 Tatsuhiro Tsujikawa
+# Copyright (c) 2012, 2013 Tatsuhiro Tsujikawa
 
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -25,10 +25,10 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: nghttp2
+Name: libnghttp2
 Description: HTTP/2.0 C library
 URL: https://github.com/tatsuhiro-t/nghttp2
 Version: @VERSION@
 Libs: -L${libdir} -lnghttp2
-Requires.private: zlib
+Libs.private: -lzlib
 Cflags: -I${includedir}


### PR DESCRIPTION
Since the name of the file is 'libnghttp2*' I think we should use the
full name within it as well (for the Name: field), as it gets confusing
otherwise for users and for pkg-config.

Also, 'Requires.private' breaks pkg-config's ability to extract -I etc
from the Cflags below it. I believe it should be 'Libs.private' and the
right side should then list the libs with -l.

With these changes, I've successfully written a configure script to
find and use libnghttp2.
