### PR TITLE
fix warning: declaration of 'free' shadows a global declaration

### DIFF
--- a/lib/nghttp2_mem.c
+++ b/lib/nghttp2_mem.c
@@ -52,8 +52,8 @@ void nghttp2_mem_free(nghttp2_mem *mem, void *ptr) {
   mem->free(ptr, mem->mem_user_data);
 }
 
-void nghttp2_mem_free2(nghttp2_free free, void *ptr, void *mem_user_data) {
-  free(ptr, mem_user_data);
+void nghttp2_mem_free2(nghttp2_free free_func, void *ptr, void *mem_user_data) {
+  free_func(ptr, mem_user_data);
 }
 
 void *nghttp2_mem_calloc(nghttp2_mem *mem, size_t nmemb, size_t size) {

--- a/lib/nghttp2_mem.h
+++ b/lib/nghttp2_mem.h
@@ -38,7 +38,7 @@ nghttp2_mem *nghttp2_mem_default(void);
    |mem|. */
 void *nghttp2_mem_malloc(nghttp2_mem *mem, size_t size);
 void nghttp2_mem_free(nghttp2_mem *mem, void *ptr);
-void nghttp2_mem_free2(nghttp2_free free, void *ptr, void *mem_user_data);
+void nghttp2_mem_free2(nghttp2_free free_func, void *ptr, void *mem_user_data);
 void *nghttp2_mem_calloc(nghttp2_mem *mem, size_t nmemb, size_t size);
 void *nghttp2_mem_realloc(nghttp2_mem *mem, void *ptr, size_t size);
 


### PR DESCRIPTION
With some old OS X release