### PR TITLE
nghttpx: add systemd support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -395,6 +395,18 @@ else
   AC_MSG_NOTICE($JANSSON_PKG_ERRORS)
 fi
 
+
+#  libsystemd
+PKG_CHECK_MODULES([SYSTEMD], [libsystemd >= 209], [have_libsystemd=yes],
+                  [have_libsystemd=no])
+if test "x${have_libsystemd}" = "xyes"; then
+  AC_DEFINE([HAVE_LIBSYSTEMD], [1],
+	    [Define to 1 if you have `libsystemd` library.])
+else
+  AC_MSG_NOTICE($SYSTEMD_PKG_ERRORS)
+fi
+
+
 # libxml2 (for src/nghttp)
 PKG_CHECK_MODULES([LIBXML2], [libxml-2.0 >= 2.7.7],
                   [have_libxml2=yes], [have_libxml2=no])
@@ -914,6 +926,7 @@ AC_MSG_NOTICE([summary of build options:
       Jansson:        ${have_jansson} (CFLAGS='${JANSSON_CFLAGS}' LIBS='${JANSSON_LIBS}')
       Jemalloc:       ${have_jemalloc} (LIBS='${JEMALLOC_LIBS}')
       Zlib:           ${have_zlib} (CFLAGS='${ZLIB_CFLAGS}' LIBS='${ZLIB_LIBS}')
+      systemd:        ${have_libsystemd} (LIBS='${SYSTEMD_LIBS}')
       Boost CPPFLAGS: ${BOOST_CPPFLAGS}
       Boost LDFLAGS:  ${BOOST_LDFLAGS}
       Boost::ASIO:    ${BOOST_ASIO_LIB}

--- a/contrib/nghttpx.service.in
+++ b/contrib/nghttpx.service.in
@@ -1,10 +1,17 @@
 [Unit]
 Description=HTTP/2 proxy
+Documentation=man:nghttpx
 After=network.target
 
 [Service]
-Type=forking
-ExecStart=@bindir@/nghttpx --conf=/etc/nghttpx/nghttpx.conf --pid-file=/run/nghttpx.pid --daemon
+Type=notify
+ExecStart=@bindir@/nghttpx --conf=/etc/nghttpx/nghttpx.conf
+ExecReload=/bin/kill --signal HUP $MAINPID
+KillSignal=SIGQUIT
+PrivateTmp=yes
+ProtectHome=yes
+ProtectSystem=full
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -57,6 +57,7 @@ LDADD = $(top_builddir)/lib/libnghttp2.la \
 	@LIBEV_LIBS@ \
 	@OPENSSL_LIBS@ \
 	@LIBCARES_LIBS@ \
+	@SYSTEMD_LIBS@ \
 	@JANSSON_LIBS@ \
 	@ZLIB_LIBS@ \
 	@APPLDFLAGS@


### PR DESCRIPTION
  Add systemd's Type=notify support by sending information about master process PID around forks. Add some hardening option to service unit.

This improves systemd tracking of main process by explicitly stating which PID is master process. No need to use --pid-file.
daemon() usage is disabled when run under systemd. It make little sense in that context, but more importanly daemon() double forks, leaving us with no time to send a message to systemd.
Please note, even if nghttpx was compiled with systemd support, the resulting binary still can be run under other init systems. sd_notifyf() is no-op if NOTIFY_SOCKET env variable is not set.

I've introduced wrapper for sd_notifyf() function in order to reduce amount of #ifdef's.

There is one harmless message from systemd during forking (systemd[1]: ng2.service: Supervising process 9267 which is not our child. We'll most likely not notice when it exits.). It doesn't really matter.
