### PR TITLE
Send window size is controllable via API callbacks

### DIFF
--- a/lib/includes/nghttp2/nghttp2.h
+++ b/lib/includes/nghttp2/nghttp2.h
@@ -598,7 +598,7 @@ typedef struct {
    */
   int32_t stream_id;
   /**
-   * The type of this frame.  See `nghttp2_frame`.
+   * The type of this frame.  See `nghttp2_frame_type`.
    */
   uint8_t type;
   /**
@@ -641,6 +641,30 @@ typedef enum {
    */
   NGHTTP2_DATA_FLAG_EOF = 0x01
 } nghttp2_data_flag;
+
+/**
+ * @functypedef
+ *
+ * Callback function invoked when |session| wants to get max |length|
+ * of data to send data to the remote peer.  The implementation of this
+ * function should return a value in the following range.
+ * [1, min(session window, stream window, settings remote max frame size)].
+ * If a window size greater than this range is returned than the max allow
+ * value will be used.  Returning a window size smaller than this range is
+ * a callback error.  The frame_type is provided for future extensibility
+ * and identifies the type of frame (see nghttp2_frame_type) for which to
+ * get the |length| for.  Currently supported frame types are: NGHTTP2_DATA.
+ *
+ * This callback can be used to control the |length| in bytes
+ * for which `nghttp2_data_source_read_callback()` is allowed to send to the
+ * remote endpoint.  This callback is optional.
+ * Returning :enum:`NGHTTP2_ERR_CALLBACK_FAILURE` will signal the entire session
+ * failure.
+ */
+typedef ssize_t (*nghttp2_data_source_read_length_callback)
+(nghttp2_session *session, int32_t stream_id, int32_t session_remote_window_size,
+ int32_t stream_remote_window_size, uint32_t remote_max_frame_size, uint8_t frame_type,
+ void *user_data);
 
 /**
  * @functypedef
@@ -1475,6 +1499,11 @@ typedef struct {
    * frame.
    */
   nghttp2_select_padding_callback select_padding_callback;
+  /**
+   * The callback function used to determine the |length| allowed
+   * in `nghttp2_data_source_read_callback()`
+   */
+  nghttp2_data_source_read_length_callback read_length_callback;
 } nghttp2_session_callbacks;
 
 struct nghttp2_option;
@@ -1984,7 +2013,6 @@ int32_t nghttp2_session_get_effective_local_window_size
  */
 int32_t nghttp2_session_get_stream_remote_window_size(nghttp2_session* session,
                                                       int32_t stream_id);
-
 
 /**
  * @function

--- a/lib/nghttp2_frame.h
+++ b/lib/nghttp2_frame.h
@@ -55,8 +55,9 @@
 /* Number of inbound buffer */
 #define NGHTTP2_FRAMEBUF_MAX_NUM 5
 
-/* The maximum length of DATA frame payload. */
-#define NGHTTP2_DATA_PAYLOADLEN 4096
+/* The default length of DATA frame payload. This should be small enough
+ * for the data payload and the header to fit into 1 TLS record */
+#define NGHTTP2_DATA_PAYLOADLEN ((NGHTTP2_MAX_FRAME_SIZE_MIN) - (NGHTTP2_FRAME_HDLEN))
 
 /* Maximum headers payload length, calculated in compressed form.
    This applies to transmission only. */
@@ -78,6 +79,9 @@
 /* Minimum length of ALTSVC extension frame payload.
    NGHTTP2_ALTSVC_FIXED_PARTLEN + Host-Len. */
 #define NGHTTP2_ALTSVC_MINLEN 8
