### PR TITLE
X-Forwarded-For header stripping option for nghttpx

### DIFF
--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -750,6 +750,7 @@ void fill_default_config()
   mod_config()->num_worker = 1;
   mod_config()->http2_max_concurrent_streams = 100;
   mod_config()->add_x_forwarded_for = false;
+  mod_config()->strip_incoming_x_forwarded_for = false;
   mod_config()->no_via = false;
   mod_config()->accesslog_file = nullptr;
   mod_config()->accesslog_syslog = false;
@@ -1156,6 +1157,9 @@ Misc:
   --add-x-forwarded-for
                      Append  X-Forwarded-For   header  field   to  the
                      downstream request.
+  --strip-incoming-x-forwarded-for
+                     Strip  X-Forwarded-For  header field from inbound
+                     client requests.
   --no-via           Don't append to Via  header field.  If Via header
                      field is received, it is left unaltered.
   --no-location-rewrite
@@ -1308,6 +1312,7 @@ int main(int argc, char **argv)
       {"no-location-rewrite", no_argument, &flag, 62},
       {"backend-connections-per-frontend", required_argument, &flag, 63},
       {"listener-disable-timeout", required_argument, &flag, 64},
+      {"strip-incoming-x-forwarded-for", no_argument, &flag, 65},
       {nullptr, 0, nullptr, 0 }
     };
 
@@ -1604,6 +1609,10 @@ int main(int argc, char **argv)
       case 64:
         // --listener-disable-timeout
         cmdcfgs.emplace_back(SHRPX_OPT_LISTENER_DISABLE_TIMEOUT, optarg);
+        break;
+      case 65:
+        // --strip-incoming-x-forwarded-for
+        cmdcfgs.emplace_back(SHRPX_OPT_STRIP_INCOMING_X_FORWARDED_FOR, "yes");
         break;
       default:
         break;

--- a/src/shrpx_config.cc
+++ b/src/shrpx_config.cc
@@ -67,6 +67,7 @@ const char SHRPX_OPT_HTTP2_PROXY[] = "http2-proxy";
 const char SHRPX_OPT_HTTP2_BRIDGE[] = "http2-bridge";
 const char SHRPX_OPT_CLIENT_PROXY[] = "client-proxy";
 const char SHRPX_OPT_ADD_X_FORWARDED_FOR[] = "add-x-forwarded-for";
+const char SHRPX_OPT_STRIP_INCOMING_X_FORWARDED_FOR[] = "strip-incoming-x-forwarded-for";
 const char SHRPX_OPT_NO_VIA[] = "no-via";
 const char
 SHRPX_OPT_FRONTEND_HTTP2_READ_TIMEOUT[] = "frontend-http2-read-timeout";
@@ -421,6 +422,12 @@ int parse_config(const char *opt, const char *optarg)
 
   if(util::strieq(opt, SHRPX_OPT_ADD_X_FORWARDED_FOR)) {
     mod_config()->add_x_forwarded_for = util::strieq(optarg, "yes");
+
+    return 0;
+  }
+
+  if(util::strieq(opt, SHRPX_OPT_STRIP_INCOMING_X_FORWARDED_FOR)) {
+    mod_config()->strip_incoming_x_forwarded_for = util::strieq(optarg, "yes");
 
     return 0;
   }

--- a/src/shrpx_config.h
+++ b/src/shrpx_config.h
@@ -65,6 +65,7 @@ extern const char SHRPX_OPT_HTTP2_PROXY[];
 extern const char SHRPX_OPT_HTTP2_BRIDGE[];
 extern const char SHRPX_OPT_CLIENT_PROXY[];
 extern const char SHRPX_OPT_ADD_X_FORWARDED_FOR[];
+extern const char SHRPX_OPT_STRIP_INCOMING_X_FORWARDED_FOR[];
 extern const char SHRPX_OPT_NO_VIA[];
 extern const char SHRPX_OPT_FRONTEND_HTTP2_READ_TIMEOUT[];
 extern const char SHRPX_OPT_FRONTEND_READ_TIMEOUT[];
@@ -260,6 +261,7 @@ struct Config {
   bool http2_bridge;
   bool client_proxy;
   bool add_x_forwarded_for;
+  bool strip_incoming_x_forwarded_for;
   bool no_via;
   bool upstream_no_tls;
   bool downstream_no_tls;

--- a/src/shrpx_http2_downstream_connection.cc
+++ b/src/shrpx_http2_downstream_connection.cc
@@ -394,14 +394,16 @@ int Http2DownstreamConnection::push_request_headers()
 
   auto xff = downstream_->get_norm_request_header("x-forwarded-for");
   if(get_config()->add_x_forwarded_for) {
-    if(xff != end_headers) {
+    if(xff != end_headers &&
+       !get_config()->strip_incoming_x_forwarded_for) {
       xff_value = (*xff).value;
       xff_value += ", ";
     }
     xff_value += downstream_->get_upstream()->get_client_handler()->
       get_ipaddr();
     nva.push_back(http2::make_nv_ls("x-forwarded-for", xff_value));
-  } else if(xff != end_headers) {
+  } else if(xff != end_headers &&
+            !get_config()->strip_incoming_x_forwarded_for) {
     nva.push_back(http2::make_nv_ls("x-forwarded-for", (*xff).value));
   }
 

--- a/src/shrpx_http_downstream_connection.cc
+++ b/src/shrpx_http_downstream_connection.cc
@@ -209,14 +209,16 @@ int HttpDownstreamConnection::push_request_headers()
   auto xff = downstream_->get_norm_request_header("x-forwarded-for");
   if(get_config()->add_x_forwarded_for) {
     hdrs += "X-Forwarded-For: ";
-    if(xff != end_headers) {
+    if(xff != end_headers &&
+       !get_config()->strip_incoming_x_forwarded_for) {
       hdrs += (*xff).value;
       http2::sanitize_header_value(hdrs, hdrs.size() - (*xff).value.size());
       hdrs += ", ";
     }
     hdrs += client_handler_->get_ipaddr();
     hdrs += "\r\n";
-  } else if(xff != end_headers) {
+  } else if(xff != end_headers &&
+            !get_config()->strip_incoming_x_forwarded_for) {
     hdrs += "X-Forwarded-For: ";
     hdrs += (*xff).value;
     http2::sanitize_header_value(hdrs, hdrs.size() - (*xff).value.size());


### PR DESCRIPTION
Introduces a new option `--strip-incoming-x-forwarded-for` that will remove any X-Forwarded-For header contained in an incoming request. This option can be used in combination with `--add-x-forwarded-for`. The following image captures the combinations possible and the expected downstream request header:

![stip-x-forwarded-test-results_trimmed](https://cloud.githubusercontent.com/assets/6571445/4771266/4e221146-5b8d-11e4-9986-32d4a6d219b3.PNG)
