### PR TITLE
close_stream erases from streams_ while it's being iterated over.

### DIFF
--- a/src/asio_server_http2_handler.cc
+++ b/src/asio_server_http2_handler.cc
@@ -253,7 +253,6 @@ http2_handler::~http2_handler() {
   for (auto &p : streams_) {
     auto &strm = p.second;
     strm->response().impl().call_on_close(NGHTTP2_INTERNAL_ERROR);
-    close_stream(strm->get_stream_id());
   }
 
   nghttp2_session_del(session_);


### PR DESCRIPTION
close_stream just erases the id from the streams_ container which invalidates the iterator.  The who streams_ data structure is about to be deleted anyway so this is unnecessary.