### PR TITLE
Add --disable-threads option for configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,11 @@ AC_ARG_ENABLE([debug],
                     [Turn on debug output])],
     [debug=$enableval], [debug=no])
 
+AC_ARG_ENABLE([threads],
+    [AS_HELP_STRING([--disable-threads],
+                    [Turn off threading in apps])],
+    [threads=$enableval], [threads=yes])
+
 AC_ARG_ENABLE([app],
     [AS_HELP_STRING([--enable-app],
                     [Build applications (nghttp, nghttpd and nghttpx) [default=check]])],
@@ -429,6 +434,10 @@ fi
 
 if test "x$debug" != "xno"; then
     AC_DEFINE([DEBUGBUILD], [1], [Define to 1 to enable debug output.])
+fi
+
+if test "x$threads" != "xyes"; then
+    AC_DEFINE([NOTHREADS], [1], [Define to 1 if you want to disable threads.])
 fi
 
 AC_SUBST([TESTS_LIBS])

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -666,7 +666,12 @@ int main(int argc, char **argv)
       config.nclients = strtoul(optarg, nullptr, 10);
       break;
     case 't':
+#ifdef NOTHREADS
+	  std::cerr << "-t: WARNING: Threading disabled at build time, " <<
+		  "no threads created." << std::endl;
+#else
       config.nthreads = strtoul(optarg, nullptr, 10);
+#endif /* NOTHREADS */
       break;
     case 'm':
       if(util::strieq("auto", optarg)) {
@@ -776,7 +781,9 @@ int main(int argc, char **argv)
   SSL_load_error_strings();
   SSL_library_init();
 
+#ifndef NOTHREADS
   ssl::LibsslGlobalLock();
+#endif /* NOTHREADS */
 
   auto ssl_ctx = SSL_CTX_new(SSLv23_client_method());
   if(!ssl_ctx) {

--- a/src/nghttpd.cc
+++ b/src/nghttpd.cc
@@ -185,12 +185,17 @@ int main(int argc, char **argv)
       config.error_gzip = true;
       break;
     case 'n':
+#ifdef NOTHREADS
+	  std::cerr << "-n: WARNING: Threading disabled at build time, " <<
+		  "no threads created." << std::endl;
+#else
       errno = 0;
       config.num_worker = strtoul(optarg, &end, 10);
       if(errno == ERANGE || *end != '\0' || config.num_worker == 0) {
         std::cerr << "-n: Bad option value: " << optarg << std::endl;
         exit(EXIT_FAILURE);
       }
+#endif /* NOTHREADS */
       break;
     case 'h':
       print_help(std::cout);
@@ -271,7 +276,9 @@ int main(int argc, char **argv)
   OpenSSL_add_all_algorithms();
   SSL_load_error_strings();
   SSL_library_init();
+#ifndef NOTHREADS
   ssl::LibsslGlobalLock();
+#endif /* NOTHREADS */
 
   reset_timer();
 

--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -910,7 +910,11 @@ int main(int argc, char **argv)
       cmdcfgs.emplace_back(SHRPX_OPT_INSECURE, "yes");
       break;
     case 'n':
+#ifdef NOTHREADS
+	  LOG(WARNING) << "Threading disabled at build time, no threads created.";
+#else
       cmdcfgs.emplace_back(SHRPX_OPT_WORKERS, optarg);
+#endif /* NOTHREADS */
       break;
     case 'o':
       cmdcfgs.emplace_back(SHRPX_OPT_FRONTEND_FRAME_DEBUG, "yes");
@@ -1156,7 +1160,9 @@ int main(int argc, char **argv)
   OpenSSL_add_all_algorithms();
   SSL_load_error_strings();
   SSL_library_init();
+#ifndef NOTHREADS
   nghttp2::ssl::LibsslGlobalLock();
+#endif /* NOTHREADS */
 
   if(conf_exists(get_config()->conf_path)) {
     if(load_config(get_config()->conf_path) == -1) {


### PR DESCRIPTION
This allows users of OS X 10.9 to run nghttpd (and friends) with
threading entirely disabled, to avoid crashes on startup related to
std::mutex.

This is the commits from #34 squashed into one commit, and rebased onto master as of about 30 seconds ago :)
