### PR TITLE
in nghttp2_session_send() data is declared uninitialized and used

### DIFF
--- a/lib/nghttp2_session.c
+++ b/lib/nghttp2_session.c
@@ -2877,6 +2877,7 @@ static ssize_t nghttp2_session_mem_send_internal(nghttp2_session *session,
   aob = &session->aob;
   framebufs = &aob->framebufs;
 
+  *data_ptr = NULL;
   /* We may have idle streams more than we expect (e.g.,
      nghttp2_session_change_stream_priority() or
      nghttp2_session_create_idle_stream()).  Adjust them here. */
@@ -2885,7 +2886,6 @@ static ssize_t nghttp2_session_mem_send_internal(nghttp2_session *session,
     return rv;
   }
 
-  *data_ptr = NULL;
   for (;;) {
     switch (aob->state) {
     case NGHTTP2_OB_POP_ITEM: {
@@ -3163,7 +3163,7 @@ ssize_t nghttp2_session_mem_send(nghttp2_session *session,
 }
 
 int nghttp2_session_send(nghttp2_session *session) {
-  const uint8_t *data;
+  const uint8_t *data = NULL;
   ssize_t datalen;
   ssize_t sentlen;
   nghttp2_bufs *framebufs;


### PR DESCRIPTION
The variable data is used possibly unset after a call to 
nghttp2_session_mem_send_internal() which should
set it, however in nghttp2_session_mem_send_internal() it is
possible to return before setting the pointer.

This change initializes the variable to NULL where delcared and
sets the variable in nghttp2_session_mem_send_internal() to
NULL before possibly returning rather than after.

both options are not necessary but are both ideal practice

Note: this tickled the following compilation failure in gcc 4.8.4

nghttp2_session.c: In function 'nghttp2_session_send':
nghttp2_session.c:2942:13: error: 'data' may be used uninitialized in this function [-Werror=maybe-uninitialized]
     sentlen = session->callbacks.send_callback(session, data, (size_t)datalen,
             ^
cc1: all warnings being treated as errors
