### PR TITLE
Add set_nghttp2_debug_callback 

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -23,6 +23,7 @@ set(NGHTTP2_SOURCES
   nghttp2_mem.c
   nghttp2_http.c
   nghttp2_rcbuf.c
+  nghttp2_debug.c
 )
 
 # Public shared library

--- a/lib/includes/nghttp2/nghttp2.h
+++ b/lib/includes/nghttp2/nghttp2.h
@@ -45,6 +45,7 @@ extern "C" {
 #include <inttypes.h>
 #endif /* !defined(_MSC_VER) || (_MSC_VER >= 1800) */
 #include <sys/types.h>
+#include <stdarg.h>
 
 #include <nghttp2/nghttp2ver.h>
 
@@ -5237,6 +5238,16 @@ NGHTTP2_EXTERN int32_t nghttp2_stream_get_weight(nghttp2_stream *stream);
  */
 NGHTTP2_EXTERN int32_t
 nghttp2_stream_get_sum_dependency_weight(nghttp2_stream *stream);
+
+/**
+ * @function
+ *
+ * Sets a debug callback called by nghttp2 when built when DEBUGBUILD is
+ * defined. The function is called with arguments suitable for vfprintf.
+ */
+
+typedef void (*nghttp2_debug_cb)(const char *format, va_list args);
+NGHTTP2_EXTERN void set_nghttp2_debug_callback(nghttp2_debug_cb cb);
 
 #ifdef __cplusplus
 }

--- a/lib/nghttp2_buf.c
+++ b/lib/nghttp2_buf.c
@@ -316,9 +316,8 @@ static int bufs_alloc_chain(nghttp2_bufs *bufs) {
     return rv;
   }
 
-  DEBUGF(fprintf(stderr,
-                 "new buffer %zu bytes allocated for bufs %p, used %zu\n",
-                 bufs->chunk_length, bufs, bufs->chunk_used));
+  DEBUGF("new buffer %zu bytes allocated for bufs %p, used %zu\n",
+         bufs->chunk_length, bufs, bufs->chunk_used);
 
   ++bufs->chunk_used;
 

--- a/lib/nghttp2_debug.c
+++ b/lib/nghttp2_debug.c
@@ -22,38 +22,31 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#ifndef NGHTTP2_INT_H
-#define NGHTTP2_INT_H
+#include <time.h>
+#include <stdio.h>
+#include "config.h"
+#include <nghttp2/nghttp2.h>
+#include "nghttp2_int.h"
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif /* HAVE_CONFIG_H */
-
-/* Macros, types and constants for internal use */
+static void nghttp2_debug_cb_default(const char *fmt, va_list args)
+{
+    vfprintf(stderr, fmt, args);
+}
+static nghttp2_debug_cb static_debug_callback = &nghttp2_debug_cb_default;
 
 #ifdef DEBUGBUILD
-void nghttp2_debug(const char *format, ...);
-#define DEBUGF(...) nghttp2_debug(__VA_ARGS__)
-#else
-#define DEBUGF(...)                             \
-    do {                                        \
-    } while (0)
+void nghttp2_debug(const char *format, ...)
+{
+  if (static_debug_callback) {
+    va_list args;
+    va_start(args, format);
+    static_debug_callback(format, args);
+    va_end(args);
+  }
+}
 #endif
 
-/* "less" function, return nonzero if |lhs| is less than |rhs|. */
-typedef int (*nghttp2_less)(const void *lhs, const void *rhs);
-
-/* Internal error code. They must be in the range [-499, -100],
-   inclusive. */
-typedef enum {
-  NGHTTP2_ERR_CREDENTIAL_PENDING = -101,
-  NGHTTP2_ERR_IGN_HEADER_BLOCK = -103,
-  NGHTTP2_ERR_IGN_PAYLOAD = -104,
-  /*
-   * Invalid HTTP header field was received but it can be treated as
-   * if it was not received because of compatibility reasons.
-   */
-  NGHTTP2_ERR_IGN_HTTP_HEADER = -105
-} nghttp2_internal_error;
-
-#endif /* NGHTTP2_INT_H */
+void set_nghttp2_debug_callback(nghttp2_debug_cb cb)
+{
+  static_debug_callback = cb;
+}

