### PR TITLE
Remote Window Size Not Updated When Settings Received

### DIFF
--- a/lib/nghttp2_session.c
+++ b/lib/nghttp2_session.c
@@ -3733,7 +3733,7 @@ int nghttp2_session_on_settings_received(nghttp2_session *session,
           (session, frame, NGHTTP2_FLOW_CONTROL_ERROR, NULL);
       }
 
-      session->remote_settings.initial_window_size = entry->value;
+      session->remote_settings.initial_window_size = session->remote_window_size = entry->value;
 
       break;
     case NGHTTP2_SETTINGS_MAX_FRAME_SIZE:


### PR DESCRIPTION
Motivation:
There are a few different variables which represent the remote window size.  Not all of them are updated to correctly utilize the available window size.

Modifications:
Update the missing variable when a settings frame is received.

Result:
Flow control window should be correctly utilized due to remote settings frame being received.
