### PR TITLE
nghttpx: Don't write again after failure

### DIFF
--- a/src/shrpx_http2_session.cc
+++ b/src/shrpx_http2_session.cc
@@ -2026,7 +2026,7 @@ int Http2Session::write_clear() {
         // contain part of response body.  So keep reading.  Invoke
         // read event to get read(2) error just in case.
         ev_feed_event(conn_.loop, &conn_.rev, EV_READ);
-        wb_.drain(wb_.rleft());
+        write_ = &Http2Session::write_void;
         break;
       }
 
@@ -2141,7 +2141,7 @@ int Http2Session::write_tls() {
         // contain part of response body.  So keep reading.  Invoke
         // read event to get read(2) error just in case.
         ev_feed_event(conn_.loop, &conn_.rev, EV_READ);
-        wb_.drain(wb_.rleft());
+        write_ = &Http2Session::write_void;
         break;
       }
 
@@ -2162,6 +2162,11 @@ int Http2Session::write_tls() {
   conn_.wlimit.stopw();
   ev_timer_stop(conn_.loop, &conn_.wt);
 
+  return 0;
+}
+
+int Http2Session::write_void() {
+  conn_.wlimit.stopw();
   return 0;
 }
 

--- a/src/shrpx_http2_session.h
+++ b/src/shrpx_http2_session.h
@@ -114,6 +114,9 @@ public:
   int tls_handshake();
   int read_tls();
   int write_tls();
+  // This is a special write function which just stop write event
+  // watcher.
+  int write_void();
 
   int downstream_read_proxy(const uint8_t *data, size_t datalen);
   int downstream_connect_proxy();

--- a/src/shrpx_http_downstream_connection.h
+++ b/src/shrpx_http_downstream_connection.h
@@ -112,6 +112,8 @@ private:
   // true if first write of reused connection succeeded.  For
   // convenience, this is initialized as true.
   bool reuse_first_write_done_;
+  // true if this object can be reused
+  bool reusable_;
 };
 
 } // namespace shrpx


### PR DESCRIPTION
Plain write(2) is OK, but SSL_write requires same arguments on retry.
It would be better to avoid calling them again.