### PR TITLE
nghttpx: Redirect to HTTPS URI with redirect-if-no-tls parameter in backend option

### DIFF
--- a/gennghttpxfun.py
+++ b/gennghttpxfun.py
@@ -160,6 +160,7 @@ OPTIONS = [
     "accesslog-write-early",
     "tls-min-proto-version",
     "tls-max-proto-version",
+    "redirect-https-port",
 ]
 
 LOGVARS = [

--- a/integration-tests/nghttpx_http1_test.go
+++ b/integration-tests/nghttpx_http1_test.go
@@ -533,6 +533,49 @@ func TestH1H1RespPhaseReturn(t *testing.T) {
 	}
 }
 
+// TestH1H1HTTPSRedirect tests that the request to the backend which
+// requires TLS is redirected to https URI.
+func TestH1H1HTTPSRedirect(t *testing.T) {
+	st := newServerTester([]string{"--redirect-if-not-tls"}, t, noopHandler)
+	defer st.Close()
+
+	res, err := st.http1(requestParam{
+		name: "TestH1H1HTTPSRedirect",
+	})
+	if err != nil {
+		t.Fatalf("Error st.http1() = %v", err)
+	}
+
+	if got, want := res.status, 308; got != want {
+		t.Errorf("status = %v; want %v", got, want)
+	}
+	if got, want := res.header.Get("location"), "https://127.0.0.1/"; got != want {
+		t.Errorf("location: %v; want %v", got, want)
+	}
+}
+
+// TestH1H1HTTPSRedirectPort tests that the request to the backend
+// which requires TLS is redirected to https URI with given port.
+func TestH1H1HTTPSRedirectPort(t *testing.T) {
+	st := newServerTester([]string{"--redirect-if-not-tls", "--redirect-https-port=8443"}, t, noopHandler)
+	defer st.Close()
+
+	res, err := st.http1(requestParam{
+		path: "/foo?bar",
+		name: "TestH1H1HTTPSRedirectPort",
+	})
+	if err != nil {
+		t.Fatalf("Error st.http1() = %v", err)
+	}
+
+	if got, want := res.status, 308; got != want {
+		t.Errorf("status = %v; want %v", got, want)
+	}
+	if got, want := res.header.Get("location"), "https://127.0.0.1:8443/foo?bar"; got != want {
+		t.Errorf("location: %v; want %v", got, want)
+	}
+}
+
 // // TestH1H2ConnectFailure tests that server handles the situation that
 // // connection attempt to HTTP/2 backend failed.
 // func TestH1H2ConnectFailure(t *testing.T) {

--- a/integration-tests/nghttpx_http2_test.go
+++ b/integration-tests/nghttpx_http2_test.go
@@ -1405,6 +1405,49 @@ func TestH2H1DNS(t *testing.T) {
 	}
 }
 
