### PR TITLE
Fix bug that fetch-ocsp-response does not work with OpenSSL 1.1.0

### DIFF
--- a/script/fetch-ocsp-response
+++ b/script/fetch-ocsp-response
@@ -146,7 +146,7 @@ def send_and_receive_ocsp(respder_fn, cmd, cert_fn, issuer_fn, ocsp_uri,
         '-noverify', '-respout', respder_fn
     ]
     ver = openssl_version.lower()
-    if ver.startswith('openssl 1.') or ver.startswith('libressl '):
+    if ver.startswith('openssl 1.0.') or ver.startswith('libressl '):
         args.extend(['-header', 'Host', ocsp_host])
     resp = run_openssl(args, allow_tempfail=True)
     return resp.decode('utf-8')


### PR DESCRIPTION
The syntax of openssl ocsp -header option has been changed in OpenSSL
1.1.0.  And it now does not require -header option anymore.  It looks
like that it is workaround for 1.0.x versions.

Fixes #742 