### PR TITLE
More useful warning on NPN negotiation failure due to draft version mism...

### DIFF
--- a/src/nghttp.cc
+++ b/src/nghttp.cc
@@ -1243,6 +1243,7 @@ int client_select_next_proto_cb(SSL* ssl,
   }
   if(nghttp2_select_next_protocol(out, outlen, in, inlen) <= 0) {
     std::cerr << "Server did not advertise HTTP/2.0 protocol."
+	      << " (nghttp2 expects " << NGHTTP2_PROTO_VERSION_ID << ")"
               << std::endl;
   } else {
     if(config.verbose) {


### PR DESCRIPTION
I was surprised to see that nghttp2 rejected Twitter's NPN:

$ ./src/nghttp https://twitter.com/ -v
[  0.098] NPN select next protocol: the remote server offers:
          \* HTTP-draft-06/2.0
          \* spdy/3.1
          \* spdy/3
          \* http/1.1
Server did not advertise HTTP/2.0 protocol.

After reviewing the code, I saw this was due to Twitter advertising draft-06 and nghttp2 strictly only supporting draft-09. A more helpful error message would have made this clearer. Diff attached.
