### PR TITLE
nghttpx: Specify TLS protocol by version range

### DIFF
--- a/gennghttpxfun.py
+++ b/gennghttpxfun.py
@@ -158,6 +158,8 @@ OPTIONS = [
     "client-no-http2-cipher-black-list",
     "client-ciphers",
     "accesslog-write-early",
+    "tls-min-proto-version",
+    "tls-max-proto-version",
 ]
 
 LOGVARS = [

--- a/src/shrpx_config.h
+++ b/src/shrpx_config.h
@@ -327,6 +327,10 @@ constexpr auto SHRPX_OPT_CLIENT_NO_HTTP2_CIPHER_BLACK_LIST =
 constexpr auto SHRPX_OPT_CLIENT_CIPHERS = StringRef::from_lit("client-ciphers");
 constexpr auto SHRPX_OPT_ACCESSLOG_WRITE_EARLY =
     StringRef::from_lit("accesslog-write-early");
+constexpr auto SHRPX_OPT_TLS_MIN_PROTO_VERSION =
+    StringRef::from_lit("tls-min-proto-version");
+constexpr auto SHRPX_OPT_TLS_MAX_PROTO_VERSION =
+    StringRef::from_lit("tls-max-proto-version");
 
 constexpr size_t SHRPX_OBFUSCATED_NODE_LENGTH = 8;
 
@@ -594,6 +598,10 @@ struct TLSConfig {
   StringRef ciphers;
   StringRef ecdh_curves;
   StringRef cacert;
+  // The minimum and maximum TLS version.  These values are defined in
+  // OpenSSL header file.
+  int min_proto_version;
+  int max_proto_version;
   bool insecure;
   bool no_http2_cipher_black_list;
 };
@@ -1020,6 +1028,8 @@ enum {
   SHRPX_OPTID_SYSLOG_FACILITY,
   SHRPX_OPTID_TLS_DYN_REC_IDLE_TIMEOUT,
   SHRPX_OPTID_TLS_DYN_REC_WARMUP_THRESHOLD,
+  SHRPX_OPTID_TLS_MAX_PROTO_VERSION,
+  SHRPX_OPTID_TLS_MIN_PROTO_VERSION,
   SHRPX_OPTID_TLS_PROTO_LIST,
   SHRPX_OPTID_TLS_SCT_DIR,
   SHRPX_OPTID_TLS_SESSION_CACHE_MEMCACHED,

--- a/src/shrpx_ssl.cc
+++ b/src/shrpx_ssl.cc
@@ -639,6 +639,55 @@ long int create_tls_proto_mask(const std::vector<StringRef> &tls_proto_list) {
   return res;
 }
 
+#if defined(OPENSSL_IS_BORINGSSL)
+namespace {
+int ssl_ctx_set_proto_versions(SSL_CTX *ssl_ctx, int min, int max) {
+  SSL_CTX_set_min_version(ssl_ctx, min);
+  SSL_CTX_set_max_version(ssl_ctx, max);
+  return 0;
+}
+} // namespace
+#elif OPENSSL_1_1_API
+namespace {
+int ssl_ctx_set_proto_versions(SSL_CTX *ssl_ctx, int min, int max) {
+  if (SSL_CTX_set_min_proto_version(ssl_ctx, min) != 1 ||
+      SSL_CTX_set_max_proto_version(ssl_ctx, max) != 1) {
+    return -1;
+  }
+  return 0;
+}
+} // namespace
+#else  // !OPENSSL_1_1_API
+namespace {
+int ssl_ctx_set_proto_versions(SSL_CTX *ssl_ctx, int min, int max) {
+  long int opts = 0;
+
+  // TODO We depends on the ordering of protocol version macro in
+  // OpenSSL.
+  if (min > TLS1_VERSION) {
+    opts |= SSL_OP_NO_TLSv1;
+  }
+  if (min > TLS1_1_VERSION) {
+    opts |= SSL_OP_NO_TLSv1_1;
+  }
+  if (min > TLS1_2_VERSION) {
+    opts |= SSL_OP_NO_TLSv1_2;
+  }
+
+  if (max < TLS1_2_VERSION) {
+    opts |= SSL_OP_NO_TLSv1_2;
+  }
+  if (max < TLS1_1_VERSION) {
+    opts |= SSL_OP_NO_TLSv1_1;
+  }
+
+  SSL_CTX_set_options(ssl_ctx, opts);
+
+  return 0;
+}
+} // namespace
+#endif // !OPENSSL_1_1_API
+
 SSL_CTX *create_ssl_context(const char *private_key_file, const char *cert_file,
                             const std::vector<uint8_t> &sct_data
 #ifdef HAVE_NEVERBLEED
@@ -662,6 +711,13 @@ SSL_CTX *create_ssl_context(const char *private_key_file, const char *cert_file,
   auto &tlsconf = config->tls;
 
   SSL_CTX_set_options(ssl_ctx, ssl_opts | tlsconf.tls_proto_mask);
+
+  if (ssl_ctx_set_proto_versions(ssl_ctx, tlsconf.min_proto_version,
+                                 tlsconf.max_proto_version) != 0) {
+    LOG(FATAL) << "Could not set TLS protocol version: "
+               << ERR_error_string(ERR_get_error(), nullptr);
+    DIE();
+  }
 
   const unsigned char sid_ctx[] = "shrpx";
   SSL_CTX_set_session_id_context(ssl_ctx, sid_ctx, sizeof(sid_ctx) - 1);
@@ -896,6 +952,13 @@ SSL_CTX *create_ssl_client_context(
   auto &tlsconf = get_config()->tls;
 
   SSL_CTX_set_options(ssl_ctx, ssl_opts | tlsconf.tls_proto_mask);
+
+  if (ssl_ctx_set_proto_versions(ssl_ctx, tlsconf.min_proto_version,
+                                 tlsconf.max_proto_version) != 0) {
+    LOG(FATAL) << "Could not set TLS protocol version: "
+               << ERR_error_string(ERR_get_error(), nullptr);
+    DIE();
+  }
 
   if (SSL_CTX_set_cipher_list(ssl_ctx, tlsconf.client.ciphers.c_str()) == 0) {
     LOG(FATAL) << "SSL_CTX_set_cipher_list " << tlsconf.client.ciphers
@@ -1676,6 +1739,19 @@ SSL_SESSION *reuse_tls_session(const TLSSessionCache &cache) {
 
   auto p = cache.session_data.data();
   return d2i_SSL_SESSION(nullptr, &p, cache.session_data.size());
+}
+
+int proto_version_from_string(const StringRef &v) {
+  if (util::strieq_l("TLSv1.2", v)) {
+    return TLS1_2_VERSION;
+  }
+  if (util::strieq_l("TLSv1.1", v)) {
+    return TLS1_1_VERSION;
+  }
+  if (util::strieq_l("TLSv1.0", v)) {
+    return TLS1_VERSION;
+  }
+  return -1;
 }
 
 } // namespace ssl

--- a/src/shrpx_ssl.h
+++ b/src/shrpx_ssl.h
@@ -258,6 +258,11 @@ SSL_SESSION *reuse_tls_session(const TLSSessionCache &addr);
 // the returned object using X509_free().
 X509 *load_certificate(const char *filename);
 
+// Returns TLS version from |v|.  The returned value is defined in
+// OpenSSL header file.  This function returns -1 if |v| is not valid
+// TLS version string.
+int proto_version_from_string(const StringRef &v);
+
 } // namespace ssl
 
 } // namespace shrpx


### PR DESCRIPTION
This commit deprecates --tls-proto-list option, and adds 2 new
options: --tls-min-proto-version and --tls-max-proto-version to
specify minimum and maximum protocol version respectively.  Versions
between the two are enabled.  The deprecated --tls-proto-list has
empty default value, and acts like disabling specific protocol version
in the range for now.

Fixes #809