### PR TITLE
Fix GCC build with -Werror

### DIFF
--- a/src/timegm.h
+++ b/src/timegm.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif // HAVE_CONFIG_H
+#endif /* HAVE_CONFIG_H */
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
timegm.h:30:8: error: C++ style comments are not allowed in ISO C90 [-Werror]
