### PR TITLE
Allow NGHTTP2_ERR_PAUSE from nghttp2_data_source_read_callback

### DIFF
--- a/lib/includes/nghttp2/nghttp2.h
+++ b/lib/includes/nghttp2/nghttp2.h
@@ -860,8 +860,13 @@ typedef enum {
  * achieved by returning :enum:`NGHTTP2_ERR_DEFERRED` without reading
  * any data in this invocation.  The library removes DATA frame from
  * the outgoing queue temporarily.  To move back deferred DATA frame
- * to outgoing queue, call `nghttp2_session_resume_data()`.  In case
- * of error, there are 2 choices. Returning
+ * to outgoing queue, call `nghttp2_session_resume_data()`.
+ *
+ * If the application just wants to return from
+ * `nghttp2_session_send()` or `nghttp2_session_mem_send()` without
+ * sending anything, return :enum:`NGHTTP2_ERR_PAUSE`.
+ *
+ * In case of error, there are 2 choices. Returning
  * :enum:`NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE` will close the stream
  * by issuing RST_STREAM with :enum:`NGHTTP2_INTERNAL_ERROR`.  If a
  * different error code is desirable, use

--- a/tests/main.c
+++ b/tests/main.c
@@ -310,6 +310,8 @@ int main(int argc _U_, char *argv[] _U_) {
                    test_nghttp2_session_cancel_from_before_frame_send) ||
       !CU_add_test(pSuite, "session_removed_closed_stream",
                    test_nghttp2_session_removed_closed_stream) ||
+      !CU_add_test(pSuite, "session_pause_data",
+                   test_nghttp2_session_pause_data) ||
       !CU_add_test(pSuite, "http_mandatory_headers",
                    test_nghttp2_http_mandatory_headers) ||
       !CU_add_test(pSuite, "http_content_length",

--- a/tests/nghttp2_session_test.h
+++ b/tests/nghttp2_session_test.h
@@ -153,6 +153,7 @@ void test_nghttp2_session_repeated_priority_submission(void);
 void test_nghttp2_session_set_local_window_size(void);
 void test_nghttp2_session_cancel_from_before_frame_send(void);
 void test_nghttp2_session_removed_closed_stream(void);
+void test_nghttp2_session_pause_data(void);
 void test_nghttp2_http_mandatory_headers(void);
 void test_nghttp2_http_content_length(void);
 void test_nghttp2_http_content_length_mismatch(void);


### PR DESCRIPTION
This fixes #671