### PR TITLE
Make it possible to include nghttp2/CMakeLists.txt in another project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ set(LT_CURRENT  25)
 set(LT_REVISION 0)
 set(LT_AGE      11)
 
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(Version)
 
 math(EXPR LT_SOVERSION "${LT_CURRENT} - ${LT_AGE}")
@@ -408,10 +408,10 @@ configure_file(cmakeconfig.h.in config.h)
 # autotools-compatible names
 # Sphinx expects relative paths in the .rst files. Use the fact that the files
 # below are all one directory level deep.
-file(RELATIVE_PATH top_srcdir   "${CMAKE_BINARY_DIR}/dir" "${CMAKE_SOURCE_DIR}")
-file(RELATIVE_PATH top_builddir "${CMAKE_BINARY_DIR}/dir" "${CMAKE_BINARY_DIR}")
-set(abs_top_srcdir  "${CMAKE_SOURCE_DIR}")
-set(abs_top_builddir "${CMAKE_BINARY_DIR}")
+file(RELATIVE_PATH top_srcdir   "${CMAKE_CURRENT_BINARY_DIR}/dir" "${CMAKE_CURRENT_SOURCE_DIR}")
+file(RELATIVE_PATH top_builddir "${CMAKE_CURRENT_BINARY_DIR}/dir" "${CMAKE_CURRENT_BINARY_DIR}")
+set(abs_top_srcdir  "${CMAKE_CURRENT_SOURCE_DIR}")
+set(abs_top_builddir "${CMAKE_CURRENT_BINARY_DIR}")
 # libnghttp2.pc (pkg-config file)
 set(prefix          "${CMAKE_INSTALL_PREFIX}")
 set(exec_prefix     "${CMAKE_INSTALL_PREFIX}")
@@ -450,7 +450,7 @@ foreach(name
 endforeach()
 
 include_directories(
-  "${CMAKE_BINARY_DIR}" # for config.h
+  "${CMAKE_CURRENT_BINARY_DIR}" # for config.h
 )
 # For use in src/CMakeLists.txt
 set(PKGDATADIR "${CMAKE_INSTALL_FULL_DATADIR}/${CMAKE_PROJECT_NAME}")


### PR DESCRIPTION
Without this fix add_subdirectory won't work.

CMAKE_SOURCE_DIR/CMAKE_BINARY_DIR points to the top level
CMakeLists.txt. This isn't necessarily nghttp2/CMakeLists.txt.