### PR TITLE
nghttpx: Select certificate by client's supported signature algo

### DIFF
--- a/src/shrpx-unittest.cc
+++ b/src/shrpx-unittest.cc
@@ -72,8 +72,8 @@ int main(int argc, char *argv[]) {
   // add the tests to the suite
   if (!CU_add_test(pSuite, "ssl_create_lookup_tree",
                    shrpx::test_shrpx_ssl_create_lookup_tree) ||
-      !CU_add_test(pSuite, "ssl_cert_lookup_tree_add_cert_from_x509",
-                   shrpx::test_shrpx_ssl_cert_lookup_tree_add_cert_from_x509) ||
+      !CU_add_test(pSuite, "ssl_cert_lookup_tree_add_ssl_ctx",
+                   shrpx::test_shrpx_ssl_cert_lookup_tree_add_ssl_ctx) ||
       !CU_add_test(pSuite, "ssl_tls_hostname_match",
                    shrpx::test_shrpx_ssl_tls_hostname_match) ||
       !CU_add_test(pSuite, "http2_add_header", shrpx::test_http2_add_header) ||

--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -1943,9 +1943,14 @@ SSL/TLS:
   --subcert=<KEYPATH>:<CERTPATH>[[;<PARAM>]...]
               Specify  additional certificate  and  private key  file.
               nghttpx will  choose certificates based on  the hostname
-              indicated  by  client  using TLS  SNI  extension.   This
-              option  can  be  used  multiple  times.   To  make  OCSP
-              stapling work, <CERTPATH> must be absolute path.
+              indicated by client using TLS SNI extension.  If nghttpx
+              is  built with  OpenSSL >=  1.0.2, signature  algorithms
+              (e.g., ECDSA+SHA256, RSA+SHA256) presented by client are
+              also taken  into consideration.  This allows  nghttpx to
+              send ECDSA certificate to  modern clients, while sending
+              RSA based certificate to older clients.  This option can
+              be  used multiple  times.  To  make OCSP  stapling work,
+              <CERTPATH> must be absolute path.
 
               Additional parameter  can be specified in  <PARAM>.  The
               available <PARAM> is "sct-dir=<DIR>".

--- a/src/shrpx_connection_handler.cc
+++ b/src/shrpx_connection_handler.cc
@@ -199,12 +199,13 @@ void ConnectionHandler::worker_replace_downstream(
 
 int ConnectionHandler::create_single_worker() {
   cert_tree_ = ssl::create_cert_lookup_tree();
-  auto sv_ssl_ctx = ssl::setup_server_ssl_context(all_ssl_ctx_, cert_tree_.get()
+  auto sv_ssl_ctx = ssl::setup_server_ssl_context(
+      all_ssl_ctx_, indexed_ssl_ctx_, cert_tree_.get()
 #ifdef HAVE_NEVERBLEED
-                                                                    ,
-                                                  nb_.get()
+                                          ,
+      nb_.get()
 #endif // HAVE_NEVERBLEED
-                                                      );
+          );
   auto cl_ssl_ctx = ssl::setup_downstream_client_ssl_context(
 #ifdef HAVE_NEVERBLEED
       nb_.get()
@@ -247,12 +248,13 @@ int ConnectionHandler::create_worker_thread(size_t num) {
   assert(workers_.size() == 0);
 
   cert_tree_ = ssl::create_cert_lookup_tree();
-  auto sv_ssl_ctx = ssl::setup_server_ssl_context(all_ssl_ctx_, cert_tree_.get()
+  auto sv_ssl_ctx = ssl::setup_server_ssl_context(
+      all_ssl_ctx_, indexed_ssl_ctx_, cert_tree_.get()
 #ifdef HAVE_NEVERBLEED
-                                                                    ,
-                                                  nb_.get()
+                                          ,
+      nb_.get()
 #endif // HAVE_NEVERBLEED
-                                                      );
+          );
   auto cl_ssl_ctx = ssl::setup_downstream_client_ssl_context(
 #ifdef HAVE_NEVERBLEED
       nb_.get()
@@ -839,6 +841,11 @@ void ConnectionHandler::send_serial_event(SerialEvent ev) {
 
 SSL_CTX *ConnectionHandler::get_ssl_ctx(size_t idx) const {
   return all_ssl_ctx_[idx];
+}
+
+const std::vector<SSL_CTX *> &
+ConnectionHandler::get_indexed_ssl_ctx(size_t idx) const {
+  return indexed_ssl_ctx_[idx];
 }
 
 } // namespace shrpx

--- a/src/shrpx_connection_handler.h
+++ b/src/shrpx_connection_handler.h
@@ -156,6 +156,8 @@ public:
   // array bound checking.
   SSL_CTX *get_ssl_ctx(size_t idx) const;
 
+  const std::vector<SSL_CTX *> &get_indexed_ssl_ctx(size_t idx) const;
+
 #ifdef HAVE_NEVERBLEED
   void set_neverbleed(std::unique_ptr<neverbleed_t> nb);
   neverbleed_t *get_neverbleed() const;
@@ -175,6 +177,12 @@ public:
 private:
   // Stores all SSL_CTX objects.
   std::vector<SSL_CTX *> all_ssl_ctx_;
+  // Stores all SSL_CTX objects in a way that its index is stored in
+  // cert_tree.  The SSL_CTXs stored in the same index share the same
+  // hostname, but could have different signature algorithm.  The
+  // selection among them are performed by hostname presented by SNI,
+  // and signature algorithm presented by client.
+  std::vector<std::vector<SSL_CTX *>> indexed_ssl_ctx_;
   OCSPUpdateContext ocsp_;
   std::mt19937 gen_;
   // ev_loop for each worker

--- a/src/shrpx_router.cc
+++ b/src/shrpx_router.cc
@@ -69,7 +69,7 @@ void Router::add_node(RNode *node, const char *pattern, size_t patlen,
   add_next_node(node, std::move(new_node));
 }
 
-bool Router::add_route(const StringRef &pattern, size_t index) {
+size_t Router::add_route(const StringRef &pattern, size_t index) {
   auto node = &root_;
   size_t i = 0;
 
@@ -77,7 +77,7 @@ bool Router::add_route(const StringRef &pattern, size_t index) {
     auto next_node = find_next_node(node, pattern[i]);
     if (next_node == nullptr) {
       add_node(node, pattern.c_str() + i, pattern.size() - i, index);
-      return true;
+      return index;
     }
 
     node = next_node;
@@ -93,11 +93,11 @@ bool Router::add_route(const StringRef &pattern, size_t index) {
       if (slen == node->len) {
         // Complete match
         if (node->index != -1) {
-          // Don't allow duplicate
-          return false;
+          // Return the existing index for duplicates.
+          return node->index;
         }
         node->index = index;
-        return true;
+        return index;
       }
 
       if (slen > node->len) {
@@ -122,7 +122,7 @@ bool Router::add_route(const StringRef &pattern, size_t index) {
 
       if (slen == j) {
         node->index = index;
-        return true;
+        return index;
       }
     }
 
@@ -131,7 +131,7 @@ bool Router::add_route(const StringRef &pattern, size_t index) {
     assert(pattern.size() > i);
     add_node(node, pattern.c_str() + i, pattern.size() - i, index);
 
-    return true;
+    return index;
   }
 }
 

--- a/src/shrpx_router.h
+++ b/src/shrpx_router.h
@@ -63,8 +63,9 @@ public:
   Router &operator=(Router &&) = default;
   Router &operator=(const Router &) = delete;
 
-  // Adds route |pattern| with its |index|.
-  bool add_route(const StringRef &pattern, size_t index);
+  // Adds route |pattern| with its |index|.  If same pattern has
+  // already been added, the existing index is returned.
+  size_t add_route(const StringRef &pattern, size_t index);
   // Returns the matched index of pattern.  -1 if there is no match.
   ssize_t match(const StringRef &host, const StringRef &path) const;
   // Returns the matched index of pattern |s|.  -1 if there is no

--- a/src/shrpx_ssl_test.cc
+++ b/src/shrpx_ssl_test.cc
@@ -115,24 +115,39 @@ void test_shrpx_ssl_create_lookup_tree(void) {
 //     -config=ca-config.json -profile=server test.example.com.csr |
 //     cfssljson -bare test.example.com
 //
-void test_shrpx_ssl_cert_lookup_tree_add_cert_from_x509(void) {
+void test_shrpx_ssl_cert_lookup_tree_add_ssl_ctx(void) {
   int rv;
 
   constexpr char nghttp2_certfile[] = NGHTTP2_SRC_DIR "/test.nghttp2.org.pem";
-  auto nghttp2_cert = ssl::load_certificate(nghttp2_certfile);
-  auto nghttp2_cert_deleter = defer(X509_free, nghttp2_cert);
+  auto nghttp2_ssl_ctx = SSL_CTX_new(SSLv23_server_method());
+  auto nghttp2_ssl_ctx_del = defer(SSL_CTX_free, nghttp2_ssl_ctx);
+  auto nghttp2_tls_ctx_data = make_unique<ssl::TLSContextData>();
+  nghttp2_tls_ctx_data->cert_file = nghttp2_certfile;
+  SSL_CTX_set_app_data(nghttp2_ssl_ctx, nghttp2_tls_ctx_data.get());
+  rv = SSL_CTX_use_certificate_chain_file(nghttp2_ssl_ctx, nghttp2_certfile);
+
+  CU_ASSERT(1 == rv);
 
   constexpr char examples_certfile[] = NGHTTP2_SRC_DIR "/test.example.com.pem";
-  auto examples_cert = ssl::load_certificate(examples_certfile);
-  auto examples_cert_deleter = defer(X509_free, examples_cert);
+  auto examples_ssl_ctx = SSL_CTX_new(SSLv23_server_method());
+  auto examples_ssl_ctx_del = defer(SSL_CTX_free, examples_ssl_ctx);
+  auto examples_tls_ctx_data = make_unique<ssl::TLSContextData>();
+  examples_tls_ctx_data->cert_file = examples_certfile;
+  SSL_CTX_set_app_data(examples_ssl_ctx, examples_tls_ctx_data.get());
+  rv = SSL_CTX_use_certificate_chain_file(examples_ssl_ctx, examples_certfile);
+
+  CU_ASSERT(1 == rv);
 
   ssl::CertLookupTree tree;
+  std::vector<std::vector<SSL_CTX *>> indexed_ssl_ctx;
 
-  rv = ssl::cert_lookup_tree_add_cert_from_x509(&tree, 0, nghttp2_cert);
+  rv = ssl::cert_lookup_tree_add_ssl_ctx(&tree, indexed_ssl_ctx,
+                                         nghttp2_ssl_ctx);
 
   CU_ASSERT(0 == rv);
 
-  rv = ssl::cert_lookup_tree_add_cert_from_x509(&tree, 1, examples_cert);
+  rv = ssl::cert_lookup_tree_add_ssl_ctx(&tree, indexed_ssl_ctx,
+                                         examples_ssl_ctx);
 
   CU_ASSERT(0 == rv);
 

--- a/src/shrpx_ssl_test.h
+++ b/src/shrpx_ssl_test.h
@@ -32,7 +32,7 @@
 namespace shrpx {
 
 void test_shrpx_ssl_create_lookup_tree(void);
-void test_shrpx_ssl_cert_lookup_tree_add_cert_from_x509(void);
+void test_shrpx_ssl_cert_lookup_tree_add_ssl_ctx(void);
 void test_shrpx_ssl_tls_hostname_match(void);
 
 } // namespace shrpx


### PR DESCRIPTION
nghttpx supports multiple certificates using --subcert option.
Previously, SNI hostname is used to select certificate.  With this
commit, signature algorithm presented by client is also taken into
consideration.  nghttpx now accepts certificates which share the same
hostname (CN, SAN), but have different signature algorithm (e.g.,
ECDSA+SHA256, RSA+SHA256).

Currently, this feature requires OpenSSL >= 1.0.2.  BoringSSL, and
LibreSSL do not work since they lack required APIs.

Fixes #792 