+// TestH2H1HTTPSRedirect tests that the request to the backend which
+// requires TLS is redirected to https URI.
+func TestH2H1HTTPSRedirect(t *testing.T) {
+	st := newServerTester([]string{"--redirect-if-not-tls"}, t, noopHandler)
+	defer st.Close()
+
+	res, err := st.http2(requestParam{
+		name: "TestH2H1HTTPSRedirect",
+	})
+	if err != nil {
+		t.Fatalf("Error st.http2() = %v", err)
+	}
+
+	if got, want := res.status, 308; got != want {
+		t.Errorf("status = %v; want %v", got, want)
+	}
+	if got, want := res.header.Get("location"), "https://127.0.0.1/"; got != want {
+		t.Errorf("location: %v; want %v", got, want)
+	}
+}
+
+// TestH2H1HTTPSRedirectPort tests that the request to the backend
+// which requires TLS is redirected to https URI with given port.
+func TestH2H1HTTPSRedirectPort(t *testing.T) {
+	st := newServerTester([]string{"--redirect-if-not-tls", "--redirect-https-port=8443"}, t, noopHandler)
+	defer st.Close()
+
+	res, err := st.http2(requestParam{
+		path: "/foo?bar",
+		name: "TestH2H1HTTPSRedirectPort",
+	})
+	if err != nil {
+		t.Fatalf("Error st.http2() = %v", err)
+	}
+
+	if got, want := res.status, 308; got != want {
+		t.Errorf("status = %v; want %v", got, want)
+	}
+	if got, want := res.header.Get("location"), "https://127.0.0.1:8443/foo?bar"; got != want {
+		t.Errorf("location: %v; want %v", got, want)
+	}
+}
+
 // TestH2H1GracefulShutdown tests graceful shutdown.
 func TestH2H1GracefulShutdown(t *testing.T) {
 	st := newServerTester(nil, t, noopHandler)

--- a/integration-tests/server_tester.go
+++ b/integration-tests/server_tester.go
@@ -101,10 +101,8 @@ func newServerTesterInternal(src_args []string, t *testing.T, handler http.Handl
 
 	args := []string{}
 
-	backendTLS := false
-	dns := false
-	externalDNS := false
-	acceptProxyProtocol := false
+	var backendTLS, dns, externalDNS, acceptProxyProtocol, redirectIfNotTLS bool
+
 	for _, k := range src_args {
 		switch k {
 		case "--http2-bridge":
@@ -116,6 +114,8 @@ func newServerTesterInternal(src_args []string, t *testing.T, handler http.Handl
 			externalDNS = true
 		case "--accept-proxy-protocol":
 			acceptProxyProtocol = true
+		case "--redirect-if-not-tls":
+			redirectIfNotTLS = true
 		default:
 			args = append(args, k)
 		}
@@ -162,6 +162,10 @@ func newServerTesterInternal(src_args []string, t *testing.T, handler http.Handl
 	}
 	if dns {
 		b += ";dns"
+	}
+
+	if redirectIfNotTLS {
+		b += ";redirect-if-not-tls"
 	}
 
 	noTLS := ";no-tls"

--- a/src/shrpx-unittest.cc
+++ b/src/shrpx-unittest.cc
@@ -185,6 +185,8 @@ int main(int argc, char *argv[]) {
       !CU_add_test(pSuite, "util_is_hex_string",
                    shrpx::test_util_is_hex_string) ||
       !CU_add_test(pSuite, "util_decode_hex", shrpx::test_util_decode_hex) ||
+      !CU_add_test(pSuite, "util_extract_host",
+                   shrpx::test_util_extract_host) ||
       !CU_add_test(pSuite, "gzip_inflate", test_nghttp2_gzip_inflate) ||
       !CU_add_test(pSuite, "buffer_write", nghttp2::test_buffer_write) ||
       !CU_add_test(pSuite, "pool_recycle", nghttp2::test_pool_recycle) ||

--- a/src/shrpx_client_handler.h
+++ b/src/shrpx_client_handler.h
@@ -99,8 +99,12 @@ public:
 
   void pool_downstream_connection(std::unique_ptr<DownstreamConnection> dconn);
   void remove_downstream_connection(DownstreamConnection *dconn);
+  // Returns DownstreamConnection object based on request path.  This
+  // function returns non-null DownstreamConnection, and assigns 0 to
+  // |err| if it succeeds, or returns nullptr, and assigns negative
+  // error code to |err|.
   std::unique_ptr<DownstreamConnection>
-  get_downstream_connection(Downstream *downstream);
+  get_downstream_connection(int &err, Downstream *downstream);
   MemchunkPool *get_mcpool();
   SSL *get_ssl() const;
   // Call this function when HTTP/2 connection header is received at

--- a/src/shrpx_error.h
+++ b/src/shrpx_error.h
@@ -38,6 +38,7 @@ enum ErrorCode {
   SHRPX_ERR_INPROGRESS = -102,
   SHRPX_ERR_DCONN_CANCELED = -103,
   SHRPX_ERR_RETRY = -104,
+  SHRPX_ERR_TLS_REQUIRED = -105,
 };
 
 } // namespace shrpx

--- a/src/shrpx_http2_upstream.h
+++ b/src/shrpx_http2_upstream.h
@@ -54,6 +54,8 @@ public:
   virtual int on_timeout(Downstream *downstream);
   virtual int on_downstream_abort_request(Downstream *downstream,
                                           unsigned int status_code);
+  virtual int
+  on_downstream_abort_request_with_https_redirect(Downstream *downstream);
   virtual ClientHandler *get_client_handler() const;
 
   virtual int downstream_read(DownstreamConnection *dconn);
@@ -119,6 +121,8 @@ public:
   DefaultMemchunks *get_response_buf();
 
   size_t get_max_buffer_size() const;
+
+  int redirect_to_https(Downstream *downstream);
 
 private:
   DefaultMemchunks wb_;

--- a/src/shrpx_https_upstream.h
+++ b/src/shrpx_https_upstream.h
@@ -50,6 +50,8 @@ public:
   virtual int on_event();
   virtual int on_downstream_abort_request(Downstream *downstream,
                                           unsigned int status_code);
+  virtual int
+  on_downstream_abort_request_with_https_redirect(Downstream *downstream);
   virtual ClientHandler *get_client_handler() const;
 
   virtual int downstream_read(DownstreamConnection *dconn);
@@ -91,6 +93,7 @@ public:
 
   void reset_current_header_length();
   void log_response_headers(DefaultMemchunks *buf) const;
+  int redirect_to_https(Downstream *downstream);
 
 private:
   ClientHandler *handler_;

--- a/src/shrpx_spdy_upstream.cc
+++ b/src/shrpx_spdy_upstream.cc
@@ -370,7 +370,7 @@ void SpdyUpstream::start_downstream(Downstream *downstream) {
 void SpdyUpstream::initiate_downstream(Downstream *downstream) {
   int rv;
 
-  auto dconn = handler_->get_downstream_connection(downstream);
+  auto dconn = handler_->get_downstream_connection(rv, downstream);
 
   if (!dconn ||
       (rv = downstream->attach_downstream_connection(std::move(dconn))) != 0) {
@@ -1265,6 +1265,13 @@ int SpdyUpstream::on_downstream_abort_request(Downstream *downstream,
   return 0;
 }
 
+int SpdyUpstream::on_downstream_abort_request_with_https_redirect(
+    Downstream *downstream) {
+  // This should not be called since SPDY is only available with TLS.
+  assert(0);
+  return 0;
+}
+
 int SpdyUpstream::consume(int32_t stream_id, size_t len) {
   int rv;
 
@@ -1345,7 +1352,7 @@ int SpdyUpstream::on_downstream_reset(Downstream *downstream, bool no_retry) {
   // downstream connection is clean; we can retry with new
   // downstream connection.
 
-  dconn = handler_->get_downstream_connection(downstream);
+  dconn = handler_->get_downstream_connection(rv, downstream);
   if (!dconn) {
     goto fail;
   }

--- a/src/shrpx_spdy_upstream.h
+++ b/src/shrpx_spdy_upstream.h
@@ -51,6 +51,8 @@ public:
   virtual int on_timeout(Downstream *downstream);
   virtual int on_downstream_abort_request(Downstream *downstream,
                                           unsigned int status_code);
+  virtual int
+  on_downstream_abort_request_with_https_redirect(Downstream *downstream);
   virtual ClientHandler *get_client_handler() const;
   virtual int downstream_read(DownstreamConnection *dconn);
   virtual int downstream_write(DownstreamConnection *dconn);

--- a/src/shrpx_upstream.h
+++ b/src/shrpx_upstream.h
@@ -45,6 +45,10 @@ public:
   virtual int on_timeout(Downstream *downstream) { return 0; };
   virtual int on_downstream_abort_request(Downstream *downstream,
                                           unsigned int status_code) = 0;
+  // Called when the current request is aborted without forwarding it
+  // to backend, and it should be redirected to https URI.
+  virtual int
+  on_downstream_abort_request_with_https_redirect(Downstream *downstream) = 0;
   virtual int downstream_read(DownstreamConnection *dconn) = 0;
   virtual int downstream_write(DownstreamConnection *dconn) = 0;
   virtual int downstream_eof(DownstreamConnection *dconn) = 0;

--- a/src/shrpx_worker.cc
+++ b/src/shrpx_worker.cc
@@ -77,7 +77,7 @@ bool match_shared_downstream_addr(
   }
 
   if (lhs->affinity != rhs->affinity ||
-      lhs->require_upstream_tls != rhs->require_upstream_tls) {
+      lhs->redirect_if_not_tls != rhs->redirect_if_not_tls) {
     return false;
   }
 
@@ -192,7 +192,7 @@ void Worker::replace_downstream_config(
     shared_addr->addrs.resize(src.addrs.size());
     shared_addr->affinity = src.affinity;
     shared_addr->affinity_hash = src.affinity_hash;
-    shared_addr->require_upstream_tls = src.require_upstream_tls;
+    shared_addr->redirect_if_not_tls = src.redirect_if_not_tls;
 
     size_t num_http1 = 0;
     size_t num_http2 = 0;

--- a/src/shrpx_worker.h
+++ b/src/shrpx_worker.h
@@ -137,7 +137,7 @@ struct SharedDownstreamAddr {
         http1_pri{},
         http2_pri{},
         affinity{AFFINITY_NONE},
-        require_upstream_tls{false} {}
+        redirect_if_not_tls{false} {}
 
   SharedDownstreamAddr(const SharedDownstreamAddr &) = delete;
   SharedDownstreamAddr(SharedDownstreamAddr &&) = delete;
@@ -172,8 +172,9 @@ struct SharedDownstreamAddr {
   WeightedPri http2_pri;
   // Session affinity
   shrpx_session_affinity affinity;
-  // true if this group requires that client connection must be TLS.
-  bool require_upstream_tls;
+  // true if this group requires that client connection must be TLS,
+  // and the request must be redirected to https URI.
+  bool redirect_if_not_tls;
 };
 
 struct DownstreamAddrGroup {

--- a/src/util.cc
+++ b/src/util.cc
@@ -1432,6 +1432,26 @@ StringRef decode_hex(BlockAllocator &balloc, const StringRef &s) {
   return StringRef{iov.base, p};
 }
 
+StringRef extract_host(const StringRef &hostport) {
+  if (hostport[0] == '[') {
+    // assume this is IPv6 numeric address
+    auto p = std::find(std::begin(hostport), std::end(hostport), ']');
+    if (p == std::end(hostport)) {
+      return StringRef{};
+    }
+    if (p + 1 < std::end(hostport) && *(p + 1) != ':') {
+      return StringRef{};
+    }
+    return StringRef{std::begin(hostport), p + 1};
+  }
+
+  auto p = std::find(std::begin(hostport), std::end(hostport), ':');
+  if (p == std::begin(hostport)) {
+    return StringRef{};
+  }
+  return StringRef{std::begin(hostport), p};
+}
+
 } // namespace util
 
 } // namespace nghttp2

--- a/src/util.h
+++ b/src/util.h
@@ -739,6 +739,11 @@ uint32_t hash32(const StringRef &s);
 // returns 0 if it succeeds, or -1.
 int sha256(uint8_t *buf, const StringRef &s);
 
+// Returns host from |hostport|.  If host cannot be found in
+// |hostport|, returns empty string.  The returned string might not be
+// NULL-terminated.
+StringRef extract_host(const StringRef &hostport);
+
 } // namespace util
 
 } // namespace nghttp2

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -609,4 +609,22 @@ void test_util_decode_hex(void) {
   CU_ASSERT("" == util::decode_hex(balloc, StringRef{}));
 }
 
+void test_util_extract_host(void) {
+  CU_ASSERT(StringRef::from_lit("foo") ==
+            util::extract_host(StringRef::from_lit("foo")));
+  CU_ASSERT(StringRef::from_lit("foo") ==
+            util::extract_host(StringRef::from_lit("foo:")));
+  CU_ASSERT(StringRef::from_lit("foo") ==
+            util::extract_host(StringRef::from_lit("foo:0")));
+  CU_ASSERT(StringRef::from_lit("[::1]") ==
+            util::extract_host(StringRef::from_lit("[::1]")));
+  CU_ASSERT(StringRef::from_lit("[::1]") ==
+            util::extract_host(StringRef::from_lit("[::1]:")));
+
+  CU_ASSERT(util::extract_host(StringRef::from_lit(":foo")).empty());
+  CU_ASSERT(util::extract_host(StringRef::from_lit("[::1")).empty());
+  CU_ASSERT(util::extract_host(StringRef::from_lit("[::1]0")).empty());
+  CU_ASSERT(util::extract_host(StringRef{}).empty());
+}
+
 } // namespace shrpx

--- a/src/util_test.h
+++ b/src/util_test.h
@@ -66,6 +66,7 @@ void test_util_random_alpha_digit(void);
 void test_util_format_hex(void);
 void test_util_is_hex_string(void);
 void test_util_decode_hex(void);
+void test_util_extract_host(void);
 
 } // namespace shrpx
 


### PR DESCRIPTION
This commit removes frontend-tls parameter, and adds
redirect-if-not-tls parameter parameter to --backend option.  nghttpx
now responds to the request with 308 status code to redirect the
request to https URI if frontend connection is not TLS encrypted, and
redirect-if-no-tls parameter is used in --backend option.  The port
number in Location header field is 443 by default (thus omitted), but
it can be configurable using --redirect-https-port option.