+
+/* Maximum length of padding in bytes. */
+#define NGHTTP2_MAX_PADLEN 256
 
 /* Category of frames. */
 typedef enum {

--- a/lib/nghttp2_session.c
+++ b/lib/nghttp2_session.c
@@ -1323,33 +1323,41 @@ static int nghttp2_session_predicate_settings_send(nghttp2_session *session,
   return 0;
 }
 
-/*
- * Returns the maximum length of next data read. If the
- * connection-level and/or stream-wise flow control are enabled, the
- * return value takes into account those current window sizes.
- */
-static size_t nghttp2_session_next_data_read(nghttp2_session *session,
-                                             nghttp2_stream *stream)
+/* Take into account settings max frame size and both connection-level flow control here */
+static ssize_t nghttp2_session_enforce_flow_control_limits(nghttp2_session *session,
+                                                           nghttp2_stream *stream,
+                                                           ssize_t requested_window_size)
 {
-  int32_t window_size = NGHTTP2_DATA_PAYLOADLEN;
-
   DEBUGF(fprintf(stderr,
-                 "send: remote windowsize connection=%d, "
+                 "send: remote windowsize connection=%d, remote maxframsize=%u, "
                  "stream(id %d)=%d\n",
                  session->remote_window_size,
+                 session->remote_settings.max_frame_size,
                  stream->stream_id,
                  stream->remote_window_size));
 
-  /* Take into account both connection-level flow control here */
-  window_size = nghttp2_min(window_size, session->remote_window_size);
-  window_size = nghttp2_min(window_size, stream->remote_window_size);
+  return nghttp2_min(
+            nghttp2_min(nghttp2_min(requested_window_size, stream->remote_window_size),
+            session->remote_window_size),
+         session->remote_settings.max_frame_size);
+}
 
-  DEBUGF(fprintf(stderr, "send: available window=%d\n", window_size));
+/*
+ * Returns the maximum length of next data read. If the
+ * connection-level and/or stream-wise flow control are enabled, the
+ * return value takes into account those current window sizes. The remote
+ * settings for max frame size is also taken into account.
+ */
+static size_t nghttp2_session_next_data_read(nghttp2_session *session,
+                                              nghttp2_stream *stream)
+{
+  ssize_t window_size = nghttp2_session_enforce_flow_control_limits(session,
+                                                                    stream,
+                                                                    NGHTTP2_DATA_PAYLOADLEN);
 
-  if(window_size > 0) {
-    return window_size;
-  }
-  return 0;
+  DEBUGF(fprintf(stderr, "send: available window=%zd\n", window_size));
+
+  return window_size > 0 ? (size_t) window_size : 0;
 }
 
 /*
@@ -1414,8 +1422,7 @@ static ssize_t session_call_select_padding(nghttp2_session *session,
   if(session->callbacks.select_padding_callback) {
     size_t max_paddedlen;
 
-    /* 256 is maximum padding size */
-    max_paddedlen = nghttp2_min(frame->hd.length + 256, max_payloadlen);
+    max_paddedlen = nghttp2_min(frame->hd.length + NGHTTP2_MAX_PADLEN, max_payloadlen);
 
     rv = session->callbacks.select_padding_callback(session, frame,
                                                     max_paddedlen,
@@ -1444,7 +1451,7 @@ static int session_headers_add_pad(nghttp2_session *session,
   aob = &session->aob;
   framebufs = &aob->framebufs;
 
-  max_payloadlen = nghttp2_min(NGHTTP2_MAX_PAYLOADLEN, frame->hd.length + 256);
+  max_payloadlen = nghttp2_min(NGHTTP2_MAX_PAYLOADLEN, frame->hd.length + NGHTTP2_MAX_PADLEN);
 
   padded_payloadlen = session_call_select_padding(session, frame,
                                                   max_payloadlen);
@@ -5568,6 +5575,36 @@ int nghttp2_session_pack_data(nghttp2_session *session,
 
   buf = &bufs->cur->buf;
 
+  if(session->callbacks.read_length_callback) {
+    nghttp2_stream *stream = nghttp2_session_get_stream(session, frame->hd.stream_id);
+    if(!stream) {
+      return NGHTTP2_ERR_INVALID_ARGUMENT;
+    }
+
+    payloadlen = session->callbacks.read_length_callback(session, stream->stream_id,
+        session->remote_window_size, stream->remote_window_size,
+        session->remote_settings.max_frame_size, frame->hd.type, session->user_data);
+    DEBUGF(fprintf(stderr, "send: read_length_callback=%zd\n", payloadlen));
+    payloadlen = nghttp2_session_enforce_flow_control_limits(session, stream, payloadlen);
+    DEBUGF(fprintf(stderr, "send: read_length_callback after flow control=%zd\n", payloadlen));
+    if(payloadlen <= 0) {
+      return NGHTTP2_ERR_CALLBACK_FAILURE;
+    } else if(payloadlen > nghttp2_buf_avail(buf)) {
+      // Resize the current buffer(s)
+      nghttp2_bufs_free(&session->aob.framebufs);
+
+      // The reason why we do +1 for buffer size is for possible padding field.
+      rv = nghttp2_bufs_init3(&session->aob.framebufs,
+                              NGHTTP2_FRAME_HDLEN + 1 + payloadlen,
+                              NGHTTP2_FRAMEBUF_MAX_NUM,
+                              1, NGHTTP2_FRAME_HDLEN + 1);
+      if(rv != 0) {
+        return rv;
+      }
+    }
+    datamax = (size_t) payloadlen;
+  }
+
   /* Current max DATA length is less then buffer chunk size */
   assert(nghttp2_buf_avail(buf) >= (ssize_t)datamax);
 
@@ -5611,7 +5648,7 @@ int nghttp2_session_pack_data(nghttp2_session *session,
   data_frame.hd.flags = flags;
   data_frame.data.padlen = 0;
 
-  max_payloadlen = nghttp2_min(datamax, data_frame.hd.length + 256);
+  max_payloadlen = nghttp2_min(datamax, data_frame.hd.length + NGHTTP2_MAX_PADLEN);
 
   padded_payloadlen = session_call_select_padding(session, &data_frame,
                                                   max_payloadlen);

--- a/lib/nghttp2_submit.c
+++ b/lib/nghttp2_submit.c
@@ -333,7 +333,7 @@ int nghttp2_submit_window_update(nghttp2_session *session, uint8_t flags,
                                  int32_t window_size_increment)
 {
   int rv;
-  nghttp2_stream *stream;
+  nghttp2_stream *stream = 0;
   if(window_size_increment == 0) {
     return 0;
   }

--- a/tests/main.c
+++ b/tests/main.c
@@ -142,6 +142,8 @@ int main(int argc, char* argv[])
       !CU_add_test(pSuite, "session_reprioritize_stream",
                    test_nghttp2_session_reprioritize_stream) ||
       !CU_add_test(pSuite, "submit_data", test_nghttp2_submit_data) ||
+      !CU_add_test(pSuite, "submit_data_read_length_too_large",
+                   test_nghttp2_submit_data_read_length_too_large) ||
       !CU_add_test(pSuite, "submit_request_with_data",
                    test_nghttp2_submit_request_with_data) ||
       !CU_add_test(pSuite, "submit_request_without_data",
@@ -237,6 +239,8 @@ int main(int argc, char* argv[])
                    test_nghttp2_frame_pack_headers) ||
       !CU_add_test(pSuite, "frame_pack_headers_frame_too_large",
                    test_nghttp2_frame_pack_headers_frame_too_large) ||
+      !CU_add_test(pSuite, "frame_pack_headers_frame_smallest",
+                   test_nghttp2_submit_data_read_length_smallest) ||
       !CU_add_test(pSuite, "frame_pack_priority",
                    test_nghttp2_frame_pack_priority) ||
       !CU_add_test(pSuite, "frame_pack_rst_stream",

--- a/tests/nghttp2_session_test.h
+++ b/tests/nghttp2_session_test.h
@@ -62,6 +62,8 @@ void test_nghttp2_session_is_my_stream_id(void);
 void test_nghttp2_session_upgrade(void);
 void test_nghttp2_session_reprioritize_stream(void);
 void test_nghttp2_submit_data(void);
+void test_nghttp2_submit_data_read_length_too_large(void);
+void test_nghttp2_submit_data_read_length_smallest(void);
 void test_nghttp2_submit_request_with_data(void);
 void test_nghttp2_submit_request_without_data(void);
 void test_nghttp2_submit_response_with_data(void);


### PR DESCRIPTION
The send window size is now controllable via API callbacks.  The send window size is always subject to the flow control for the current connection, stream, and remote window size settings.
