### PR TITLE
Prevent undefined behavior in decode_length

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,6 +32,7 @@ Etienne Cimon
 Fabian Möller
 Fabian Wiesel
 Gabi Davar
+Google Inc.
 Jacob Champion
 Jan-E
 Janusz Dziemidowicz

--- a/lib/nghttp2_hd.c
+++ b/lib/nghttp2_hd.c
@@ -864,6 +864,11 @@ static ssize_t decode_length(uint32_t *res, size_t *shift_ptr, int *fin,
   for (; in != last; ++in, shift += 7) {
     uint32_t add = *in & 0x7f;
 
+    if (shift >= 32) {
+      DEBUGF("inflate: shift exponent overflow\n");
+      return -1;
+    }
+
     if ((UINT32_MAX >> shift) < add) {
       DEBUGF("inflate: integer overflow on shift\n");
       return -1;


### PR DESCRIPTION
When doing some fuzz testing, I found inputs that caused decode_length to be called in such a way that shift grew to values larger than 32. This is undefined behavior.