### PR TITLE
1. Modify genlibtokenlookup.py to remove redundant header comparisons.

### DIFF
--- a/genlibtokenlookup.py
+++ b/genlibtokenlookup.py
@@ -88,7 +88,8 @@ def build_header(headers):
         c = k[-1]
         if c not in ent:
             ent[c] = []
-        ent[c].append(k)
+        if k not in ent[c]:
+            ent[c].append(k)
 
     return res
 
@@ -106,7 +107,7 @@ def gen_enum():
 
 def gen_index_header():
     print '''\
-static inline int32_t lookup_token(const uint8_t *name, size_t namelen) {
+static int32_t lookup_token(const uint8_t *name, size_t namelen) {
   switch (namelen) {'''
     b = build_header(HEADERS)
     for size in sorted(b.keys()):

--- a/lib/nghttp2_hd.c
+++ b/lib/nghttp2_hd.c
@@ -186,9 +186,6 @@ static int32_t lookup_token(const uint8_t *name, size_t namelen) {
       if (lstreq(":pat", name, 4)) {
         return NGHTTP2_TOKEN__PATH;
       }
-      if (lstreq(":pat", name, 4)) {
-        return NGHTTP2_TOKEN__PATH;
-      }
       break;
     case 'w':
       if (lstreq("allo", name, 4)) {
@@ -225,14 +222,8 @@ static int32_t lookup_token(const uint8_t *name, size_t namelen) {
       if (lstreq(":metho", name, 6)) {
         return NGHTTP2_TOKEN__METHOD;
       }
-      if (lstreq(":metho", name, 6)) {
-        return NGHTTP2_TOKEN__METHOD;
-      }
       break;
     case 'e':
-      if (lstreq(":schem", name, 6)) {
-        return NGHTTP2_TOKEN__SCHEME;
-      }
       if (lstreq(":schem", name, 6)) {
         return NGHTTP2_TOKEN__SCHEME;
       }
@@ -251,24 +242,6 @@ static int32_t lookup_token(const uint8_t *name, size_t namelen) {
       }
       break;
     case 's':
-      if (lstreq(":statu", name, 6)) {
-        return NGHTTP2_TOKEN__STATUS;
-      }
-      if (lstreq(":statu", name, 6)) {
-        return NGHTTP2_TOKEN__STATUS;
-      }
-      if (lstreq(":statu", name, 6)) {
-        return NGHTTP2_TOKEN__STATUS;
-      }
-      if (lstreq(":statu", name, 6)) {
-        return NGHTTP2_TOKEN__STATUS;
-      }
-      if (lstreq(":statu", name, 6)) {
-        return NGHTTP2_TOKEN__STATUS;
-      }
-      if (lstreq(":statu", name, 6)) {
-        return NGHTTP2_TOKEN__STATUS;
-      }
       if (lstreq(":statu", name, 6)) {
         return NGHTTP2_TOKEN__STATUS;
       }


### PR DESCRIPTION
2. Remove inline qualifier of lookup_token() in genlibtokenlookup.py.