### PR TITLE
nghttp: Implement an Expect/Continue handshake option

### DIFF
--- a/src/nghttp.cc
+++ b/src/nghttp.cc
@@ -344,7 +344,10 @@ void ContinueTimer::stop() {
 }
 
 void ContinueTimer::dispatch_continue() {
-  ev_feed_event(loop, &timer, 0);
+  // Only dispatch the timeout callback if it hasn't already been called.
+  if (ev_is_active(&timer)) {
+    ev_feed_event(loop, &timer, 0);
+  }
 }
 
 namespace {

--- a/src/nghttp.cc
+++ b/src/nghttp.cc
@@ -687,7 +687,9 @@ void HttpClient::disconnect() {
   state = ClientState::IDLE;
 
   for (auto req = std::begin(reqvec); req != std::end(reqvec); ++req) {
-    (*req)->continue_timer->stop();
+    if ((*req)->continue_timer) {
+      (*req)->continue_timer->stop();
+    }
   }
 
   ev_timer_stop(loop, &settings_timer);

--- a/src/nghttp.cc
+++ b/src/nghttp.cc
@@ -113,7 +113,8 @@ Config::Config()
       no_content_length(false),
       no_dep(false),
       hexdump(false),
-      no_push(false) {
+      no_push(false),
+      expect_continue(false) {
   nghttp2_option_new(&http2_option);
   nghttp2_option_set_peer_max_concurrent_streams(http2_option,
                                                  peer_max_concurrent_streams);
@@ -2505,6 +2506,11 @@ Options:
   --max-concurrent-streams=<N>
               The  number of  concurrent  pushed  streams this  client
               accepts.
+  --expect-continue
+              Perform an Expect/Continue handshake:  wait to send DATA
+              (up to  a short  timeout)  until the server sends  a 100
+              Continue interim response. This option is ignored unless
+              combined with the -d option.
   --version   Display version information and exit.
   -h, --help  Display this help and exit.
 
@@ -2556,6 +2562,7 @@ int main(int argc, char **argv) {
         {"hexdump", no_argument, &flag, 10},
         {"no-push", no_argument, &flag, 11},
         {"max-concurrent-streams", required_argument, &flag, 12},
+        {"expect-continue", no_argument, &flag, 13},
         {nullptr, 0, nullptr, 0}};
     int option_index = 0;
     int c = getopt_long(argc, argv, "M:Oab:c:d:gm:np:r:hH:vst:uw:W:",
@@ -2752,6 +2759,10 @@ int main(int argc, char **argv) {
       case 12:
         // max-concurrent-streams option
         config.max_concurrent_streams = strtoul(optarg, nullptr, 10);
+        break;
+      case 13:
+        // expect-continue option
+        config.expect_continue = true;
         break;
       }
       break;

--- a/src/nghttp.h
+++ b/src/nghttp.h
@@ -119,7 +119,8 @@ struct ContinueTimer {
   void start();
   void stop();
 
-  // Schedules an immediate run of the continue callback on the loop
+  // Schedules an immediate run of the continue callback on the loop, if the
+  // callback has not already been run
   void dispatch_continue();
 
   struct ev_loop *loop;

--- a/src/nghttp.h
+++ b/src/nghttp.h
@@ -91,6 +91,7 @@ struct Config {
   bool no_dep;
   bool hexdump;
   bool no_push;
+  bool expect_continue;
 };
 
 enum class RequestState { INITIAL, ON_REQUEST, ON_RESPONSE, ON_COMPLETE };

--- a/src/nghttp.h
+++ b/src/nghttp.h
@@ -124,7 +124,6 @@ struct ContinueTimer {
   void dispatch_continue();
 
   struct ev_loop *loop;
-  Request *req;
   ev_timer timer;
 };
 
@@ -175,8 +174,8 @@ struct Request {
   // used for incoming PUSH_PROMISE
   http2::HeaderIndex req_hdidx;
   bool expect_final_response;
-  // only alive if this request is using Expect/Continue
-  std::weak_ptr<ContinueTimer> continue_timer;
+  // only assigned if this request is using Expect/Continue
+  std::unique_ptr<ContinueTimer> continue_timer;
 };
 
 struct SessionTiming {
@@ -285,8 +284,6 @@ struct HttpClient {
   Buffer<64_k> wb;
   // SETTINGS payload sent as token68 in HTTP Upgrade
   std::array<uint8_t, 128> settings_payload;
-  // List of timers for outstanding expect/continue handshakes
-  std::vector<std::shared_ptr<ContinueTimer>> continue_timers;
 
   enum { ERR_CONNECT_FAIL = -100 };
 };

--- a/src/nghttp.h
+++ b/src/nghttp.h
@@ -157,6 +157,7 @@ struct Request {
   // used for incoming PUSH_PROMISE
   http2::HeaderIndex req_hdidx;
   bool expect_final_response;
+  bool expect_continue;
 };
 
 struct SessionTiming {


### PR DESCRIPTION
This patchset implements an `--expect-continue` option for `nghttp`. The intent is to make it easier to test Expect/Continue handshakes against HTTP/2 server implementations. (For context, see [the definition of the Expect header](https://tools.ietf.org/html/rfc7231#section-5.1.1) as well as the last example in [RFC 7540, Sec 8.1.3](https://tools.ietf.org/html/rfc7540#section-8.1.3).)

The new option only takes effect when uploading data with `-d`. To avoid having a nonconforming server hang the client indefinitely, the Expect/Continue mechanism times out after a short delay (currently hard-coded to one second).

The three patches are divided as follows:

1. add the `getopt_long()` parsing for the new option
2. implement the handshake logic itself
3. add a timeout for each request using Expect/Continue

Feedback is very welcome, _especially_ relating to the timeout logic (and the lifetime/memory management of the new `ContinueTimer` struct), which is trickier than I wanted it to be. Thanks for your consideration!