### PR TITLE
nghttpx: Fix access.log timestamp

### DIFF
--- a/src/shrpx_client_handler.h
+++ b/src/shrpx_client_handler.h
@@ -118,10 +118,6 @@ public:
   // must not be nullptr.
   void write_accesslog(Downstream *downstream);
 
-  // Writes upstream accesslog.  This function is used if
-  // corresponding Downstream object is not available.
-  void write_accesslog(int major, int minor, unsigned int status,
-                       int64_t body_bytes_sent);
   Worker *get_worker() const;
 
   using ReadBuf = DefaultMemchunkBuffer;

--- a/src/shrpx_downstream.h
+++ b/src/shrpx_downstream.h
@@ -152,6 +152,8 @@ struct Request {
   }
 
   FieldStore fs;
+  // Timestamp when all request header fields are received.
+  std::shared_ptr<Timestamp> tstamp;
   // Request scheme.  For HTTP/2, this is :scheme header field value.
   // For HTTP/1.1, this is deduced from URI or connection.
   StringRef scheme;

--- a/src/shrpx_https_upstream.cc
+++ b/src/shrpx_https_upstream.cc
@@ -292,6 +292,10 @@ int htp_hdrs_completecb(http_parser *htp) {
   auto downstream = upstream->get_downstream();
   auto &req = downstream->request();
 
+  auto lgconf = log_config();
+  lgconf->update_tstamp(std::chrono::system_clock::now());
+  req.tstamp = lgconf->tstamp;
+
   req.http_major = htp->http_major;
   req.http_minor = htp->http_minor;
 
@@ -950,7 +954,7 @@ void HttpsUpstream::error_reply(unsigned int status_code) {
   output->append("\r\nDate: ");
   auto lgconf = log_config();
   lgconf->update_tstamp(std::chrono::system_clock::now());
-  output->append(lgconf->time_http);
+  output->append(lgconf->tstamp->time_http);
   output->append("\r\nContent-Type: text/html; "
                  "charset=UTF-8\r\nConnection: close\r\n\r\n");
   output->append(html);

--- a/src/shrpx_log.h
+++ b/src/shrpx_log.h
@@ -151,7 +151,6 @@ struct LogSpec {
   StringRef path;
   StringRef alpn;
   const nghttp2::ssl::TLSSessionInfo *tls_info;
-  std::chrono::system_clock::time_point time_now;
   std::chrono::high_resolution_clock::time_point request_start_time;
   std::chrono::high_resolution_clock::time_point request_end_time;
   int major, minor;

--- a/src/shrpx_log_config.h
+++ b/src/shrpx_log_config.h
@@ -37,15 +37,21 @@ using namespace nghttp2;
 
 namespace shrpx {
 
-struct LogConfig {
-  std::chrono::system_clock::time_point time_str_updated_;
+struct Timestamp {
+  Timestamp(const std::chrono::system_clock::time_point &tp);
+
   std::array<char, sizeof("03/Jul/2014:00:19:38 +0900")> time_local_buf;
   std::array<char, sizeof("2014-11-15T12:58:24.741+09:00")> time_iso8601_buf;
   std::array<char, sizeof("Mon, 10 Oct 2016 10:25:58 GMT")> time_http_buf;
-  std::string thread_id;
   StringRef time_local;
   StringRef time_iso8601;
   StringRef time_http;
+};
+
+struct LogConfig {
+  std::chrono::system_clock::time_point time_str_updated;
+  std::shared_ptr<Timestamp> tstamp;
+  std::string thread_id;
   pid_t pid;
   int accesslog_fd;
   int errorlog_fd;

--- a/src/shrpx_mruby_module_response.cc
+++ b/src/shrpx_mruby_module_response.cc
@@ -255,8 +255,8 @@ mrb_value response_return(mrb_state *mrb, mrb_value self) {
     auto lgconf = log_config();
     lgconf->update_tstamp(std::chrono::system_clock::now());
     resp.fs.add_header_token(StringRef::from_lit("date"),
-                             make_string_ref(balloc, lgconf->time_http), false,
-                             http2::HD_DATE);
+                             make_string_ref(balloc, lgconf->tstamp->time_http),
+                             false, http2::HD_DATE);
   }
 
   auto upstream = downstream->get_upstream();

--- a/src/shrpx_spdy_upstream.cc
+++ b/src/shrpx_spdy_upstream.cc
@@ -181,6 +181,10 @@ void on_ctrl_recv_callback(spdylay_session *session, spdylay_frame_type type,
 
     auto &balloc = downstream->get_block_allocator();
 
+    auto lgconf = log_config();
+    lgconf->update_tstamp(std::chrono::system_clock::now());
+    req.tstamp = lgconf->tstamp;
+
     downstream->reset_upstream_rtimer();
 
     auto nv = frame->syn_stream.nv;
@@ -1006,7 +1010,7 @@ int SpdyUpstream::error_reply(Downstream *downstream,
                       "content-type",   "text/html; charset=UTF-8",
                       "server",         get_config()->http.server_name.c_str(),
                       "content-length", content_length.c_str(),
-                      "date",           lgconf->time_http.c_str(),
+                      "date",           lgconf->tstamp->time_http.c_str(),
                       nullptr};
 
   rv = spdylay_submit_response(session_, downstream->get_stream_id(), nv,


### PR DESCRIPTION
access.log timestamp is now when request header fields are received,
rather than when access log is written.