### PR TITLE
Add TLSv1.3 support

### DIFF
--- a/src/HttpServer.cc
+++ b/src/HttpServer.cc
@@ -2122,6 +2122,13 @@ int HttpServer::run() {
     SSL_CTX_set_mode(ssl_ctx, SSL_MODE_AUTO_RETRY);
     SSL_CTX_set_mode(ssl_ctx, SSL_MODE_RELEASE_BUFFERS);
 
+    if (nghttp2::ssl::ssl_ctx_set_proto_versions(
+            ssl_ctx, nghttp2::ssl::NGHTTP2_TLS_MIN_VERSION,
+            nghttp2::ssl::NGHTTP2_TLS_MAX_VERSION) != 0) {
+      std::cerr << "Could not set TLS versions" << std::endl;
+      return -1;
+    }
+
     if (SSL_CTX_set_cipher_list(ssl_ctx, ssl::DEFAULT_CIPHER_LIST) == 0) {
       std::cerr << ERR_error_string(ERR_get_error(), nullptr) << std::endl;
       return -1;

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -2242,6 +2242,13 @@ int main(int argc, char **argv) {
   SSL_CTX_set_mode(ssl_ctx, SSL_MODE_AUTO_RETRY);
   SSL_CTX_set_mode(ssl_ctx, SSL_MODE_RELEASE_BUFFERS);
 
+  if (nghttp2::ssl::ssl_ctx_set_proto_versions(
+          ssl_ctx, nghttp2::ssl::NGHTTP2_TLS_MIN_VERSION,
+          nghttp2::ssl::NGHTTP2_TLS_MAX_VERSION) != 0) {
+    std::cerr << "Could not set TLS versions" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
   if (SSL_CTX_set_cipher_list(ssl_ctx, config.ciphers.c_str()) == 0) {
     std::cerr << "SSL_CTX_set_cipher_list with " << config.ciphers
               << " failed: " << ERR_error_string(ERR_get_error(), nullptr)

--- a/src/nghttp.cc
+++ b/src/nghttp.cc
@@ -2246,6 +2246,15 @@ int communicate(
     SSL_CTX_set_options(ssl_ctx, ssl_opts);
     SSL_CTX_set_mode(ssl_ctx, SSL_MODE_AUTO_RETRY);
     SSL_CTX_set_mode(ssl_ctx, SSL_MODE_RELEASE_BUFFERS);
+
+    if (nghttp2::ssl::ssl_ctx_set_proto_versions(
+            ssl_ctx, nghttp2::ssl::NGHTTP2_TLS_MIN_VERSION,
+            nghttp2::ssl::NGHTTP2_TLS_MAX_VERSION) != 0) {
+      std::cerr << "[ERROR] Could not set TLS versions" << std::endl;
+      result = -1;
+      goto fin;
+    }
+
     if (SSL_CTX_set_cipher_list(ssl_ctx, ssl::DEFAULT_CIPHER_LIST) == 0) {
       std::cerr << "[ERROR] " << ERR_error_string(ERR_get_error(), nullptr)
                 << std::endl;

--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -1369,7 +1369,11 @@ constexpr auto DEFAULT_NPN_LIST = StringRef::from_lit("h2,h2-16,h2-14,"
 
 namespace {
 constexpr auto DEFAULT_TLS_MIN_PROTO_VERSION = StringRef::from_lit("TLSv1.1");
+#ifdef TLS1_3_VERSION
+constexpr auto DEFAULT_TLS_MAX_PROTO_VERSION = StringRef::from_lit("TLSv1.3");
+#else  // !TLS1_3_VERSION
 constexpr auto DEFAULT_TLS_MAX_PROTO_VERSION = StringRef::from_lit("TLSv1.2");
+#endif // !TLS1_3_VERSION
 } // namespace
 
 namespace {
@@ -2060,23 +2064,33 @@ SSL/TLS:
               Path to  file that  contains client certificate  used in
               backend client authentication.
   --tls-min-proto-version=<VER>
-              Specify   minimum  SSL/TLS   protocol.   The   following
-              protocols are  available: TLSv1.2, TLSv1.1  and TLSv1.0.
-              The name  matching is  done in  case-insensitive manner.
-              The   versions   between   --tls-min-proto-version   and
-              --tls-max-proto-version  are enabled.   If the  protocol
-              list advertised  by client does not  overlap this range,
-              you will receive the error message "unknown protocol".
+              Specify minimum SSL/TLS protocol.   The name matching is
+              done in  case-insensitive manner.  The  versions between
+              --tls-min-proto-version and  --tls-max-proto-version are
+              enabled.  If the protocol list advertised by client does
+              not  overlap  this range,  you  will  receive the  error
+              message "unknown protocol".  The available versions are:
+              )"
+#ifdef TLS1_3_VERSION
+                             "TLSv1.3, "
+#endif // TLS1_3_VERSION
+                             "TLSv1.2, TLSv1.1, and TLSv1.0"
+                             R"(
               Default: )"
       << DEFAULT_TLS_MIN_PROTO_VERSION << R"(
   --tls-max-proto-version=<VER>
-              Specify   maximum  SSL/TLS   protocol.   The   following
-              protocols are  available: TLSv1.2, TLSv1.1  and TLSv1.0.
-              The name  matching is  done in  case-insensitive manner.
-              The   versions   between   --tls-min-proto-version   and
-              --tls-max-proto-version  are enabled.   If the  protocol
-              list advertised  by client does not  overlap this range,
-              you will receive the error message "unknown protocol".
+              Specify maximum SSL/TLS protocol.   The name matching is
+              done in  case-insensitive manner.  The  versions between
+              --tls-min-proto-version and  --tls-max-proto-version are
+              enabled.  If the protocol list advertised by client does
+              not  overlap  this range,  you  will  receive the  error
+              message "unknown protocol".  The available versions are:
+              )"
+#ifdef TLS1_3_VERSION
+                                          "TLSv1.3, "
+#endif // TLS1_3_VERSION
+                                          "TLSv1.2, TLSv1.1, and TLSv1.0"
+                                          R"(
               Default: )"
       << DEFAULT_TLS_MAX_PROTO_VERSION << R"(
   --tls-ticket-key-file=<PATH>

--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -1427,8 +1427,10 @@ void fill_default_config(Config *config) {
   tlsconf.ciphers = StringRef::from_lit(nghttp2::ssl::DEFAULT_CIPHER_LIST);
   tlsconf.client.ciphers =
       StringRef::from_lit(nghttp2::ssl::DEFAULT_CIPHER_LIST);
-  tlsconf.min_proto_version = TLS1_1_VERSION;
-  tlsconf.max_proto_version = TLS1_2_VERSION;
+  tlsconf.min_proto_version =
+      ssl::proto_version_from_string(DEFAULT_TLS_MIN_PROTO_VERSION);
+  tlsconf.max_proto_version =
+      ssl::proto_version_from_string(DEFAULT_TLS_MAX_PROTO_VERSION);
 #if OPENSSL_1_1_API
   tlsconf.ecdh_curves = StringRef::from_lit("X25519:P-256:P-384:P-521");
 #else  // !OPENSSL_1_1_API

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -49,7 +49,25 @@ public:
 // suites by mozilla.
 //
 // https://wiki.mozilla.org/Security/Server_Side_TLS
+//
+// Plus TLSv1.3 cipher suites if defined.
 constexpr char DEFAULT_CIPHER_LIST[] =
+#ifdef TLS1_3_TXT_AES_256_GCM_SHA384
+    TLS1_3_TXT_AES_256_GCM_SHA384
+    ":"
+#endif // TLS1_3_TXT_AES_256_GCM_SHA384
+#ifdef TLS1_3_TXT_CHACHA20_POLY1305_SHA256
+    TLS1_3_TXT_CHACHA20_POLY1305_SHA256 ":"
+#endif // TLS1_3_TXT_CHACHA20_POLY1305_SHA256
+#ifdef TLS1_3_TXT_AES_128_GCM_SHA256
+    TLS1_3_TXT_AES_128_GCM_SHA256 ":"
+#endif // TLS1_3_TXT_AES_128_GCM_SHA256
+#ifdef TLS1_3_TXT_AES_128_CCM_SHA256
+    TLS1_3_TXT_AES_128_CCM_SHA256 ":"
+#endif // TLS1_3_TXT_AES_128_CCM_SHA256
+#ifdef TLS1_3_TXT_AES_128_CCM_8_SHA256
+    TLS1_3_TXT_AES_128_CCM_8_SHA256 ":"
+#endif // TLS1_3_TXT_AES_128_CCM_8_SHA256
     "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-"
     "AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-"
     "SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-"
@@ -60,6 +78,13 @@ constexpr char DEFAULT_CIPHER_LIST[] =
     "ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-"
     "SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-"
     "SHA:DES-CBC3-SHA:!DSS";
+
+constexpr auto NGHTTP2_TLS_MIN_VERSION = TLS1_VERSION;
+#ifdef TLS1_3_VERSION
+constexpr auto NGHTTP2_TLS_MAX_VERSION = TLS1_3_VERSION;
+#else // !TLS1_3_VERSION
+constexpr auto NGHTTP2_TLS_MAX_VERSION = TLS1_2_VERSION;
+#endif // !TLS1_3_VERSION
 
 const char *get_tls_protocol(SSL *ssl);
 
@@ -90,6 +115,10 @@ bool check_http2_requirement(SSL *ssl);
 
 // Initializes OpenSSL library
 void libssl_init();
+
+// Sets TLS min and max versions to |ssl_ctx|.  This function returns
+// 0 if it succeeds, or -1.
+int ssl_ctx_set_proto_versions(SSL_CTX *ssl_ctx, int min, int max);
 
 } // namespace ssl
 


### PR DESCRIPTION
Fixes #764 

This enables TLSv1.3 for all applications under src (nghttp, nghttpd, nghttpx, and h2load) if OpenSSL supports it.  Currently OpenSSL master and BoringSSL enable TLSv1.3.  OpenSSL's TLSv1.3 support is still WIP.  And TLSv1.3 itself is not finalized yet.