### PR TITLE
nghttpx: Send SIGQUIT to the original master process

### DIFF
--- a/doc/nghttpx.h2r
+++ b/doc/nghttpx.h2r
@@ -83,14 +83,18 @@ SIGUSR1
   Reopen log files.
 
 SIGUSR2
+
   Fork and execute nghttpx.  It will execute the binary in the same
-  path with same command-line arguments and environment variables.
-  After new process comes up, sending SIGQUIT to the original process
-  to perform hot swapping.  The difference between SIGUSR2 + SIGQUIT
-  and SIGHUP is that former is usually used to execute new binary, and
-  the master process is newly spawned.  On the other hand, the latter
-  just reloads configuration file, and the same master process
-  continues to exist.
+  path with same command-line arguments and environment variables.  As
+  of nghttpx version 1.20.0, the new master process sends SIGQUIT to
+  the original master process when it is ready to serve requests.  For
+  the earlier versions of nghttpx, user has to send SIGQUIT to the
+  original master process.
+
+  The difference between SIGUSR2 (+ SIGQUIT) and SIGHUP is that former
+  is usually used to execute new binary, and the master process is
+  newly spawned.  On the other hand, the latter just reloads
+  configuration file, and the same master process continues to exist.
 
 .. note::
 

--- a/doc/sources/nghttpx-howto.rst
+++ b/doc/sources/nghttpx-howto.rst
@@ -229,12 +229,18 @@ Hot swapping
 nghttpx supports hot swapping using signals.  The hot swapping in
 nghttpx is multi step process.  First send USR2 signal to nghttpx
 process.  It will do fork and execute new executable, using same
-command-line arguments and environment variables.  At this point, both
-current and new processes can accept requests.  To gracefully shutdown
-current process, send QUIT signal to current nghttpx process.  When
-all existing frontend connections are done, the current process will
-exit.  At this point, only new nghttpx process exists and serves
-incoming requests.
+command-line arguments and environment variables.
+
+As of nghttpx version 1.20.0, that is all you have to do.  The new
+master process sends QUIT signal to the original process, when it is
+ready to serve requests, to shut it down gracefully.
+
+For earlier versions of nghttpx, you have to do one more thing.  At
+this point, both current and new processes can accept requests.  To
+gracefully shutdown current process, send QUIT signal to current
+nghttpx process.  When all existing frontend connections are done, the
+current process will exit.  At this point, only new nghttpx process
+exists and serves incoming requests.
 
 If you want to just reload configuration file without executing new
 binary, send SIGHUP to nghttpx master process.


### PR DESCRIPTION
Previously, after sending SIGUSR2 to the original master process, and
the new master process gets ready, user has to send SIGQUIT to the
original master process to shut it down gracefully.  With this commit,
the new master process sends SIGQUIT to the original master process
when it is ready to serve requests, eliminating for user to send
SIGQUIT manually.

This works nicely with systemd, because now you can replace nghttpx
binary with new one by "systemctl kill -s USR2 nghttpx".

Fixes #804