### PR TITLE
Holding more shared_ptrs instead of raw ptrs

### DIFF
--- a/src/asio_client_session_tcp_impl.cc
+++ b/src/asio_client_session_tcp_impl.cc
@@ -37,19 +37,20 @@ session_tcp_impl::session_tcp_impl(
 session_tcp_impl::~session_tcp_impl() {}
 
 void session_tcp_impl::start_connect(tcp::resolver::iterator endpoint_it) {
+  auto self = shared_from_this();
   boost::asio::async_connect(socket_, endpoint_it,
-                             [this](const boost::system::error_code &ec,
+                             [self](const boost::system::error_code &ec,
                                     tcp::resolver::iterator endpoint_it) {
-                               if (stopped()) {
+                               if (self->stopped()) {
                                  return;
                                }
 
                                if (ec) {
-                                 not_connected(ec);
+                                 self->not_connected(ec);
                                  return;
                                }
 
-                               connected(endpoint_it);
+                               self->connected(endpoint_it);
                              });
 }
 

--- a/src/asio_client_session_tls_impl.cc
+++ b/src/asio_client_session_tls_impl.cc
@@ -43,37 +43,38 @@ session_tls_impl::session_tls_impl(
 session_tls_impl::~session_tls_impl() {}
 
 void session_tls_impl::start_connect(tcp::resolver::iterator endpoint_it) {
+  auto self = std::static_pointer_cast<session_tls_impl>(shared_from_this());
   boost::asio::async_connect(
-      socket(), endpoint_it, [this](const boost::system::error_code &ec,
+      socket(), endpoint_it, [self](const boost::system::error_code &ec,
                                     tcp::resolver::iterator endpoint_it) {
-        if (stopped()) {
+        if (self->stopped()) {
           return;
         }
 
         if (ec) {
-          not_connected(ec);
+          self->not_connected(ec);
           return;
         }
 
-        socket_.async_handshake(
+		self->socket_.async_handshake(
             boost::asio::ssl::stream_base::client,
-            [this, endpoint_it](const boost::system::error_code &ec) {
-              if (stopped()) {
+            [self, endpoint_it](const boost::system::error_code &ec) {
+              if (self->stopped()) {
                 return;
               }
 
               if (ec) {
-                not_connected(ec);
+                self->not_connected(ec);
                 return;
               }
 
-              if (!tls_h2_negotiated(socket_)) {
-                not_connected(make_error_code(
+              if (!tls_h2_negotiated(self->socket_)) {
+                self->not_connected(make_error_code(
                     NGHTTP2_ASIO_ERR_TLS_NO_APP_PROTO_NEGOTIATED));
                 return;
               }
 
-              connected(endpoint_it);
+              self->connected(endpoint_it);
             });
       });
 }


### PR DESCRIPTION
This makes sure objects don't get deleted that are referenced by callbacks inside io_service.

This seems to fix memory issues from my tests with valgrind and -fsanitize=address.  Do you see other errors?  Do you have other tests I should run?