### PR TITLE
[nghttp] copy the request entity into temporary file if necessary

### DIFF
--- a/src/nghttp.cc
+++ b/src/nghttp.cc
@@ -2120,6 +2120,11 @@ int run(char **uris, int n) {
             return 1;
           }
         }
+        if (fstat(data_fd, &data_stat) == -1) {
+          close(data_fd);
+          std::cerr << "[ERROR] Could not stat temporary file" << std::endl;
+          return 1;
+        }
       }
     } else {
       data_fd = open(config.datafile.c_str(), O_RDONLY | O_BINARY);


### PR DESCRIPTION
This pull-request changes the `nghttp` command to copy the request entity designated by `-d` option, if the value is `-` (i.e. stdin) and if it is not a regular file.  It is necessary since stdin might not be seekable, while the input needs to be read more than once if `-m` option is used.

Note: the implemetation is based on the design discussed in https://github.com/tatsuhiro-t/nghttp2/issues/133#issuecomment-67747021
Note 2: I have read the contribution guidelines and I believe that this PR does not violate the described rules.