--- a/lib/nghttp2_frame.c
+++ b/lib/nghttp2_frame.c
@@ -252,8 +252,7 @@ static int frame_pack_headers_shared(nghttp2_bufs *bufs,
   hd = *frame_hd;
   hd.length = nghttp2_buf_len(buf);
 
-  DEBUGF(fprintf(stderr, "send: HEADERS/PUSH_PROMISE, payloadlen=%zu\n",
-                 hd.length));
+  DEBUGF("send: HEADERS/PUSH_PROMISE, payloadlen=%zu\n", hd.length);
 
   /* We have multiple frame buffers, which means one or more
      CONTINUATION frame is involved. Remove END_HEADERS flag from the
@@ -278,8 +277,7 @@ static int frame_pack_headers_shared(nghttp2_bufs *bufs,
 
       hd.length = nghttp2_buf_len(buf);
 
-      DEBUGF(fprintf(stderr, "send: int CONTINUATION, payloadlen=%zu\n",
-                     hd.length));
+      DEBUGF("send: int CONTINUATION, payloadlen=%zu\n", hd.length);
 
       buf->pos -= NGHTTP2_FRAME_HDLEN;
       nghttp2_frame_pack_frame_hd(buf->pos, &hd);
@@ -290,8 +288,7 @@ static int frame_pack_headers_shared(nghttp2_bufs *bufs,
     /* Set END_HEADERS flag for last CONTINUATION */
     hd.flags = NGHTTP2_FLAG_END_HEADERS;
 
-    DEBUGF(fprintf(stderr, "send: last CONTINUATION, payloadlen=%zu\n",
-                   hd.length));
+    DEBUGF("send: last CONTINUATION, payloadlen=%zu\n", hd.length);
 
     buf->pos -= NGHTTP2_FRAME_HDLEN;
     nghttp2_frame_pack_frame_hd(buf->pos, &hd);
@@ -930,7 +927,7 @@ static void frame_set_pad(nghttp2_buf *buf, size_t padlen, int framehd_only) {
   size_t trail_padlen;
   size_t newlen;
 
-  DEBUGF(fprintf(stderr, "send: padlen=%zu, shift left 1 bytes\n", padlen));
+  DEBUGF("send: padlen=%zu, shift left 1 bytes\n", padlen);
 
   memmove(buf->pos - 1, buf->pos, NGHTTP2_FRAME_HDLEN);
 
@@ -960,7 +957,7 @@ int nghttp2_frame_add_pad(nghttp2_bufs *bufs, nghttp2_frame_hd *hd,
   nghttp2_buf *buf;
 
   if (padlen == 0) {
-    DEBUGF(fprintf(stderr, "send: padlen = 0, nothing to do\n"));
+    DEBUGF("send: padlen = 0, nothing to do\n");
 
     return 0;
   }
@@ -994,8 +991,7 @@ int nghttp2_frame_add_pad(nghttp2_bufs *bufs, nghttp2_frame_hd *hd,
   hd->length += padlen;
   hd->flags |= NGHTTP2_FLAG_PADDED;
 
-  DEBUGF(fprintf(stderr, "send: final payloadlen=%zu, padlen=%zu\n", hd->length,
-                 padlen));
+  DEBUGF("send: final payloadlen=%zu, padlen=%zu\n", hd->length, padlen);
 
   return 0;
 }

--- a/lib/nghttp2_hd.c
+++ b/lib/nghttp2_hd.c
@@ -769,8 +769,8 @@ static size_t entry_room(size_t namelen, size_t valuelen) {
 }
 
 static void emit_header(nghttp2_hd_nv *nv_out, nghttp2_hd_nv *nv) {
-  DEBUGF(fprintf(stderr, "inflatehd: header emission: %s: %s\n", nv->name->base,
-                 nv->value->base));
+  DEBUGF("inflatehd: header emission: %s: %s\n", nv->name->base,
+         nv->value->base);
   /* ent->ref may be 0. This happens if the encoder emits literal
      block larger than header table capacity with indexing. */
   *nv_out = *nv;
@@ -864,14 +864,14 @@ static ssize_t decode_length(uint32_t *res, size_t *shift_ptr, int *final,
     uint32_t add = *in & 0x7f;
 
     if ((UINT32_MAX >> shift) < add) {
-      DEBUGF(fprintf(stderr, "inflate: integer overflow on shift\n"));
+      DEBUGF("inflate: integer overflow on shift\n");
       return -1;
     }
 
     add <<= shift;
 
     if (UINT32_MAX - add < n) {
-      DEBUGF(fprintf(stderr, "inflate: integer overflow on addition\n"));
+      DEBUGF("inflate: integer overflow on addition\n");
       return -1;
     }
 
@@ -900,7 +900,7 @@ static int emit_table_size(nghttp2_bufs *bufs, size_t table_size) {
   size_t blocklen;
   uint8_t sb[16];
 
-  DEBUGF(fprintf(stderr, "deflatehd: emit table_size=%zu\n", table_size));
+  DEBUGF("deflatehd: emit table_size=%zu\n", table_size);
 
   blocklen = count_encoded_length(table_size, 5);
 
@@ -930,8 +930,7 @@ static int emit_indexed_block(nghttp2_bufs *bufs, size_t idx) {
 
   blocklen = count_encoded_length(idx + 1, 7);
 
-  DEBUGF(fprintf(stderr, "deflatehd: emit indexed index=%zu, %zu bytes\n", idx,
-                 blocklen));
+  DEBUGF("deflatehd: emit indexed index=%zu, %zu bytes\n", idx, blocklen);
 
   if (sizeof(sb) < blocklen) {
     return NGHTTP2_ERR_HEADER_COMP;
@@ -967,10 +966,8 @@ static int emit_string(nghttp2_bufs *bufs, const uint8_t *str, size_t len) {
 
   blocklen = count_encoded_length(enclen, 7);
 
-  DEBUGF(fprintf(stderr, "deflatehd: emit string str="));
-  DEBUGF(fwrite(str, 1, len, stderr));
-  DEBUGF(fprintf(stderr, ", length=%zu, huffman=%d, encoded_length=%zu\n", len,
-                 huffman, enclen));
+  DEBUGF("deflatehd: emit string str=%.*s, length=%zu, huffman=%d, encoded_length=%zu\n",
+         (int)len, (const char*)str, len, huffman, enclen);
 
   if (sizeof(sb) < blocklen) {
     return NGHTTP2_ERR_HEADER_COMP;
@@ -1025,9 +1022,9 @@ static int emit_indname_block(nghttp2_bufs *bufs, size_t idx,
     prefixlen = 4;
   }
 
-  DEBUGF(fprintf(stderr, "deflatehd: emit indname index=%zu, valuelen=%zu, "
-                         "indexing_mode=%d\n",
-                 idx, nv->valuelen, indexing_mode));
+  DEBUGF("deflatehd: emit indname index=%zu, valuelen=%zu, "
+         "indexing_mode=%d\n",
+         idx, nv->valuelen, indexing_mode);
 
   blocklen = count_encoded_length(idx + 1, prefixlen);
 
@@ -1058,9 +1055,9 @@ static int emit_newname_block(nghttp2_bufs *bufs, const nghttp2_nv *nv,
                               int indexing_mode) {
   int rv;
 
-  DEBUGF(fprintf(stderr, "deflatehd: emit newname namelen=%zu, valuelen=%zu, "
-                         "indexing_mode=%d\n",
-                 nv->namelen, nv->valuelen, indexing_mode));
+  DEBUGF("deflatehd: emit newname namelen=%zu, valuelen=%zu, "
+         "indexing_mode=%d\n",
+         nv->namelen, nv->valuelen, indexing_mode);
 
   rv = nghttp2_bufs_addb(bufs, pack_first_byte(indexing_mode));
   if (rv != 0) {
@@ -1100,8 +1097,8 @@ static int add_hd_table_incremental(nghttp2_hd_context *context,
     context->hd_table_bufsize -=
         entry_room(ent->nv.name->len, ent->nv.value->len);
 
-    DEBUGF(fprintf(stderr, "hpack: remove item from header table: %s: %s\n",
-                   (char *)ent->nv.name->base, (char *)ent->nv.value->base));
+    DEBUGF("hpack: remove item from header table: %s: %s\n",
+           (char *)ent->nv.name->base, (char *)ent->nv.value->base);
 
     hd_ringbuf_pop_back(&context->hd_table);
     if (map) {
@@ -1329,8 +1326,8 @@ static int deflate_nv(nghttp2_hd_deflater *deflater, nghttp2_bufs *bufs,
   nghttp2_mem *mem;
   uint32_t hash = 0;
 
-  DEBUGF(fprintf(stderr, "deflatehd: deflating %.*s: %.*s\n", (int)nv->namelen,
-                 nv->name, (int)nv->valuelen, nv->value));
+  DEBUGF("deflatehd: deflating %.*s: %.*s\n", (int)nv->namelen,
+         nv->name, (int)nv->valuelen, nv->value);
 
   mem = deflater->ctx.mem;
 
@@ -1359,7 +1356,7 @@ static int deflate_nv(nghttp2_hd_deflater *deflater, nghttp2_bufs *bufs,
 
   if (res.name_value_match) {
 
-    DEBUGF(fprintf(stderr, "deflatehd: name/value match index=%zd\n", idx));
+    DEBUGF("deflatehd: name/value match index=%zd\n", idx);
 
     rv = emit_indexed_block(bufs, (size_t)idx);
     if (rv != 0) {
@@ -1370,7 +1367,7 @@ static int deflate_nv(nghttp2_hd_deflater *deflater, nghttp2_bufs *bufs,
   }
 
   if (res.index != -1) {
-    DEBUGF(fprintf(stderr, "deflatehd: name match index=%zd\n", res.index));
+    DEBUGF("deflatehd: name match index=%zd\n", res.index);
   }
 
   if (indexing_mode == NGHTTP2_HD_WITH_INDEXING) {
@@ -1458,12 +1455,11 @@ int nghttp2_hd_deflate_hd_bufs(nghttp2_hd_deflater *deflater,
     }
   }
 
-  DEBUGF(
-      fprintf(stderr, "deflatehd: all input name/value pairs were deflated\n"));
+  DEBUGF("deflatehd: all input name/value pairs were deflated\n");
 
   return 0;
 fail:
-  DEBUGF(fprintf(stderr, "deflatehd: error return %d\n", rv));
+  DEBUGF("deflatehd: error return %d\n", rv);
 
   deflater->ctx.bad = 1;
   return rv;
@@ -1635,19 +1631,18 @@ static ssize_t hd_inflate_read_len(nghttp2_hd_inflater *inflater, int *rfin,
                      inflater->shift, in, last, prefix);
 
   if (rv == -1) {
-    DEBUGF(fprintf(stderr, "inflatehd: integer decoding failed\n"));
+    DEBUGF("inflatehd: integer decoding failed\n");
     return NGHTTP2_ERR_HEADER_COMP;
   }
 
   if (out > maxlen) {
-    DEBUGF(fprintf(
-        stderr, "inflatehd: integer exceeded the maximum value %zu\n", maxlen));
+    DEBUGF("inflatehd: integer exceeded the maximum value %zu\n", maxlen);
     return NGHTTP2_ERR_HEADER_COMP;
   }
 
   inflater->left = out;
 
-  DEBUGF(fprintf(stderr, "inflatehd: decoded integer is %u\n", out));
+  DEBUGF("inflatehd: decoded integer is %u\n", out);
 
   return rv;
 }
@@ -1678,7 +1673,7 @@ static ssize_t hd_inflate_read_huff(nghttp2_hd_inflater *inflater,
                                    (size_t)(last - in), final);
 
   if (readlen < 0) {
-    DEBUGF(fprintf(stderr, "inflatehd: huffman decoding failed\n"));
+    DEBUGF("inflatehd: huffman decoding failed\n");
     return readlen;
   }
   inflater->left -= (size_t)readlen;
@@ -1859,7 +1854,7 @@ ssize_t nghttp2_hd_inflate_hd_nv(nghttp2_hd_inflater *inflater,
     return NGHTTP2_ERR_HEADER_COMP;
   }
 
-  DEBUGF(fprintf(stderr, "inflatehd: start state=%d\n", inflater->state));
+  DEBUGF("inflatehd: start state=%d\n", inflater->state);
   hd_inflate_keep_free(inflater);
   *inflate_flags = NGHTTP2_HD_INFLATE_NONE;
   for (; in != last || busy;) {
@@ -1867,9 +1862,8 @@ ssize_t nghttp2_hd_inflate_hd_nv(nghttp2_hd_inflater *inflater,
     switch (inflater->state) {
     case NGHTTP2_HD_STATE_EXPECT_TABLE_SIZE:
       if ((*in & 0xe0u) != 0x20u) {
-        DEBUGF(fprintf(stderr, "inflatehd: header table size change was "
-                               "expected, but saw 0x%02x as first byte",
-                       *in));
+        DEBUGF("inflatehd: header table size change was "
+               "expected, but saw 0x%02x as first byte", *in);
         rv = NGHTTP2_ERR_HEADER_COMP;
         goto fail;
       }
@@ -1877,35 +1871,33 @@ ssize_t nghttp2_hd_inflate_hd_nv(nghttp2_hd_inflater *inflater,
     case NGHTTP2_HD_STATE_INFLATE_START:
     case NGHTTP2_HD_STATE_OPCODE:
       if ((*in & 0xe0u) == 0x20u) {
-        DEBUGF(fprintf(stderr, "inflatehd: header table size change\n"));
+        DEBUGF("inflatehd: header table size change\n");
         if (inflater->state == NGHTTP2_HD_STATE_OPCODE) {
-          DEBUGF(fprintf(stderr, "inflatehd: header table size change must "
-                                 "appear at the head of header block\n"));
+          DEBUGF("inflatehd: header table size change must "
+                 "appear at the head of header block\n");
           rv = NGHTTP2_ERR_HEADER_COMP;
           goto fail;
         }
         inflater->opcode = NGHTTP2_HD_OPCODE_INDEXED;
         inflater->state = NGHTTP2_HD_STATE_READ_TABLE_SIZE;
       } else if (*in & 0x80u) {
-        DEBUGF(fprintf(stderr, "inflatehd: indexed repr\n"));
+        DEBUGF("inflatehd: indexed repr\n");
         inflater->opcode = NGHTTP2_HD_OPCODE_INDEXED;
         inflater->state = NGHTTP2_HD_STATE_READ_INDEX;
       } else {
         if (*in == 0x40u || *in == 0 || *in == 0x10u) {
-          DEBUGF(
-              fprintf(stderr, "inflatehd: literal header repr - new name\n"));
+          DEBUGF("inflatehd: literal header repr - new name\n");
           inflater->opcode = NGHTTP2_HD_OPCODE_NEWNAME;
           inflater->state = NGHTTP2_HD_STATE_NEWNAME_CHECK_NAMELEN;
         } else {
-          DEBUGF(fprintf(stderr,
-                         "inflatehd: literal header repr - indexed name\n"));
+          DEBUGF("inflatehd: literal header repr - indexed name\n");
           inflater->opcode = NGHTTP2_HD_OPCODE_INDNAME;
           inflater->state = NGHTTP2_HD_STATE_READ_INDEX;
         }
         inflater->index_required = (*in & 0x40) != 0;
         inflater->no_index = (*in & 0xf0u) == 0x10u;
-        DEBUGF(fprintf(stderr, "inflatehd: indexing required=%d, no_index=%d\n",
-                       inflater->index_required, inflater->no_index));
+        DEBUGF("inflatehd: indexing required=%d, no_index=%d\n",
+               inflater->index_required, inflater->no_index);
         if (inflater->opcode == NGHTTP2_HD_OPCODE_NEWNAME) {
           ++in;
         }
@@ -1926,7 +1918,7 @@ ssize_t nghttp2_hd_inflate_hd_nv(nghttp2_hd_inflater *inflater,
       if (!rfin) {
         goto almost_ok;
       }
-      DEBUGF(fprintf(stderr, "inflatehd: table_size=%zu\n", inflater->left));
+      DEBUGF("inflatehd: table_size=%zu\n", inflater->left);
       inflater->min_hd_table_bufsize_max = UINT32_MAX;
       inflater->ctx.hd_table_bufsize_max = inflater->left;
       hd_context_shrink_table_size(&inflater->ctx, NULL);
@@ -1961,7 +1953,7 @@ ssize_t nghttp2_hd_inflate_hd_nv(nghttp2_hd_inflater *inflater,
         goto fail;
       }
 
-      DEBUGF(fprintf(stderr, "inflatehd: index=%zu\n", inflater->left));
+      DEBUGF("inflatehd: index=%zu\n", inflater->left);
       if (inflater->opcode == NGHTTP2_HD_OPCODE_INDEXED) {
         inflater->index = inflater->left;
         --inflater->index;
@@ -1984,8 +1976,8 @@ ssize_t nghttp2_hd_inflate_hd_nv(nghttp2_hd_inflater *inflater,
       inflater->state = NGHTTP2_HD_STATE_NEWNAME_READ_NAMELEN;
       inflater->left = 0;
       inflater->shift = 0;
-      DEBUGF(fprintf(stderr, "inflatehd: huffman encoded=%d\n",
-                     inflater->huffman_encoded != 0));
+      DEBUGF("inflatehd: huffman encoded=%d\n",
+             inflater->huffman_encoded != 0);
     /* Fall through */
     case NGHTTP2_HD_STATE_NEWNAME_READ_NAMELEN:
       rfin = 0;
@@ -1995,9 +1987,7 @@ ssize_t nghttp2_hd_inflate_hd_nv(nghttp2_hd_inflater *inflater,
       }
       in += rv;
       if (!rfin) {
-        DEBUGF(fprintf(stderr,
-                       "inflatehd: integer not fully decoded. current=%zu\n",
-                       inflater->left));
+        DEBUGF("inflatehd: integer not fully decoded. current=%zu\n", inflater->left);
 
         goto almost_ok;
       }
@@ -2030,11 +2020,10 @@ ssize_t nghttp2_hd_inflate_hd_nv(nghttp2_hd_inflater *inflater,
 
       in += rv;
 
-      DEBUGF(fprintf(stderr, "inflatehd: %zd bytes read\n", rv));
+      DEBUGF("inflatehd: %zd bytes read\n", rv);
 
       if (inflater->left) {
-        DEBUGF(fprintf(stderr, "inflatehd: still %zu bytes to go\n",
-                       inflater->left));
+        DEBUGF("inflatehd: still %zu bytes to go\n", inflater->left);
 
         goto almost_ok;
       }
@@ -2053,10 +2042,9 @@ ssize_t nghttp2_hd_inflate_hd_nv(nghttp2_hd_inflater *inflater,
 
       in += rv;
 
-      DEBUGF(fprintf(stderr, "inflatehd: %zd bytes read\n", rv));
+      DEBUGF("inflatehd: %zd bytes read\n", rv);
       if (inflater->left) {
-        DEBUGF(fprintf(stderr, "inflatehd: still %zu bytes to go\n",
-                       inflater->left));
+        DEBUGF("inflatehd: still %zu bytes to go\n", inflater->left);
 
         goto almost_ok;
       }
@@ -2072,8 +2060,7 @@ ssize_t nghttp2_hd_inflate_hd_nv(nghttp2_hd_inflater *inflater,
       inflater->state = NGHTTP2_HD_STATE_READ_VALUELEN;
       inflater->left = 0;
       inflater->shift = 0;
-      DEBUGF(fprintf(stderr, "inflatehd: huffman encoded=%d\n",
-                     inflater->huffman_encoded != 0));
+      DEBUGF("inflatehd: huffman encoded=%d\n", inflater->huffman_encoded != 0);
     /* Fall through */
     case NGHTTP2_HD_STATE_READ_VALUELEN:
       rfin = 0;
@@ -2088,7 +2075,7 @@ ssize_t nghttp2_hd_inflate_hd_nv(nghttp2_hd_inflater *inflater,
         goto almost_ok;
       }
 
-      DEBUGF(fprintf(stderr, "inflatehd: valuelen=%zu\n", inflater->left));
+      DEBUGF("inflatehd: valuelen=%zu\n", inflater->left);
 
       if (inflater->huffman_encoded) {
         nghttp2_hd_huff_decode_context_init(&inflater->huff_decode_ctx);
@@ -2121,11 +2108,10 @@ ssize_t nghttp2_hd_inflate_hd_nv(nghttp2_hd_inflater *inflater,
 
       in += rv;
 
-      DEBUGF(fprintf(stderr, "inflatehd: %zd bytes read\n", rv));
+      DEBUGF("inflatehd: %zd bytes read\n", rv);
 
       if (inflater->left) {
-        DEBUGF(fprintf(stderr, "inflatehd: still %zu bytes to go\n",
-                       inflater->left));
+        DEBUGF("inflatehd: still %zu bytes to go\n", inflater->left);
 
         goto almost_ok;
       }
@@ -2150,18 +2136,16 @@ ssize_t nghttp2_hd_inflate_hd_nv(nghttp2_hd_inflater *inflater,
     case NGHTTP2_HD_STATE_READ_VALUE:
       rv = hd_inflate_read(inflater, &inflater->valuebuf, in, last);
       if (rv < 0) {
-        DEBUGF(fprintf(stderr, "inflatehd: value read failure %zd: %s\n", rv,
-                       nghttp2_strerror((int)rv)));
+        DEBUGF("inflatehd: value read failure %zd: %s\n", rv, nghttp2_strerror((int)rv));
         goto fail;
       }
 
       in += rv;
 
-      DEBUGF(fprintf(stderr, "inflatehd: %zd bytes read\n", rv));
+      DEBUGF("inflatehd: %zd bytes read\n", rv);
 
       if (inflater->left) {
-        DEBUGF(fprintf(stderr, "inflatehd: still %zu bytes to go\n",
-                       inflater->left));
+        DEBUGF("inflatehd: still %zu bytes to go\n", inflater->left);
         goto almost_ok;
       }
 
@@ -2187,15 +2171,14 @@ ssize_t nghttp2_hd_inflate_hd_nv(nghttp2_hd_inflater *inflater,
 
   assert(in == last);
 
-  DEBUGF(fprintf(stderr, "inflatehd: all input bytes were processed\n"));
+  DEBUGF("inflatehd: all input bytes were processed\n");
 
   if (in_final) {
-    DEBUGF(fprintf(stderr, "inflatehd: in_final set\n"));
+    DEBUGF("inflatehd: in_final set\n");
 
     if (inflater->state != NGHTTP2_HD_STATE_OPCODE &&
         inflater->state != NGHTTP2_HD_STATE_INFLATE_START) {
-      DEBUGF(fprintf(stderr, "inflatehd: unacceptable state=%d\n",
-                     inflater->state));
+      DEBUGF("inflatehd: unacceptable state=%d\n", inflater->state);
       rv = NGHTTP2_ERR_HEADER_COMP;
 
       goto fail;
@@ -2206,7 +2189,7 @@ ssize_t nghttp2_hd_inflate_hd_nv(nghttp2_hd_inflater *inflater,
 
 almost_ok:
   if (in_final) {
-    DEBUGF(fprintf(stderr, "inflatehd: input ended prematurely\n"));
+    DEBUGF("inflatehd: input ended prematurely\n");
 
     rv = NGHTTP2_ERR_HEADER_COMP;
 
@@ -2215,7 +2198,7 @@ almost_ok:
   return (ssize_t)(in - first);
 
 fail:
-  DEBUGF(fprintf(stderr, "inflatehd: error return %zd\n", rv));
+  DEBUGF("inflatehd: error return %zd\n", rv);
 
   inflater->ctx.bad = 1;
   return rv;

--- a/lib/nghttp2_session.c
+++ b/lib/nghttp2_session.c
@@ -184,9 +184,7 @@ static int session_call_error_callback(nghttp2_session *session,
     /* vsnprintf may return error because of various things we can
        imagine, but typically we don't want to drop session just for
        debug callback. */
-    DEBUGF(fprintf(stderr,
-                   "error_callback: vsnprintf failed. The template was %s\n",
-                   fmt));
+    DEBUGF("error_callback: vsnprintf failed. The template was %s\n", fmt);
     return 0;
   }
 
@@ -373,8 +371,8 @@ static void init_settings(nghttp2_settings_storage *settings) {
 
 static void active_outbound_item_reset(nghttp2_active_outbound_item *aob,
                                        nghttp2_mem *mem) {
-  DEBUGF(fprintf(stderr, "send: reset nghttp2_active_outbound_item\n"));
-  DEBUGF(fprintf(stderr, "send: aob->item = %p\n", aob->item));
+  DEBUGF("send: reset nghttp2_active_outbound_item\n");
+  DEBUGF("send: aob->item = %p\n", aob->item);
   nghttp2_outbound_item_free(aob->item, mem);
   nghttp2_mem_free(mem, aob->item);
   aob->item = NULL;
@@ -773,10 +771,10 @@ int nghttp2_session_reprioritize_stream(
   if (pri_spec->stream_id == 0) {
     dep_stream = &session->root;
   } else if (nghttp2_stream_dep_find_ancestor(dep_stream, stream)) {
-    DEBUGF(fprintf(stderr, "stream: cycle detected, dep_stream(%p)=%d "
-                           "stream(%p)=%d\n",
-                   dep_stream, dep_stream->stream_id, stream,
-                   stream->stream_id));
+    DEBUGF("stream: cycle detected, dep_stream(%p)=%d "
+           "stream(%p)=%d\n",
+           dep_stream, dep_stream->stream_id, stream,
+           stream->stream_id);
 
     nghttp2_stream_dep_remove_subtree(dep_stream);
     rv = nghttp2_stream_dep_add_subtree(stream->dep_prev, dep_stream);
@@ -1125,8 +1123,8 @@ int nghttp2_session_close_stream(nghttp2_session *session, int32_t stream_id,
     return NGHTTP2_ERR_INVALID_ARGUMENT;
   }
 
-  DEBUGF(fprintf(stderr, "stream: stream(%p)=%d close\n", stream,
-                 stream->stream_id));
+  DEBUGF("stream: stream(%p)=%d close\n", stream,
+         stream->stream_id);
 
   if (stream->item) {
     nghttp2_outbound_item *item;
@@ -1204,8 +1202,8 @@ int nghttp2_session_destroy_stream(nghttp2_session *session,
   nghttp2_mem *mem;
   int rv;
 
-  DEBUGF(fprintf(stderr, "stream: destroy closed stream(%p)=%d\n", stream,
-                 stream->stream_id));
+  DEBUGF("stream: destroy closed stream(%p)=%d\n", stream,
+         stream->stream_id);
 
   mem = &session->mem;
 
@@ -1225,8 +1223,8 @@ int nghttp2_session_destroy_stream(nghttp2_session *session,
 
 void nghttp2_session_keep_closed_stream(nghttp2_session *session,
                                         nghttp2_stream *stream) {
-  DEBUGF(fprintf(stderr, "stream: keep closed stream(%p)=%d, state=%d\n",
-                 stream, stream->stream_id, stream->state));
+  DEBUGF("stream: keep closed stream(%p)=%d, state=%d\n",
+         stream, stream->stream_id, stream->state);
 
   if (session->closed_stream_tail) {
     session->closed_stream_tail->closed_next = stream;
@@ -1241,8 +1239,8 @@ void nghttp2_session_keep_closed_stream(nghttp2_session *session,
 
 void nghttp2_session_keep_idle_stream(nghttp2_session *session,
                                       nghttp2_stream *stream) {
-  DEBUGF(fprintf(stderr, "stream: keep idle stream(%p)=%d, state=%d\n", stream,
-                 stream->stream_id, stream->state));
+  DEBUGF("stream: keep idle stream(%p)=%d, state=%d\n", stream,
+         stream->stream_id, stream->state);
 
   if (session->idle_stream_tail) {
     session->idle_stream_tail->closed_next = stream;
@@ -1259,8 +1257,8 @@ void nghttp2_session_detach_idle_stream(nghttp2_session *session,
                                         nghttp2_stream *stream) {
   nghttp2_stream *prev_stream, *next_stream;
 
-  DEBUGF(fprintf(stderr, "stream: detach idle stream(%p)=%d, state=%d\n",
-                 stream, stream->stream_id, stream->state));
+  DEBUGF("stream: detach idle stream(%p)=%d, state=%d\n",
+         stream, stream->stream_id, stream->state);
 
   prev_stream = stream->closed_prev;
   next_stream = stream->closed_next;
@@ -1294,11 +1292,11 @@ int nghttp2_session_adjust_closed_stream(nghttp2_session *session) {
     num_stream_max = session->local_settings.max_concurrent_streams;
   }
 
-  DEBUGF(fprintf(stderr, "stream: adjusting kept closed streams "
-                         "num_closed_streams=%zu, num_incoming_streams=%zu, "
-                         "max_concurrent_streams=%zu\n",
-                 session->num_closed_streams, session->num_incoming_streams,
-                 num_stream_max));
+  DEBUGF("stream: adjusting kept closed streams "
+         "num_closed_streams=%zu, num_incoming_streams=%zu, "
+         "max_concurrent_streams=%zu\n",
+         session->num_closed_streams, session->num_incoming_streams,
+         num_stream_max);
 
   while (session->num_closed_streams > 0 &&
          session->num_closed_streams + session->num_incoming_streams >
@@ -1344,9 +1342,9 @@ int nghttp2_session_adjust_idle_stream(nghttp2_session *session) {
                16, nghttp2_min(session->local_settings.max_concurrent_streams,
                                session->pending_local_max_concurrent_stream)));
 
-  DEBUGF(fprintf(stderr, "stream: adjusting kept idle streams "
-                         "num_idle_streams=%zu, max=%zu\n",
-                 session->num_idle_streams, max));
+  DEBUGF("stream: adjusting kept idle streams "
+         "num_idle_streams=%zu, max=%zu\n",
+         session->num_idle_streams, max);
 
   while (session->num_idle_streams > max) {
     nghttp2_stream *head;
@@ -1741,11 +1739,11 @@ static ssize_t
 nghttp2_session_enforce_flow_control_limits(nghttp2_session *session,
                                             nghttp2_stream *stream,
                                             ssize_t requested_window_size) {
-  DEBUGF(fprintf(stderr, "send: remote windowsize connection=%d, "
-                         "remote maxframsize=%u, stream(id %d)=%d\n",
-                 session->remote_window_size,
-                 session->remote_settings.max_frame_size, stream->stream_id,
-                 stream->remote_window_size));
+  DEBUGF("send: remote windowsize connection=%d, "
+         "remote maxframsize=%u, stream(id %d)=%d\n",
+         session->remote_window_size,
+         session->remote_settings.max_frame_size, stream->stream_id,
+         stream->remote_window_size);
 
   return nghttp2_min(nghttp2_min(nghttp2_min(requested_window_size,
                                              stream->remote_window_size),
@@ -1766,7 +1764,7 @@ static size_t nghttp2_session_next_data_read(nghttp2_session *session,
   window_size = nghttp2_session_enforce_flow_control_limits(
       session, stream, NGHTTP2_DATA_PAYLOADLEN);
 
-  DEBUGF(fprintf(stderr, "send: available window=%zd\n", window_size));
+  DEBUGF("send: available window=%zd\n", window_size);
 
   return window_size > 0 ? (size_t)window_size : 0;
 }
@@ -1873,8 +1871,8 @@ static int session_headers_add_pad(nghttp2_session *session,
 
   padlen = (size_t)padded_payloadlen - frame->hd.length;
 
-  DEBUGF(fprintf(stderr, "send: padding selected: payloadlen=%zd, padlen=%zu\n",
-                 padded_payloadlen, padlen));
+  DEBUGF("send: padding selected: payloadlen=%zd, padlen=%zu\n",
+         padded_payloadlen, padlen);
 
   rv = nghttp2_frame_add_pad(framebufs, &frame->hd, padlen, 0);
 
@@ -2122,9 +2120,8 @@ static int session_prep_frame(nghttp2_session *session,
       return rv;
     }
 
-    DEBUGF(fprintf(stderr,
-                   "send: before padding, HEADERS serialized in %zd bytes\n",
-                   nghttp2_bufs_len(&session->aob.framebufs)));
+    DEBUGF("send: before padding, HEADERS serialized in %zd bytes\n",
+           nghttp2_bufs_len(&session->aob.framebufs));
 
     rv = session_headers_add_pad(session, frame);
 
@@ -2132,8 +2129,8 @@ static int session_prep_frame(nghttp2_session *session,
       return rv;
     }
 
-    DEBUGF(fprintf(stderr, "send: HEADERS finally serialized in %zd bytes\n",
-                   nghttp2_bufs_len(&session->aob.framebufs)));
+    DEBUGF("send: HEADERS finally serialized in %zd bytes\n",
+           nghttp2_bufs_len(&session->aob.framebufs));
 
     if (frame->headers.cat == NGHTTP2_HCAT_REQUEST) {
       assert(session->last_sent_stream_id < frame->hd.stream_id);
@@ -2559,7 +2556,7 @@ static int session_after_frame_sent1(nghttp2_session *session) {
   if (frame->hd.type == NGHTTP2_HEADERS ||
       frame->hd.type == NGHTTP2_PUSH_PROMISE) {
     if (nghttp2_bufs_next_present(framebufs)) {
-      DEBUGF(fprintf(stderr, "send: CONTINUATION exists, just return\n"));
+      DEBUGF("send: CONTINUATION exists, just return\n");
       return 0;
     }
   }
@@ -2775,8 +2772,8 @@ static int session_after_frame_sent2(nghttp2_session *session) {
       if (nghttp2_bufs_next_present(framebufs)) {
         framebufs->cur = framebufs->cur->next;
 
-        DEBUGF(fprintf(stderr, "send: next CONTINUATION frame, %zu bytes\n",
-                       nghttp2_buf_len(&framebufs->cur->buf)));
+        DEBUGF("send: next CONTINUATION frame, %zu bytes\n",
+               nghttp2_buf_len(&framebufs->cur->buf));
 
         return 0;
       }
@@ -2892,15 +2889,15 @@ static ssize_t nghttp2_session_mem_send_internal(nghttp2_session *session,
         return 0;
       }
       if (rv == NGHTTP2_ERR_DEFERRED) {
-        DEBUGF(fprintf(stderr, "send: frame transmission deferred\n"));
+        DEBUGF("send: frame transmission deferred\n");
         break;
       }
       if (rv < 0) {
         int32_t opened_stream_id = 0;
         uint32_t error_code = NGHTTP2_INTERNAL_ERROR;
 
-        DEBUGF(fprintf(stderr, "send: frame preparation failed with %s\n",
-                       nghttp2_strerror(rv)));
+        DEBUGF("send: frame preparation failed with %s\n",
+               nghttp2_strerror(rv));
         /* TODO If the error comes from compressor, the connection
            must be closed. */
         if (item->frame.hd.type != NGHTTP2_DATA &&
@@ -2974,10 +2971,10 @@ static ssize_t nghttp2_session_mem_send_internal(nghttp2_session *session,
 
         frame = &item->frame;
 
-        DEBUGF(fprintf(stderr, "send: next frame: payloadlen=%zu, type=%u, "
-                               "flags=0x%02x, stream_id=%d\n",
-                       frame->hd.length, frame->hd.type, frame->hd.flags,
-                       frame->hd.stream_id));
+        DEBUGF("send: next frame: payloadlen=%zu, type=%u, "
+               "flags=0x%02x, stream_id=%d\n",
+               frame->hd.length, frame->hd.type, frame->hd.flags,
+               frame->hd.stream_id);
 
         rv = session_call_before_frame_send(session, frame);
         if (nghttp2_is_fatal(rv)) {
@@ -3029,7 +3026,7 @@ static ssize_t nghttp2_session_mem_send_internal(nghttp2_session *session,
           break;
         }
       } else {
-        DEBUGF(fprintf(stderr, "send: next frame: DATA\n"));
+        DEBUGF("send: next frame: DATA\n");
 
         if (item->aux_data.data.no_copy) {
           aob->state = NGHTTP2_OB_SEND_NO_COPY;
@@ -3037,10 +3034,9 @@ static ssize_t nghttp2_session_mem_send_internal(nghttp2_session *session,
         }
       }
 
-      DEBUGF(fprintf(stderr,
-                     "send: start transmitting frame type=%u, length=%zd\n",
-                     framebufs->cur->buf.pos[3],
-                     framebufs->cur->buf.last - framebufs->cur->buf.pos));
+      DEBUGF("send: start transmitting frame type=%u, length=%zd\n",
+             framebufs->cur->buf.pos[3],
+             framebufs->cur->buf.last - framebufs->cur->buf.pos);
 
       aob->state = NGHTTP2_OB_SEND_DATA;
 
@@ -3053,7 +3049,7 @@ static ssize_t nghttp2_session_mem_send_internal(nghttp2_session *session,
       buf = &framebufs->cur->buf;
 
       if (buf->pos == buf->last) {
-        DEBUGF(fprintf(stderr, "send: end transmission of a frame\n"));
+        DEBUGF("send: end transmission of a frame\n");
 
         /* Frame has completely sent */
         if (fast_cb) {
@@ -3090,15 +3086,13 @@ static ssize_t nghttp2_session_mem_send_internal(nghttp2_session *session,
       nghttp2_frame *frame;
       int pause;
 
-      DEBUGF(fprintf(stderr, "send: no copy DATA\n"));
+      DEBUGF("send: no copy DATA\n");
 
       frame = &aob->item->frame;
 
       stream = nghttp2_session_get_stream(session, frame->hd.stream_id);
       if (stream == NULL) {
-        DEBUGF(fprintf(
-            stderr,
-            "send: no copy DATA cancelled because stream was closed\n"));
+        DEBUGF("send: no copy DATA cancelled because stream was closed\n");
 
         active_outbound_item_reset(aob, mem);
 
@@ -3160,7 +3154,7 @@ static ssize_t nghttp2_session_mem_send_internal(nghttp2_session *session,
       buf = &framebufs->cur->buf;
 
       if (buf->pos == buf->last) {
-        DEBUGF(fprintf(stderr, "send: end transmission of client magic\n"));
+        DEBUGF("send: end transmission of client magic\n");
         active_outbound_item_reset(aob, mem);
         break;
       }
@@ -3280,8 +3274,7 @@ static int session_call_on_frame_received(nghttp2_session *session,
 static int session_call_on_begin_headers(nghttp2_session *session,
                                          nghttp2_frame *frame) {
   int rv;
-  DEBUGF(fprintf(stderr, "recv: call on_begin_headers callback stream_id=%d\n",
-                 frame->hd.stream_id));
+  DEBUGF("recv: call on_begin_headers callback stream_id=%d\n", frame->hd.stream_id);
   if (session->callbacks.on_begin_headers_callback) {
     rv = session->callbacks.on_begin_headers_callback(session, frame,
                                                       session->user_data);
@@ -3537,7 +3530,7 @@ static int inflate_header_block(nghttp2_session *session, nghttp2_frame *frame,
     trailer = session_trailer_headers(session, stream, frame);
   }
 
-  DEBUGF(fprintf(stderr, "recv: decoding header block %zu bytes\n", inlen));
+  DEBUGF("recv: decoding header block %zu bytes\n", inlen);
   for (;;) {
     inflate_flags = 0;
     proclen = nghttp2_hd_inflate_hd_nv(&session->hd_inflater, &nv,
@@ -3571,7 +3564,7 @@ static int inflate_header_block(nghttp2_session *session, nghttp2_frame *frame,
     inlen -= (size_t)proclen;
     *readlen_ptr += (size_t)proclen;
 
-    DEBUGF(fprintf(stderr, "recv: proclen=%zd\n", proclen));
+    DEBUGF("recv: proclen=%zd\n", proclen);
 
     if (call_header_cb && (inflate_flags & NGHTTP2_HD_INFLATE_EMIT)) {
       rv = 0;
@@ -3579,10 +3572,9 @@ static int inflate_header_block(nghttp2_session *session, nghttp2_frame *frame,
         rv = nghttp2_http_on_header(session, subject_stream, frame, &nv,
                                     trailer);
         if (rv == NGHTTP2_ERR_HTTP_HEADER) {
-          DEBUGF(fprintf(
-              stderr, "recv: HTTP error: type=%u, id=%d, header %.*s: %.*s\n",
-              frame->hd.type, frame->hd.stream_id, (int)nv.name->len,
-              nv.name->base, (int)nv.value->len, nv.value->base));
+            DEBUGF("recv: HTTP error: type=%u, id=%d, header %.*s: %.*s\n",
+                   frame->hd.type, frame->hd.stream_id, (int)nv.name->len,
+                   nv.name->base, (int)nv.value->len, nv.value->base);
 
           rv = session_call_error_callback(
               session, "Invalid HTTP header field was received: frame type: "
@@ -3615,10 +3607,9 @@ static int inflate_header_block(nghttp2_session *session, nghttp2_frame *frame,
           }
 
           /* header is ignored */
-          DEBUGF(fprintf(
-              stderr, "recv: HTTP ignored: type=%u, id=%d, header %.*s: %.*s\n",
-              frame->hd.type, frame->hd.stream_id, (int)nv.name->len,
-              nv.name->base, (int)nv.value->len, nv.value->base));
+          DEBUGF("recv: HTTP ignored: type=%u, id=%d, header %.*s: %.*s\n",
+                 frame->hd.type, frame->hd.stream_id, (int)nv.name->len,
+                 nv.name->base, (int)nv.value->len, nv.value->base);
 
           rv2 = session_call_error_callback(
               session,
@@ -5173,8 +5164,7 @@ static void inbound_frame_set_settings_entry(nghttp2_inbound_frame *iframe) {
   case NGHTTP2_SETTINGS_MAX_HEADER_LIST_SIZE:
     break;
   default:
-    DEBUGF(
-        fprintf(stderr, "recv: unknown settings id=0x%02x\n", iv.settings_id));
+    DEBUGF("recv: unknown settings id=0x%02x\n", iv.settings_id);
 
     iframe->iv[iframe->niv++] = iv;
 
@@ -5216,7 +5206,7 @@ static int inbound_frame_handle_pad(nghttp2_inbound_frame *iframe,
     inbound_frame_set_mark(iframe, 1);
     return 1;
   }
-  DEBUGF(fprintf(stderr, "recv: no padding in payload\n"));
+  DEBUGF("recv: no padding in payload\n");
   return 0;
 }
 
@@ -5230,7 +5220,7 @@ static ssize_t inbound_frame_compute_pad(nghttp2_inbound_frame *iframe) {
   /* 1 for Pad Length field */
   padlen = (size_t)(iframe->sbuf.pos[0] + 1);
 
-  DEBUGF(fprintf(stderr, "recv: padlen=%zu\n", padlen));
+  DEBUGF("recv: padlen=%zu\n", padlen);
 
   /* We cannot use iframe->frame.hd.length because of CONTINUATION */
   if (padlen - 1 > iframe->payloadleft) {
@@ -5278,9 +5268,8 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
   size_t pri_fieldlen;
   nghttp2_mem *mem;
 
-  DEBUGF(fprintf(stderr,
-                 "recv: connection recv_window_size=%d, local_window=%d\n",
-                 session->recv_window_size, session->local_window_size));
+  DEBUGF("recv: connection recv_window_size=%d, local_window=%d\n",
+         session->recv_window_size, session->local_window_size);
 
   mem = &session->mem;
 
@@ -5313,7 +5302,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
 
       break;
     case NGHTTP2_IB_READ_FIRST_SETTINGS:
-      DEBUGF(fprintf(stderr, "recv: [IB_READ_FIRST_SETTINGS]\n"));
+      DEBUGF("recv: [IB_READ_FIRST_SETTINGS]\n");
 
       readlen = inbound_frame_buf_read(iframe, in, last);
       in += readlen;
@@ -5352,7 +5341,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
     case NGHTTP2_IB_READ_HEAD: {
       int on_begin_frame_called = 0;
 
-      DEBUGF(fprintf(stderr, "recv: [IB_READ_HEAD]\n"));
+      DEBUGF("recv: [IB_READ_HEAD]\n");
 
       readlen = inbound_frame_buf_read(iframe, in, last);
       in += readlen;
@@ -5364,15 +5353,15 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
       nghttp2_frame_unpack_frame_hd(&iframe->frame.hd, iframe->sbuf.pos);
       iframe->payloadleft = iframe->frame.hd.length;
 
-      DEBUGF(fprintf(stderr, "recv: payloadlen=%zu, type=%u, flags=0x%02x, "
-                             "stream_id=%d\n",
-                     iframe->frame.hd.length, iframe->frame.hd.type,
-                     iframe->frame.hd.flags, iframe->frame.hd.stream_id));
+      DEBUGF("recv: payloadlen=%zu, type=%u, flags=0x%02x, "
+             "stream_id=%d\n",
+             iframe->frame.hd.length, iframe->frame.hd.type,
+             iframe->frame.hd.flags, iframe->frame.hd.stream_id);
 
       if (iframe->frame.hd.length > session->local_settings.max_frame_size) {
-        DEBUGF(fprintf(stderr, "recv: length is too large %zu > %u\n",
-                       iframe->frame.hd.length,
-                       session->local_settings.max_frame_size));
+        DEBUGF("recv: length is too large %zu > %u\n",
+               iframe->frame.hd.length,
+               session->local_settings.max_frame_size);
 
         busy = 1;
 
@@ -5390,7 +5379,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
 
       switch (iframe->frame.hd.type) {
       case NGHTTP2_DATA: {
-        DEBUGF(fprintf(stderr, "recv: DATA\n"));
+        DEBUGF("recv: DATA\n");
 
         iframe->frame.hd.flags &=
             (NGHTTP2_FLAG_END_STREAM | NGHTTP2_FLAG_PADDED);
@@ -5400,8 +5389,8 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
 
         rv = session_on_data_received_fail_fast(session);
         if (rv == NGHTTP2_ERR_IGN_PAYLOAD) {
-          DEBUGF(fprintf(stderr, "recv: DATA not allowed stream_id=%d\n",
-                         iframe->frame.hd.stream_id));
+          DEBUGF("recv: DATA not allowed stream_id=%d\n",
+                 iframe->frame.hd.stream_id);
           iframe->state = NGHTTP2_IB_IGN_DATA;
           break;
         }
@@ -5433,7 +5422,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
       }
       case NGHTTP2_HEADERS:
 
-        DEBUGF(fprintf(stderr, "recv: HEADERS\n"));
+        DEBUGF("recv: HEADERS\n");
 
         iframe->frame.hd.flags &=
             (NGHTTP2_FLAG_END_STREAM | NGHTTP2_FLAG_END_HEADERS |
@@ -5512,7 +5501,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
 
         break;
       case NGHTTP2_PRIORITY:
-        DEBUGF(fprintf(stderr, "recv: PRIORITY\n"));
+        DEBUGF("recv: PRIORITY\n");
 
         iframe->frame.hd.flags = NGHTTP2_FLAG_NONE;
 
@@ -5534,10 +5523,10 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
 #ifdef DEBUGBUILD
         switch (iframe->frame.hd.type) {
         case NGHTTP2_RST_STREAM:
-          DEBUGF(fprintf(stderr, "recv: RST_STREAM\n"));
+          DEBUGF("recv: RST_STREAM\n");
           break;
         case NGHTTP2_WINDOW_UPDATE:
-          DEBUGF(fprintf(stderr, "recv: WINDOW_UPDATE\n"));
+          DEBUGF("recv: WINDOW_UPDATE\n");
           break;
         }
 #endif /* DEBUGBUILD */
@@ -5556,7 +5545,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
 
         break;
       case NGHTTP2_SETTINGS:
-        DEBUGF(fprintf(stderr, "recv: SETTINGS\n"));
+        DEBUGF("recv: SETTINGS\n");
 
         iframe->frame.hd.flags &= NGHTTP2_FLAG_ACK;
 
@@ -5600,7 +5589,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
 
         break;
       case NGHTTP2_PUSH_PROMISE:
-        DEBUGF(fprintf(stderr, "recv: PUSH_PROMISE\n"));
+        DEBUGF("recv: PUSH_PROMISE\n");
 
         iframe->frame.hd.flags &=
             (NGHTTP2_FLAG_END_HEADERS | NGHTTP2_FLAG_PADDED);
@@ -5635,7 +5624,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
 
         break;
       case NGHTTP2_PING:
-        DEBUGF(fprintf(stderr, "recv: PING\n"));
+        DEBUGF("recv: PING\n");
 
         iframe->frame.hd.flags &= NGHTTP2_FLAG_ACK;
 
@@ -5650,7 +5639,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
 
         break;
       case NGHTTP2_GOAWAY:
-        DEBUGF(fprintf(stderr, "recv: GOAWAY\n"));
+        DEBUGF("recv: GOAWAY\n");
 
         iframe->frame.hd.flags = NGHTTP2_FLAG_NONE;
 
@@ -5665,7 +5654,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
 
         break;
       case NGHTTP2_CONTINUATION:
-        DEBUGF(fprintf(stderr, "recv: unexpected CONTINUATION\n"));
+        DEBUGF("recv: unexpected CONTINUATION\n");
 
         /* Receiving CONTINUATION in this state are subject to
            connection error of type PROTOCOL_ERROR */
@@ -5681,7 +5670,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
 
         break;
       default:
-        DEBUGF(fprintf(stderr, "recv: extension frame\n"));
+        DEBUGF("recv: extension frame\n");
 
         if (check_ext_type_set(session->user_recv_ext_types,
                                iframe->frame.hd.type)) {
@@ -5710,7 +5699,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
               break;
             }
 
-            DEBUGF(fprintf(stderr, "recv: ALTSVC\n"));
+            DEBUGF("recv: ALTSVC\n");
 
             iframe->frame.hd.flags = NGHTTP2_FLAG_NONE;
             iframe->frame.ext.payload = &iframe->ext_frame_payload.altsvc;
@@ -5762,15 +5751,15 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
       break;
     }
     case NGHTTP2_IB_READ_NBYTE:
-      DEBUGF(fprintf(stderr, "recv: [IB_READ_NBYTE]\n"));
+      DEBUGF("recv: [IB_READ_NBYTE]\n");
 
       readlen = inbound_frame_buf_read(iframe, in, last);
       in += readlen;
       iframe->payloadleft -= readlen;
 
-      DEBUGF(fprintf(stderr, "recv: readlen=%zu, payloadleft=%zu, left=%zd\n",
-                     readlen, iframe->payloadleft,
-                     nghttp2_buf_mark_avail(&iframe->sbuf)));
+      DEBUGF("recv: readlen=%zu, payloadleft=%zu, left=%zd\n",
+             readlen, iframe->payloadleft,
+             nghttp2_buf_mark_avail(&iframe->sbuf));
 
       if (nghttp2_buf_mark_avail(&iframe->sbuf)) {
         return in - first;
@@ -5955,7 +5944,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
 
         origin_len = nghttp2_get_uint16(iframe->sbuf.pos);
 
-        DEBUGF(fprintf(stderr, "recv: origin_len=%zu\n", origin_len));
+        DEBUGF("recv: origin_len=%zu\n", origin_len);
 
         if (2 + origin_len > iframe->payloadleft) {
           busy = 1;
@@ -5995,16 +5984,16 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
       int final;
 #ifdef DEBUGBUILD
       if (iframe->state == NGHTTP2_IB_READ_HEADER_BLOCK) {
-        fprintf(stderr, "recv: [IB_READ_HEADER_BLOCK]\n");
+        DEBUGF("recv: [IB_READ_HEADER_BLOCK]\n");
       } else {
-        fprintf(stderr, "recv: [IB_IGN_HEADER_BLOCK]\n");
+        DEBUGF("recv: [IB_IGN_HEADER_BLOCK]\n");
       }
 #endif /* DEBUGBUILD */
 
       readlen = inbound_frame_payload_readlen(iframe, in, last);
 
-      DEBUGF(fprintf(stderr, "recv: readlen=%zu, payloadleft=%zu\n", readlen,
-                     iframe->payloadleft - readlen));
+      DEBUGF("recv: readlen=%zu, payloadleft=%zu\n", readlen,
+             iframe->payloadleft - readlen);
 
       data_readlen = inbound_frame_effective_readlen(
           iframe, iframe->payloadleft - readlen, readlen);
@@ -6016,7 +6005,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
       if (data_readlen > 0 || (data_readlen == 0 && final)) {
         size_t hd_proclen = 0;
 
-        DEBUGF(fprintf(stderr, "recv: block final=%d\n", final));
+        DEBUGF("recv: block final=%d\n", final);
 
         rv =
             inflate_header_block(session, &iframe->frame, &hd_proclen,
@@ -6100,14 +6089,14 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
       break;
     }
     case NGHTTP2_IB_IGN_PAYLOAD:
-      DEBUGF(fprintf(stderr, "recv: [IB_IGN_PAYLOAD]\n"));
+      DEBUGF("recv: [IB_IGN_PAYLOAD]\n");
 
       readlen = inbound_frame_payload_readlen(iframe, in, last);
       iframe->payloadleft -= readlen;
       in += readlen;
 
-      DEBUGF(fprintf(stderr, "recv: readlen=%zu, payloadleft=%zu\n", readlen,
-                     iframe->payloadleft));
+      DEBUGF("recv: readlen=%zu, payloadleft=%zu\n", readlen,
+             iframe->payloadleft);
 
       if (iframe->payloadleft) {
         break;
@@ -6128,7 +6117,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
 
       break;
     case NGHTTP2_IB_FRAME_SIZE_ERROR:
-      DEBUGF(fprintf(stderr, "recv: [IB_FRAME_SIZE_ERROR]\n"));
+      DEBUGF("recv: [IB_FRAME_SIZE_ERROR]\n");
 
       rv = session_handle_frame_size_error(session, &iframe->frame);
       if (nghttp2_is_fatal(rv)) {
@@ -6141,14 +6130,13 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
 
       break;
     case NGHTTP2_IB_READ_SETTINGS:
-      DEBUGF(fprintf(stderr, "recv: [IB_READ_SETTINGS]\n"));
+      DEBUGF("recv: [IB_READ_SETTINGS]\n");
 
       readlen = inbound_frame_buf_read(iframe, in, last);
       iframe->payloadleft -= readlen;
       in += readlen;
 
-      DEBUGF(fprintf(stderr, "recv: readlen=%zu, payloadleft=%zu\n", readlen,
-                     iframe->payloadleft));
+      DEBUGF("recv: readlen=%zu, payloadleft=%zu\n", readlen, iframe->payloadleft);
 
       if (nghttp2_buf_mark_avail(&iframe->sbuf)) {
         break;
@@ -6172,7 +6160,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
 
       break;
     case NGHTTP2_IB_READ_GOAWAY_DEBUG:
-      DEBUGF(fprintf(stderr, "recv: [IB_READ_GOAWAY_DEBUG]\n"));
+      DEBUGF("recv: [IB_READ_GOAWAY_DEBUG]\n");
 
       readlen = inbound_frame_payload_readlen(iframe, in, last);
 
@@ -6183,8 +6171,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
         in += readlen;
       }
 
-      DEBUGF(fprintf(stderr, "recv: readlen=%zu, payloadleft=%zu\n", readlen,
-                     iframe->payloadleft));
+      DEBUGF("recv: readlen=%zu, payloadleft=%zu\n", readlen, iframe->payloadleft);
 
       if (iframe->payloadleft) {
         assert(nghttp2_buf_avail(&iframe->lbuf) > 0);
@@ -6221,17 +6208,17 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
       nghttp2_frame_unpack_frame_hd(&cont_hd, iframe->sbuf.pos);
       iframe->payloadleft = cont_hd.length;
 
-      DEBUGF(fprintf(stderr, "recv: payloadlen=%zu, type=%u, flags=0x%02x, "
-                             "stream_id=%d\n",
-                     cont_hd.length, cont_hd.type, cont_hd.flags,
-                     cont_hd.stream_id));
+      DEBUGF("recv: payloadlen=%zu, type=%u, flags=0x%02x, "
+             "stream_id=%d\n",
+             cont_hd.length, cont_hd.type, cont_hd.flags,
+             cont_hd.stream_id);
 
       if (cont_hd.type != NGHTTP2_CONTINUATION ||
           cont_hd.stream_id != iframe->frame.hd.stream_id) {
-        DEBUGF(fprintf(stderr, "recv: expected stream_id=%d, type=%d, but "
-                               "got stream_id=%d, type=%u\n",
-                       iframe->frame.hd.stream_id, NGHTTP2_CONTINUATION,
-                       cont_hd.stream_id, cont_hd.type));
+        DEBUGF("recv: expected stream_id=%d, type=%d, but "
+               "got stream_id=%d, type=%u\n",
+               iframe->frame.hd.stream_id, NGHTTP2_CONTINUATION,
+               cont_hd.stream_id, cont_hd.type);
         rv = nghttp2_session_terminate_session_with_reason(
             session, NGHTTP2_PROTOCOL_ERROR,
             "unexpected non-CONTINUATION frame or stream_id is invalid");
@@ -6268,15 +6255,15 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
 
       break;
     case NGHTTP2_IB_READ_PAD_DATA:
-      DEBUGF(fprintf(stderr, "recv: [IB_READ_PAD_DATA]\n"));
+      DEBUGF("recv: [IB_READ_PAD_DATA]\n");
 
       readlen = inbound_frame_buf_read(iframe, in, last);
       in += readlen;
       iframe->payloadleft -= readlen;
 
-      DEBUGF(fprintf(stderr, "recv: readlen=%zu, payloadleft=%zu, left=%zu\n",
-                     readlen, iframe->payloadleft,
-                     nghttp2_buf_mark_avail(&iframe->sbuf)));
+      DEBUGF("recv: readlen=%zu, payloadleft=%zu, left=%zu\n",
+             readlen, iframe->payloadleft,
+             nghttp2_buf_mark_avail(&iframe->sbuf));
 
       if (nghttp2_buf_mark_avail(&iframe->sbuf)) {
         return in - first;
@@ -6334,14 +6321,13 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
         break;
       }
 
-      DEBUGF(fprintf(stderr, "recv: [IB_READ_DATA]\n"));
+      DEBUGF("recv: [IB_READ_DATA]\n");
 
       readlen = inbound_frame_payload_readlen(iframe, in, last);
       iframe->payloadleft -= readlen;
       in += readlen;
 
-      DEBUGF(fprintf(stderr, "recv: readlen=%zu, payloadleft=%zu\n", readlen,
-                     iframe->payloadleft));
+      DEBUGF("recv: readlen=%zu, payloadleft=%zu\n", readlen, iframe->payloadleft);
 
       if (readlen > 0) {
         ssize_t data_readlen;
@@ -6379,7 +6365,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
           }
         }
 
-        DEBUGF(fprintf(stderr, "recv: data_readlen=%zd\n", data_readlen));
+        DEBUGF("recv: data_readlen=%zd\n", data_readlen);
 
         if (data_readlen > 0) {
           if (session_enforce_http_messaging(session)) {
@@ -6432,14 +6418,13 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
 
       break;
     case NGHTTP2_IB_IGN_DATA:
-      DEBUGF(fprintf(stderr, "recv: [IB_IGN_DATA]\n"));
+      DEBUGF("recv: [IB_IGN_DATA]\n");
 
       readlen = inbound_frame_payload_readlen(iframe, in, last);
       iframe->payloadleft -= readlen;
       in += readlen;
 
-      DEBUGF(fprintf(stderr, "recv: readlen=%zu, payloadleft=%zu\n", readlen,
-                     iframe->payloadleft));
+      DEBUGF("recv: readlen=%zu, payloadleft=%zu\n", readlen, iframe->payloadleft);
 
       if (readlen > 0) {
         /* Update connection-level flow control window for ignored
@@ -6470,14 +6455,13 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
     case NGHTTP2_IB_IGN_ALL:
       return (ssize_t)inlen;
     case NGHTTP2_IB_READ_EXTENSION_PAYLOAD:
-      DEBUGF(fprintf(stderr, "recv: [IB_READ_EXTENSION_PAYLOAD]\n"));
+      DEBUGF("recv: [IB_READ_EXTENSION_PAYLOAD]\n");
 
       readlen = inbound_frame_payload_readlen(iframe, in, last);
       iframe->payloadleft -= readlen;
       in += readlen;
 
-      DEBUGF(fprintf(stderr, "recv: readlen=%zu, payloadleft=%zu\n", readlen,
-                     iframe->payloadleft));
+      DEBUGF("recv: readlen=%zu, payloadleft=%zu\n", readlen, iframe->payloadleft);
 
       if (readlen > 0) {
         rv = session_call_on_extension_chunk_recv_callback(
@@ -6508,7 +6492,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
 
       break;
     case NGHTTP2_IB_READ_ALTSVC_PAYLOAD:
-      DEBUGF(fprintf(stderr, "recv: [IB_READ_ALTSVC_PAYLOAD]\n"));
+      DEBUGF("recv: [IB_READ_ALTSVC_PAYLOAD]\n");
 
       readlen = inbound_frame_payload_readlen(iframe, in, last);
 
@@ -6519,8 +6503,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
         in += readlen;
       }
 
-      DEBUGF(fprintf(stderr, "recv: readlen=%zu, payloadleft=%zu\n", readlen,
-                     iframe->payloadleft));
+      DEBUGF("recv: readlen=%zu, payloadleft=%zu\n", readlen, iframe->payloadleft);
 
       if (iframe->payloadleft) {
         assert(nghttp2_buf_avail(&iframe->lbuf) > 0);
@@ -6891,14 +6874,12 @@ int nghttp2_session_pack_data(nghttp2_session *session, nghttp2_bufs *bufs,
         stream->remote_window_size, session->remote_settings.max_frame_size,
         session->user_data);
 
-    DEBUGF(fprintf(stderr, "send: read_length_callback=%zd\n", payloadlen));
+    DEBUGF("send: read_length_callback=%zd\n", payloadlen);
 
     payloadlen = nghttp2_session_enforce_flow_control_limits(session, stream,
                                                              payloadlen);
 
-    DEBUGF(fprintf(stderr,
-                   "send: read_length_callback after flow control=%zd\n",
-                   payloadlen));
+    DEBUGF("send: read_length_callback after flow control=%zd\n", payloadlen);
 
     if (payloadlen <= 0) {
       return NGHTTP2_ERR_CALLBACK_FAILURE;
@@ -6911,13 +6892,12 @@ int nghttp2_session_pack_data(nghttp2_session *session, nghttp2_bufs *bufs,
                                 (size_t)(NGHTTP2_FRAME_HDLEN + 1 + payloadlen));
 
       if (rv != 0) {
-        DEBUGF(fprintf(stderr, "send: realloc buffer failed rv=%d", rv));
+        DEBUGF("send: realloc buffer failed rv=%d", rv);
         /* If reallocation failed, old buffers are still in tact.  So
            use safe limit. */
         payloadlen = (ssize_t)datamax;
 
-        DEBUGF(
-            fprintf(stderr, "send: use safe limit payloadlen=%zd", payloadlen));
+        DEBUGF("send: use safe limit payloadlen=%zd", payloadlen);
       } else {
         assert(&session->aob.framebufs == bufs);
 
@@ -6938,8 +6918,7 @@ int nghttp2_session_pack_data(nghttp2_session *session, nghttp2_bufs *bufs,
   if (payloadlen == NGHTTP2_ERR_DEFERRED ||
       payloadlen == NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE ||
       payloadlen == NGHTTP2_ERR_PAUSE) {
-    DEBUGF(fprintf(stderr, "send: DATA postponed due to %s\n",
-                   nghttp2_strerror((int)payloadlen)));
+    DEBUGF("send: DATA postponed due to %s\n", nghttp2_strerror((int)payloadlen));
 
     return (int)payloadlen;
   }
@@ -6968,9 +6947,7 @@ int nghttp2_session_pack_data(nghttp2_session *session, nghttp2_bufs *bufs,
 
   if (data_flags & NGHTTP2_DATA_FLAG_NO_COPY) {
     if (session->callbacks.send_data_callback == NULL) {
-      DEBUGF(fprintf(
-          stderr,
-          "NGHTTP2_DATA_FLAG_NO_COPY requires send_data_callback set\n"));
+      DEBUGF("NGHTTP2_DATA_FLAG_NO_COPY requires send_data_callback set\n");
 
       return NGHTTP2_ERR_CALLBACK_FAILURE;
     }

--- a/lib/nghttp2_stream.c
+++ b/lib/nghttp2_stream.c
@@ -152,11 +152,10 @@ static int stream_obq_push(nghttp2_stream *dep_stream, nghttp2_stream *stream) {
     stream_next_cycle(stream, dep_stream->descendant_last_cycle);
     stream->seq = dep_stream->descendant_next_seq++;
 
-    DEBUGF(fprintf(stderr, "stream: stream=%d obq push cycle=%d\n",
-                   stream->stream_id, stream->cycle));
+    DEBUGF("stream: stream=%d obq push cycle=%d\n", stream->stream_id, stream->cycle);
 
-    DEBUGF(fprintf(stderr, "stream: push stream %d to stream %d\n",
-                   stream->stream_id, dep_stream->stream_id));
+    DEBUGF("stream: push stream %d to stream %d\n",
+           stream->stream_id, dep_stream->stream_id);
 
     rv = nghttp2_pq_push(&dep_stream->obq, &stream->pq_entry);
     if (rv != 0) {
@@ -183,8 +182,8 @@ static void stream_obq_remove(nghttp2_stream *stream) {
   }
 
   for (; dep_stream; stream = dep_stream, dep_stream = dep_stream->dep_prev) {
-    DEBUGF(fprintf(stderr, "stream: remove stream %d from stream %d\n",
-                   stream->stream_id, dep_stream->stream_id));
+    DEBUGF("stream: remove stream %d from stream %d\n",
+           stream->stream_id, dep_stream->stream_id);
 
     nghttp2_pq_remove(&dep_stream->obq, &stream->pq_entry);
 
@@ -214,8 +213,8 @@ static int stream_obq_move(nghttp2_stream *dest, nghttp2_stream *src,
     return 0;
   }
 
-  DEBUGF(fprintf(stderr, "stream: remove stream %d from stream %d (move)\n",
-                 stream->stream_id, src->stream_id));
+  DEBUGF("stream: remove stream %d from stream %d (move)\n",
+         stream->stream_id, src->stream_id);
 
   nghttp2_pq_remove(&src->obq, &stream->pq_entry);
   stream->queued = 0;
@@ -238,8 +237,8 @@ void nghttp2_stream_reschedule(nghttp2_stream *stream) {
 
     nghttp2_pq_push(&dep_stream->obq, &stream->pq_entry);
 
-    DEBUGF(fprintf(stderr, "stream: stream=%d obq resched cycle=%d\n",
-                   stream->stream_id, stream->cycle));
+    DEBUGF("stream: stream=%d obq resched cycle=%d\n",
+           stream->stream_id, stream->cycle);
 
     dep_stream->last_writelen = stream->last_writelen;
   }
@@ -298,8 +297,8 @@ void nghttp2_stream_change_weight(nghttp2_stream *stream, int32_t weight) {
 
   nghttp2_pq_push(&dep_stream->obq, &stream->pq_entry);
 
-  DEBUGF(fprintf(stderr, "stream: stream=%d obq resched cycle=%d\n",
-                 stream->stream_id, stream->cycle));
+  DEBUGF("stream: stream=%d obq resched cycle=%d\n",
+         stream->stream_id, stream->cycle);
 }
 
 static nghttp2_stream *stream_last_sib(nghttp2_stream *stream) {
@@ -481,8 +480,7 @@ int nghttp2_stream_attach_item(nghttp2_stream *stream,
   assert((stream->flags & NGHTTP2_STREAM_FLAG_DEFERRED_ALL) == 0);
   assert(stream->item == NULL);
 
-  DEBUGF(fprintf(stderr, "stream: stream=%d attach item=%p\n",
-                 stream->stream_id, item));
+  DEBUGF("stream: stream=%d attach item=%p\n", stream->stream_id, item);
 
   stream->item = item;
 
@@ -500,8 +498,7 @@ int nghttp2_stream_attach_item(nghttp2_stream *stream,
 }
 
 int nghttp2_stream_detach_item(nghttp2_stream *stream) {
-  DEBUGF(fprintf(stderr, "stream: stream=%d detach item=%p\n",
-                 stream->stream_id, stream->item));
+  DEBUGF("stream: stream=%d detach item=%p\n", stream->stream_id, stream->item);
 
   stream->item = NULL;
   stream->flags = (uint8_t)(stream->flags & ~NGHTTP2_STREAM_FLAG_DEFERRED_ALL);
@@ -512,8 +509,8 @@ int nghttp2_stream_detach_item(nghttp2_stream *stream) {
 int nghttp2_stream_defer_item(nghttp2_stream *stream, uint8_t flags) {
   assert(stream->item);
 
-  DEBUGF(fprintf(stderr, "stream: stream=%d defer item=%p cause=%02x\n",
-                 stream->stream_id, stream->item, flags));
+  DEBUGF("stream: stream=%d defer item=%p cause=%02x\n",
+         stream->stream_id, stream->item, flags);
 
   stream->flags |= flags;
 
@@ -523,8 +520,8 @@ int nghttp2_stream_defer_item(nghttp2_stream *stream, uint8_t flags) {
 int nghttp2_stream_resume_deferred_item(nghttp2_stream *stream, uint8_t flags) {
   assert(stream->item);
 
-  DEBUGF(fprintf(stderr, "stream: stream=%d resume item=%p flags=%02x\n",
-                 stream->stream_id, stream->item, flags));
+  DEBUGF("stream: stream=%d resume item=%p flags=%02x\n",
+         stream->stream_id, stream->item, flags);
 
   stream->flags = (uint8_t)(stream->flags & ~flags);
 
@@ -593,9 +590,8 @@ int nghttp2_stream_dep_insert(nghttp2_stream *dep_stream,
   nghttp2_stream *si;
   int rv;
 
-  DEBUGF(fprintf(stderr,
-                 "stream: dep_insert dep_stream(%p)=%d, stream(%p)=%d\n",
-                 dep_stream, dep_stream->stream_id, stream, stream->stream_id));
+  DEBUGF("stream: dep_insert dep_stream(%p)=%d, stream(%p)=%d\n",
+         dep_stream, dep_stream->stream_id, stream, stream->stream_id);
 
   stream->sum_dep_weight = dep_stream->sum_dep_weight;
   dep_stream->sum_dep_weight = stream->weight;
@@ -740,8 +736,8 @@ static void unlink_dep(nghttp2_stream *stream) {
 
 void nghttp2_stream_dep_add(nghttp2_stream *dep_stream,
                             nghttp2_stream *stream) {
-  DEBUGF(fprintf(stderr, "stream: dep_add dep_stream(%p)=%d, stream(%p)=%d\n",
-                 dep_stream, dep_stream->stream_id, stream, stream->stream_id));
+  DEBUGF("stream: dep_add dep_stream(%p)=%d, stream(%p)=%d\n",
+         dep_stream, dep_stream->stream_id, stream, stream->stream_id);
 
   dep_stream->sum_dep_weight += stream->weight;
 
@@ -759,8 +755,7 @@ int nghttp2_stream_dep_remove(nghttp2_stream *stream) {
   int32_t sum_dep_weight_delta;
   int rv;
 
-  DEBUGF(fprintf(stderr, "stream: dep_remove stream(%p)=%d\n", stream,
-                 stream->stream_id));
+  DEBUGF("stream: dep_remove stream(%p)=%d\n", stream, stream->stream_id);
 
   /* Distribute weight of |stream| to direct descendants */
   sum_dep_weight_delta = -stream->weight;
@@ -813,9 +808,9 @@ int nghttp2_stream_dep_insert_subtree(nghttp2_stream *dep_stream,
   nghttp2_stream *si;
   int rv;
 
-  DEBUGF(fprintf(stderr, "stream: dep_insert_subtree dep_stream(%p)=%d "
-                         "stream(%p)=%d\n",
-                 dep_stream, dep_stream->stream_id, stream, stream->stream_id));
+  DEBUGF("stream: dep_insert_subtree dep_stream(%p)=%d "
+         "stream(%p)=%d\n",
+         dep_stream, dep_stream->stream_id, stream, stream->stream_id);
 
   stream->sum_dep_weight += dep_stream->sum_dep_weight;
   dep_stream->sum_dep_weight = stream->weight;
@@ -862,9 +857,9 @@ int nghttp2_stream_dep_add_subtree(nghttp2_stream *dep_stream,
                                    nghttp2_stream *stream) {
   int rv;
 
-  DEBUGF(fprintf(stderr, "stream: dep_add_subtree dep_stream(%p)=%d "
-                         "stream(%p)=%d\n",
-                 dep_stream, dep_stream->stream_id, stream, stream->stream_id));
+  DEBUGF("stream: dep_add_subtree dep_stream(%p)=%d "
+         "stream(%p)=%d\n",
+         dep_stream, dep_stream->stream_id, stream, stream->stream_id);
 
   dep_stream->sum_dep_weight += stream->weight;
 
@@ -889,8 +884,7 @@ int nghttp2_stream_dep_add_subtree(nghttp2_stream *dep_stream,
 void nghttp2_stream_dep_remove_subtree(nghttp2_stream *stream) {
   nghttp2_stream *next, *dep_prev;
 
-  DEBUGF(fprintf(stderr, "stream: dep_remove_subtree stream(%p)=%d\n", stream,
-                 stream->stream_id));
+  DEBUGF("stream: dep_remove_subtree stream(%p)=%d\n", stream, stream->stream_id);
 
   assert(stream->dep_prev);
 


### PR DESCRIPTION
This enables applications to take advantage of the DEBUGF statements inside of nghttp2 to fold it into their general logging infrastructure.
