### PR TITLE
Eliminate _U_ macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,19 +110,9 @@ foreach(_build_type "Release" "MinSizeRel" "RelWithDebInfo")
   endforeach()
 endforeach()
 
-#
-# If we're running GCC or clang define _U_ to be "__attribute__((unused))"
-# so we can use _U_ to flag unused function parameters and not get warnings
-# about them. Otherwise, define _U_ to be an empty string so that _U_ used
-# to flag an unused function parameters will compile with other compilers.
-#
-# XXX - similar hints for other compilers?
-#
 if(CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-  set(HINT_UNUSED_PARAM   "__attribute__((unused))")
   set(HINT_NORETURN       "__attribute__((noreturn))")
 else()
-  set(HINT_UNUSED_PARAM)
   set(HINT_NORETURN)
 endif()
 

--- a/cmakeconfig.h.in
+++ b/cmakeconfig.h.in
@@ -1,7 +1,3 @@
-
-/* Hint to the compiler that a function parameter is not used  */
-#define _U_ @HINT_UNUSED_PARAM@
-
 /* Hint to the compiler that a function never returns */
 #define NGHTTP2_NORETURN @HINT_NORETURN@
 

--- a/configure.ac
+++ b/configure.ac
@@ -176,19 +176,9 @@ else
   AC_SUBST([CYTHON])
 fi
 
-#
-# If we're running GCC or clang define _U_ to be "__attribute__((unused))"
-# so we can use _U_ to flag unused function parameters and not get warnings
-# about them. Otherwise, define _U_ to be an empty string so that _U_ used
-# to flag an unused function parameters will compile with other compilers.
-#
-# XXX - similar hints for other compilers?
-#
 if test "x$GCC" = "xyes" -o "x$CC" = "xclang" ; then
-  AC_DEFINE([_U_], [__attribute__((unused))], [Hint to the compiler that a function parameters is not used])
   AC_DEFINE([NGHTTP2_NORETURN], [__attribute__((noreturn))], [Hint to the compiler that a function never return])
 else
-  AC_DEFINE([_U_], , [Hint to the compiler that a function parameter is not used])
   AC_DEFINE([NGHTTP2_NORETURN], , [Hint to the compiler that a function never return])
 fi
 

--- a/examples/client.c
+++ b/examples/client.c
@@ -159,10 +159,13 @@ static void diec(const char *func, int error_code) {
  * bytes actually written. See the documentation of
  * nghttp2_send_callback for the details.
  */
-static ssize_t send_callback(nghttp2_session *session _U_, const uint8_t *data,
-                             size_t length, int flags _U_, void *user_data) {
+static ssize_t send_callback(nghttp2_session *session, const uint8_t *data,
+                             size_t length, int flags, void *user_data) {
   struct Connection *connection;
   int rv;
+  (void)session;
+  (void)flags;
+
   connection = (struct Connection *)user_data;
   connection->want_io = IO_NONE;
   ERR_clear_error();
@@ -186,10 +189,13 @@ static ssize_t send_callback(nghttp2_session *session _U_, const uint8_t *data,
  * |length| bytes. Returns the number of bytes stored in |buf|. See
  * the documentation of nghttp2_recv_callback for the details.
  */
-static ssize_t recv_callback(nghttp2_session *session _U_, uint8_t *buf,
-                             size_t length, int flags _U_, void *user_data) {
+static ssize_t recv_callback(nghttp2_session *session, uint8_t *buf,
+                             size_t length, int flags, void *user_data) {
   struct Connection *connection;
   int rv;
+  (void)session;
+  (void)flags;
+
   connection = (struct Connection *)user_data;
   connection->want_io = IO_NONE;
   ERR_clear_error();
@@ -210,9 +216,10 @@ static ssize_t recv_callback(nghttp2_session *session _U_, uint8_t *buf,
 }
 
 static int on_frame_send_callback(nghttp2_session *session,
-                                  const nghttp2_frame *frame,
-                                  void *user_data _U_) {
+                                  const nghttp2_frame *frame, void *user_data) {
   size_t i;
+  (void)user_data;
+
   switch (frame->hd.type) {
   case NGHTTP2_HEADERS:
     if (nghttp2_session_get_stream_user_data(session, frame->hd.stream_id)) {
@@ -237,9 +244,10 @@ static int on_frame_send_callback(nghttp2_session *session,
 }
 
 static int on_frame_recv_callback(nghttp2_session *session,
-                                  const nghttp2_frame *frame,
-                                  void *user_data _U_) {
+                                  const nghttp2_frame *frame, void *user_data) {
   size_t i;
+  (void)user_data;
+
   switch (frame->hd.type) {
   case NGHTTP2_HEADERS:
     if (frame->headers.cat == NGHTTP2_HCAT_RESPONSE) {
@@ -274,9 +282,11 @@ static int on_frame_recv_callback(nghttp2_session *session,
  * we submit GOAWAY and close the session.
  */
 static int on_stream_close_callback(nghttp2_session *session, int32_t stream_id,
-                                    uint32_t error_code _U_,
-                                    void *user_data _U_) {
+                                    uint32_t error_code, void *user_data) {
   struct Request *req;
+  (void)error_code;
+  (void)user_data;
+
   req = nghttp2_session_get_stream_user_data(session, stream_id);
   if (req) {
     int rv;
@@ -293,11 +303,13 @@ static int on_stream_close_callback(nghttp2_session *session, int32_t stream_id,
  * The implementation of nghttp2_on_data_chunk_recv_callback type. We
  * use this function to print the received response body.
  */
-static int on_data_chunk_recv_callback(nghttp2_session *session,
-                                       uint8_t flags _U_, int32_t stream_id,
-                                       const uint8_t *data, size_t len,
-                                       void *user_data _U_) {
+static int on_data_chunk_recv_callback(nghttp2_session *session, uint8_t flags,
+                                       int32_t stream_id, const uint8_t *data,
+                                       size_t len, void *user_data) {
   struct Request *req;
+  (void)flags;
+  (void)user_data;
+
   req = nghttp2_session_get_stream_user_data(session, stream_id);
   if (req) {
     printf("[INFO] C <---------------------------- S (DATA chunk)\n"
@@ -338,10 +350,13 @@ static void setup_nghttp2_callbacks(nghttp2_session_callbacks *callbacks) {
  * HTTP/2 protocol, if server does not offer HTTP/2 the nghttp2
  * library supports, we terminate program.
  */
-static int select_next_proto_cb(SSL *ssl _U_, unsigned char **out,
+static int select_next_proto_cb(SSL *ssl, unsigned char **out,
                                 unsigned char *outlen, const unsigned char *in,
-                                unsigned int inlen, void *arg _U_) {
+                                unsigned int inlen, void *arg) {
   int rv;
+  (void)ssl;
+  (void)arg;
+
   /* nghttp2_select_next_protocol() selects HTTP/2 protocol the
      nghttp2 library supports. */
   rv = nghttp2_select_next_protocol(out, outlen, in, inlen);

--- a/examples/deflate.c
+++ b/examples/deflate.c
@@ -44,7 +44,7 @@ static void deflate(nghttp2_hd_deflater *deflater,
 static int inflate_header_block(nghttp2_hd_inflater *inflater, uint8_t *in,
                                 size_t inlen, int final);
 
-int main(int argc _U_, char **argv _U_) {
+int main() {
   int rv;
   nghttp2_hd_deflater *deflater;
   nghttp2_hd_inflater *inflater;

--- a/examples/libevent-server.c
+++ b/examples/libevent-server.c
@@ -109,18 +109,23 @@ struct app_context {
 static unsigned char next_proto_list[256];
 static size_t next_proto_list_len;
 
-static int next_proto_cb(SSL *s _U_, const unsigned char **data,
-                         unsigned int *len, void *arg _U_) {
+static int next_proto_cb(SSL *ssl, const unsigned char **data,
+                         unsigned int *len, void *arg) {
+  (void)ssl;
+  (void)arg;
+
   *data = next_proto_list;
   *len = (unsigned int)next_proto_list_len;
   return SSL_TLSEXT_ERR_OK;
 }
 
 #if OPENSSL_VERSION_NUMBER >= 0x10002000L
-static int alpn_select_proto_cb(SSL *ssl _U_, const unsigned char **out,
+static int alpn_select_proto_cb(SSL *ssl, const unsigned char **out,
                                 unsigned char *outlen, const unsigned char *in,
-                                unsigned int inlen, void *arg _U_) {
+                                unsigned int inlen, void *arg) {
   int rv;
+  (void)ssl;
+  (void)arg;
 
   rv = nghttp2_select_next_protocol((unsigned char **)out, outlen, in, inlen);
 
@@ -197,8 +202,10 @@ static void add_stream(http2_session_data *session_data,
   }
 }
 
-static void remove_stream(http2_session_data *session_data _U_,
+static void remove_stream(http2_session_data *session_data,
                           http2_stream_data *stream_data) {
+  (void)session_data;
+
   stream_data->prev->next = stream_data->next;
   if (stream_data->next) {
     stream_data->next->prev = stream_data->prev;
@@ -309,10 +316,13 @@ static int session_recv(http2_session_data *session_data) {
   return 0;
 }
 
-static ssize_t send_callback(nghttp2_session *session _U_, const uint8_t *data,
-                             size_t length, int flags _U_, void *user_data) {
+static ssize_t send_callback(nghttp2_session *session, const uint8_t *data,
+                             size_t length, int flags, void *user_data) {
   http2_session_data *session_data = (http2_session_data *)user_data;
   struct bufferevent *bev = session_data->bev;
+  (void)session;
+  (void)flags;
+
   /* Avoid excessive buffering in server side. */
   if (evbuffer_get_length(bufferevent_get_output(session_data->bev)) >=
       OUTPUT_WOULDBLOCK_THRESHOLD) {
@@ -375,13 +385,17 @@ static char *percent_decode(const uint8_t *value, size_t valuelen) {
   return res;
 }
 
-static ssize_t file_read_callback(nghttp2_session *session _U_,
-                                  int32_t stream_id _U_, uint8_t *buf,
-                                  size_t length, uint32_t *data_flags,
+static ssize_t file_read_callback(nghttp2_session *session, int32_t stream_id,
+                                  uint8_t *buf, size_t length,
+                                  uint32_t *data_flags,
                                   nghttp2_data_source *source,
-                                  void *user_data _U_) {
+                                  void *user_data) {
   int fd = source->fd;
   ssize_t r;
+  (void)session;
+  (void)stream_id;
+  (void)user_data;
+
   while ((r = read(fd, buf, length)) == -1 && errno == EINTR)
     ;
   if (r == -1) {
@@ -454,10 +468,12 @@ static int error_reply(nghttp2_session *session,
 static int on_header_callback(nghttp2_session *session,
                               const nghttp2_frame *frame, const uint8_t *name,
                               size_t namelen, const uint8_t *value,
-                              size_t valuelen, uint8_t flags _U_,
-                              void *user_data _U_) {
+                              size_t valuelen, uint8_t flags, void *user_data) {
   http2_stream_data *stream_data;
   const char PATH[] = ":path";
+  (void)flags;
+  (void)user_data;
+
   switch (frame->hd.type) {
   case NGHTTP2_HEADERS:
     if (frame->headers.cat != NGHTTP2_HCAT_REQUEST) {
@@ -570,9 +586,10 @@ static int on_frame_recv_callback(nghttp2_session *session,
 }
 
 static int on_stream_close_callback(nghttp2_session *session, int32_t stream_id,
-                                    uint32_t error_code _U_, void *user_data) {
+                                    uint32_t error_code, void *user_data) {
   http2_session_data *session_data = (http2_session_data *)user_data;
   http2_stream_data *stream_data;
+  (void)error_code;
 
   stream_data = nghttp2_session_get_stream_user_data(session, stream_id);
   if (!stream_data) {
@@ -625,8 +642,10 @@ static int send_server_connection_header(http2_session_data *session_data) {
 
 /* readcb for bufferevent after client connection header was
    checked. */
-static void readcb(struct bufferevent *bev _U_, void *ptr) {
+static void readcb(struct bufferevent *bev, void *ptr) {
   http2_session_data *session_data = (http2_session_data *)ptr;
+  (void)bev;
+
   if (session_recv(session_data) != 0) {
     delete_http2_session_data(session_data);
     return;
@@ -658,12 +677,13 @@ static void writecb(struct bufferevent *bev, void *ptr) {
 }
 
 /* eventcb for bufferevent */
-static void eventcb(struct bufferevent *bev _U_, short events, void *ptr) {
+static void eventcb(struct bufferevent *bev, short events, void *ptr) {
   http2_session_data *session_data = (http2_session_data *)ptr;
   if (events & BEV_EVENT_CONNECTED) {
     const unsigned char *alpn = NULL;
     unsigned int alpnlen = 0;
     SSL *ssl;
+    (void)bev;
 
     fprintf(stderr, "%s connected\n", session_data->client_addr);
 
@@ -703,10 +723,11 @@ static void eventcb(struct bufferevent *bev _U_, short events, void *ptr) {
 }
 
 /* callback for evconnlistener */
-static void acceptcb(struct evconnlistener *listener _U_, int fd,
+static void acceptcb(struct evconnlistener *listener, int fd,
                      struct sockaddr *addr, int addrlen, void *arg) {
   app_context *app_ctx = (app_context *)arg;
   http2_session_data *session_data;
+  (void)listener;
 
   session_data = create_http2_session_data(app_ctx, fd, addr, addrlen);
 

--- a/lib/Makefile.msvc
+++ b/lib/Makefile.msvc
@@ -62,7 +62,7 @@ AR		 := lib
 #LD		 := xilink
 #AR		 := xilib
 RC		 := rc
-CFLAGS   := -I./includes -Dssize_t=long -D_U_=""
+CFLAGS   := -I./includes -Dssize_t=long
 
 CFLAGS_R := -nologo -MD  -W3 -Z7 -DBUILDING_NGHTTP2
 CFLAGS_D := -nologo -MDd -W3 -Z7 -DBUILDING_NGHTTP2 \

--- a/lib/nghttp2_debug.c
+++ b/lib/nghttp2_debug.c
@@ -53,6 +53,8 @@ void nghttp2_set_debug_vprintf_callback(
 #else /* !DEBUGBUILD */
 
 void nghttp2_set_debug_vprintf_callback(
-    nghttp2_debug_vprintf_callback debug_vprintf_callback _U_) {}
+    nghttp2_debug_vprintf_callback debug_vprintf_callback) {
+  (void)debug_vprintf_callback;
+}
 
 #endif /* !DEBUGBUILD */

--- a/lib/nghttp2_frame.c
+++ b/lib/nghttp2_frame.c
@@ -87,7 +87,7 @@ void nghttp2_frame_priority_init(nghttp2_priority *frame, int32_t stream_id,
   frame->pri_spec = *pri_spec;
 }
 
-void nghttp2_frame_priority_free(nghttp2_priority *frame _U_) {}
+void nghttp2_frame_priority_free(nghttp2_priority *frame) { (void)frame; }
 
 void nghttp2_frame_rst_stream_init(nghttp2_rst_stream *frame, int32_t stream_id,
                                    uint32_t error_code) {
@@ -96,7 +96,7 @@ void nghttp2_frame_rst_stream_init(nghttp2_rst_stream *frame, int32_t stream_id,
   frame->error_code = error_code;
 }
 
-void nghttp2_frame_rst_stream_free(nghttp2_rst_stream *frame _U_) {}
+void nghttp2_frame_rst_stream_free(nghttp2_rst_stream *frame) { (void)frame; }
 
 void nghttp2_frame_settings_init(nghttp2_settings *frame, uint8_t flags,
                                  nghttp2_settings_entry *iv, size_t niv) {
@@ -137,7 +137,7 @@ void nghttp2_frame_ping_init(nghttp2_ping *frame, uint8_t flags,
   }
 }
 
-void nghttp2_frame_ping_free(nghttp2_ping *frame _U_) {}
+void nghttp2_frame_ping_free(nghttp2_ping *frame) { (void)frame; }
 
 void nghttp2_frame_goaway_init(nghttp2_goaway *frame, int32_t last_stream_id,
                                uint32_t error_code, uint8_t *opaque_data,
@@ -163,7 +163,9 @@ void nghttp2_frame_window_update_init(nghttp2_window_update *frame,
   frame->reserved = 0;
 }
 
-void nghttp2_frame_window_update_free(nghttp2_window_update *frame _U_) {}
+void nghttp2_frame_window_update_free(nghttp2_window_update *frame) {
+  (void)frame;
+}
 
 size_t nghttp2_frame_trail_padlen(nghttp2_frame *frame, size_t padlen) {
   /* We have iframe->padlen == 0, but iframe->frame.hd.flags may have
@@ -183,7 +185,7 @@ void nghttp2_frame_data_init(nghttp2_data *frame, uint8_t flags,
   frame->padlen = 0;
 }
 
-void nghttp2_frame_data_free(nghttp2_data *frame _U_) {}
+void nghttp2_frame_data_free(nghttp2_data *frame) { (void)frame; }
 
 void nghttp2_frame_extension_init(nghttp2_extension *frame, uint8_t type,
                                   uint8_t flags, int32_t stream_id,
@@ -192,7 +194,7 @@ void nghttp2_frame_extension_init(nghttp2_extension *frame, uint8_t type,
   frame->payload = payload;
 }
 
-void nghttp2_frame_extension_free(nghttp2_extension *frame _U_) {}
+void nghttp2_frame_extension_free(nghttp2_extension *frame) { (void)frame; }
 
 void nghttp2_frame_altsvc_init(nghttp2_extension *frame, int32_t stream_id,
                                uint8_t *origin, size_t origin_len,
@@ -346,9 +348,7 @@ void nghttp2_frame_pack_priority_spec(uint8_t *buf,
 }
 
 void nghttp2_frame_unpack_priority_spec(nghttp2_priority_spec *pri_spec,
-                                        uint8_t flags _U_,
-                                        const uint8_t *payload,
-                                        size_t payloadlen _U_) {
+                                        const uint8_t *payload) {
   int32_t dep_stream_id;
   uint8_t exclusive;
   int32_t weight;
@@ -361,11 +361,9 @@ void nghttp2_frame_unpack_priority_spec(nghttp2_priority_spec *pri_spec,
 }
 
 int nghttp2_frame_unpack_headers_payload(nghttp2_headers *frame,
-                                         const uint8_t *payload,
-                                         size_t payloadlen) {
+                                         const uint8_t *payload) {
   if (frame->hd.flags & NGHTTP2_FLAG_PRIORITY) {
-    nghttp2_frame_unpack_priority_spec(&frame->pri_spec, frame->hd.flags,
-                                       payload, payloadlen);
+    nghttp2_frame_unpack_priority_spec(&frame->pri_spec, payload);
   } else {
     nghttp2_priority_spec_default_init(&frame->pri_spec);
   }
@@ -397,10 +395,8 @@ int nghttp2_frame_pack_priority(nghttp2_bufs *bufs, nghttp2_priority *frame) {
 }
 
 void nghttp2_frame_unpack_priority_payload(nghttp2_priority *frame,
-                                           const uint8_t *payload,
-                                           size_t payloadlen) {
-  nghttp2_frame_unpack_priority_spec(&frame->pri_spec, frame->hd.flags, payload,
-                                     payloadlen);
+                                           const uint8_t *payload) {
+  nghttp2_frame_unpack_priority_spec(&frame->pri_spec, payload);
 }
 
 int nghttp2_frame_pack_rst_stream(nghttp2_bufs *bufs,
@@ -424,8 +420,7 @@ int nghttp2_frame_pack_rst_stream(nghttp2_bufs *bufs,
 }
 
 void nghttp2_frame_unpack_rst_stream_payload(nghttp2_rst_stream *frame,
-                                             const uint8_t *payload,
-                                             size_t payloadlen _U_) {
+                                             const uint8_t *payload) {
   frame->error_code = nghttp2_get_uint32(payload);
 }
 
@@ -540,8 +535,7 @@ int nghttp2_frame_pack_push_promise(nghttp2_bufs *bufs,
 }
 
 int nghttp2_frame_unpack_push_promise_payload(nghttp2_push_promise *frame,
-                                              const uint8_t *payload,
-                                              size_t payloadlen _U_) {
+                                              const uint8_t *payload) {
   frame->promised_stream_id =
       nghttp2_get_uint32(payload) & NGHTTP2_STREAM_ID_MASK;
   frame->nva = NULL;
@@ -569,8 +563,7 @@ int nghttp2_frame_pack_ping(nghttp2_bufs *bufs, nghttp2_ping *frame) {
 }
 
 void nghttp2_frame_unpack_ping_payload(nghttp2_ping *frame,
-                                       const uint8_t *payload,
-                                       size_t payloadlen _U_) {
+                                       const uint8_t *payload) {
   memcpy(frame->opaque_data, payload, sizeof(frame->opaque_data));
 }
 
@@ -607,7 +600,6 @@ int nghttp2_frame_pack_goaway(nghttp2_bufs *bufs, nghttp2_goaway *frame) {
 
 void nghttp2_frame_unpack_goaway_payload(nghttp2_goaway *frame,
                                          const uint8_t *payload,
-                                         size_t payloadlen _U_,
                                          uint8_t *var_gift_payload,
                                          size_t var_gift_payloadlen) {
   frame->last_stream_id = nghttp2_get_uint32(payload) & NGHTTP2_STREAM_ID_MASK;
@@ -643,8 +635,8 @@ int nghttp2_frame_unpack_goaway_payload2(nghttp2_goaway *frame,
     memcpy(var_gift_payload, payload + 8, var_gift_payloadlen);
   }
 
-  nghttp2_frame_unpack_goaway_payload(frame, payload, payloadlen,
-                                      var_gift_payload, var_gift_payloadlen);
+  nghttp2_frame_unpack_goaway_payload(frame, payload, var_gift_payload,
+                                      var_gift_payloadlen);
 
   return 0;
 }
@@ -670,8 +662,7 @@ int nghttp2_frame_pack_window_update(nghttp2_bufs *bufs,
 }
 
 void nghttp2_frame_unpack_window_update_payload(nghttp2_window_update *frame,
-                                                const uint8_t *payload,
-                                                size_t payloadlen _U_) {
+                                                const uint8_t *payload) {
   frame->window_size_increment =
       nghttp2_get_uint32(payload) & NGHTTP2_WINDOW_SIZE_INCREMENT_MASK;
 }

--- a/lib/nghttp2_frame.h
+++ b/lib/nghttp2_frame.h
@@ -104,8 +104,7 @@ void nghttp2_frame_pack_priority_spec(uint8_t *buf,
  * assumes the |payload| contains whole priority specification.
  */
 void nghttp2_frame_unpack_priority_spec(nghttp2_priority_spec *pri_spec,
-                                        uint8_t flags, const uint8_t *payload,
-                                        size_t payloadlen);
+                                        const uint8_t *payload);
 
 /*
  * Returns the offset from the HEADERS frame payload where the
@@ -144,8 +143,7 @@ int nghttp2_frame_pack_headers(nghttp2_bufs *bufs, nghttp2_headers *frame,
  * This function always succeeds and returns 0.
  */
 int nghttp2_frame_unpack_headers_payload(nghttp2_headers *frame,
-                                         const uint8_t *payload,
-                                         size_t payloadlen);
+                                         const uint8_t *payload);
 
 /*
  * Packs PRIORITY frame |frame| in wire format and store it in
@@ -162,8 +160,7 @@ int nghttp2_frame_pack_priority(nghttp2_bufs *bufs, nghttp2_priority *frame);
  * Unpacks PRIORITY wire format into |frame|.
  */
 void nghttp2_frame_unpack_priority_payload(nghttp2_priority *frame,
-                                           const uint8_t *payload,
-                                           size_t payloadlen);
+                                           const uint8_t *payload);
 
 /*
  * Packs RST_STREAM frame |frame| in wire frame format and store it in
@@ -181,8 +178,7 @@ int nghttp2_frame_pack_rst_stream(nghttp2_bufs *bufs,
  * Unpacks RST_STREAM frame byte sequence into |frame|.
  */
 void nghttp2_frame_unpack_rst_stream_payload(nghttp2_rst_stream *frame,
-                                             const uint8_t *payload,
-                                             size_t payloadlen);
+                                             const uint8_t *payload);
 
 /*
  * Packs SETTINGS frame |frame| in wire format and store it in
@@ -273,8 +269,7 @@ int nghttp2_frame_pack_push_promise(nghttp2_bufs *bufs,
  *     TODO END_HEADERS flag is not set
  */
 int nghttp2_frame_unpack_push_promise_payload(nghttp2_push_promise *frame,
-                                              const uint8_t *payload,
-                                              size_t payloadlen);
+                                              const uint8_t *payload);
 
 /*
  * Packs PING frame |frame| in wire format and store it in
@@ -291,8 +286,7 @@ int nghttp2_frame_pack_ping(nghttp2_bufs *bufs, nghttp2_ping *frame);
  * Unpacks PING wire format into |frame|.
  */
 void nghttp2_frame_unpack_ping_payload(nghttp2_ping *frame,
-                                       const uint8_t *payload,
-                                       size_t payloadlen);
+                                       const uint8_t *payload);
 
 /*
  * Packs GOAWAY frame |frame| in wire format and store it in |bufs|.
@@ -321,7 +315,6 @@ int nghttp2_frame_pack_goaway(nghttp2_bufs *bufs, nghttp2_goaway *frame);
  */
 void nghttp2_frame_unpack_goaway_payload(nghttp2_goaway *frame,
                                          const uint8_t *payload,
-                                         size_t payloadlen,
                                          uint8_t *var_gift_payload,
                                          size_t var_gift_payloadlen);
 
@@ -356,8 +349,7 @@ int nghttp2_frame_pack_window_update(nghttp2_bufs *bufs,
  * Unpacks WINDOW_UPDATE frame byte sequence into |frame|.
  */
 void nghttp2_frame_unpack_window_update_payload(nghttp2_window_update *frame,
-                                                const uint8_t *payload,
-                                                size_t payloadlen);
+                                                const uint8_t *payload);
 
 /*
  * Packs ALTSVC frame |frame| in wire frame format and store it in

--- a/lib/nghttp2_hd.c
+++ b/lib/nghttp2_hd.c
@@ -1537,10 +1537,11 @@ ssize_t nghttp2_hd_deflate_hd_vec(nghttp2_hd_deflater *deflater,
   return (ssize_t)buflen;
 }
 
-size_t nghttp2_hd_deflate_bound(nghttp2_hd_deflater *deflater _U_,
+size_t nghttp2_hd_deflate_bound(nghttp2_hd_deflater *deflater,
                                 const nghttp2_nv *nva, size_t nvlen) {
   size_t n = 0;
   size_t i;
+  (void)deflater;
 
   /* Possible Maximum Header Table Size Change.  Encoding (1u << 31) -
      1 using 4 bit prefix requires 6 bytes.  We may emit this at most

--- a/lib/nghttp2_http.c
+++ b/lib/nghttp2_http.c
@@ -521,8 +521,10 @@ int nghttp2_http_on_response_headers(nghttp2_stream *stream) {
   return 0;
 }
 
-int nghttp2_http_on_trailer_headers(nghttp2_stream *stream _U_,
+int nghttp2_http_on_trailer_headers(nghttp2_stream *stream,
                                     nghttp2_frame *frame) {
+  (void)stream;
+
   if ((frame->hd.flags & NGHTTP2_FLAG_END_STREAM) == 0) {
     return -1;
   }

--- a/lib/nghttp2_mem.c
+++ b/lib/nghttp2_mem.c
@@ -24,18 +24,27 @@
  */
 #include "nghttp2_mem.h"
 
-static void *default_malloc(size_t size, void *mem_user_data _U_) {
+static void *default_malloc(size_t size, void *mem_user_data) {
+  (void)mem_user_data;
+
   return malloc(size);
 }
 
-static void default_free(void *ptr, void *mem_user_data _U_) { free(ptr); }
+static void default_free(void *ptr, void *mem_user_data) {
+  (void)mem_user_data;
 
-static void *default_calloc(size_t nmemb, size_t size,
-                            void *mem_user_data _U_) {
+  free(ptr);
+}
+
+static void *default_calloc(size_t nmemb, size_t size, void *mem_user_data) {
+  (void)mem_user_data;
+
   return calloc(nmemb, size);
 }
 
-static void *default_realloc(void *ptr, size_t size, void *mem_user_data _U_) {
+static void *default_realloc(void *ptr, size_t size, void *mem_user_data) {
+  (void)mem_user_data;
+
   return realloc(ptr, size);
 }
 

--- a/lib/nghttp2_session.c
+++ b/lib/nghttp2_session.c
@@ -3394,8 +3394,7 @@ static int session_call_unpack_extension_callback(nghttp2_session *session) {
  * NGHTTP2_ERR_NOMEM
  *   Out of memory.
  */
-static int session_handle_frame_size_error(nghttp2_session *session,
-                                           nghttp2_frame *frame _U_) {
+static int session_handle_frame_size_error(nghttp2_session *session) {
   /* TODO Currently no callback is called for this error, because we
      call this callback before reading any payload */
   return nghttp2_session_terminate_session(session, NGHTTP2_FRAME_SIZE_ERROR);
@@ -3991,8 +3990,7 @@ static int session_process_headers_frame(nghttp2_session *session) {
   nghttp2_frame *frame = &iframe->frame;
   nghttp2_stream *stream;
 
-  rv = nghttp2_frame_unpack_headers_payload(&frame->headers, iframe->sbuf.pos,
-                                            nghttp2_buf_len(&iframe->sbuf));
+  rv = nghttp2_frame_unpack_headers_payload(&frame->headers, iframe->sbuf.pos);
 
   if (rv != 0) {
     return nghttp2_session_terminate_session_with_reason(
@@ -4082,8 +4080,7 @@ static int session_process_priority_frame(nghttp2_session *session) {
   nghttp2_inbound_frame *iframe = &session->iframe;
   nghttp2_frame *frame = &iframe->frame;
 
-  nghttp2_frame_unpack_priority_payload(&frame->priority, iframe->sbuf.pos,
-                                        nghttp2_buf_len(&iframe->sbuf));
+  nghttp2_frame_unpack_priority_payload(&frame->priority, iframe->sbuf.pos);
 
   return nghttp2_session_on_priority_received(session, frame);
 }
@@ -4124,8 +4121,7 @@ static int session_process_rst_stream_frame(nghttp2_session *session) {
   nghttp2_inbound_frame *iframe = &session->iframe;
   nghttp2_frame *frame = &iframe->frame;
 
-  nghttp2_frame_unpack_rst_stream_payload(&frame->rst_stream, iframe->sbuf.pos,
-                                          nghttp2_buf_len(&iframe->sbuf));
+  nghttp2_frame_unpack_rst_stream_payload(&frame->rst_stream, iframe->sbuf.pos);
 
   return nghttp2_session_on_rst_stream_received(session, frame);
 }
@@ -4597,8 +4593,8 @@ static int session_process_push_promise_frame(nghttp2_session *session) {
   nghttp2_inbound_frame *iframe = &session->iframe;
   nghttp2_frame *frame = &iframe->frame;
 
-  rv = nghttp2_frame_unpack_push_promise_payload(
-      &frame->push_promise, iframe->sbuf.pos, nghttp2_buf_len(&iframe->sbuf));
+  rv = nghttp2_frame_unpack_push_promise_payload(&frame->push_promise,
+                                                 iframe->sbuf.pos);
 
   if (rv != 0) {
     return nghttp2_session_terminate_session_with_reason(
@@ -4632,8 +4628,7 @@ static int session_process_ping_frame(nghttp2_session *session) {
   nghttp2_inbound_frame *iframe = &session->iframe;
   nghttp2_frame *frame = &iframe->frame;
 
-  nghttp2_frame_unpack_ping_payload(&frame->ping, iframe->sbuf.pos,
-                                    nghttp2_buf_len(&iframe->sbuf));
+  nghttp2_frame_unpack_ping_payload(&frame->ping, iframe->sbuf.pos);
 
   return nghttp2_session_on_ping_received(session, frame);
 }
@@ -4674,9 +4669,9 @@ static int session_process_goaway_frame(nghttp2_session *session) {
   nghttp2_inbound_frame *iframe = &session->iframe;
   nghttp2_frame *frame = &iframe->frame;
 
-  nghttp2_frame_unpack_goaway_payload(
-      &frame->goaway, iframe->sbuf.pos, nghttp2_buf_len(&iframe->sbuf),
-      iframe->lbuf.pos, nghttp2_buf_len(&iframe->lbuf));
+  nghttp2_frame_unpack_goaway_payload(&frame->goaway, iframe->sbuf.pos,
+                                      iframe->lbuf.pos,
+                                      nghttp2_buf_len(&iframe->lbuf));
 
   nghttp2_buf_wrap_init(&iframe->lbuf, NULL, 0);
 
@@ -4759,8 +4754,8 @@ static int session_process_window_update_frame(nghttp2_session *session) {
   nghttp2_inbound_frame *iframe = &session->iframe;
   nghttp2_frame *frame = &iframe->frame;
 
-  nghttp2_frame_unpack_window_update_payload(
-      &frame->window_update, iframe->sbuf.pos, nghttp2_buf_len(&iframe->sbuf));
+  nghttp2_frame_unpack_window_update_payload(&frame->window_update,
+                                             iframe->sbuf.pos);
 
   return nghttp2_session_on_window_update_received(session, frame);
 }
@@ -6128,7 +6123,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
     case NGHTTP2_IB_FRAME_SIZE_ERROR:
       DEBUGF("recv: [IB_FRAME_SIZE_ERROR]\n");
 
-      rv = session_handle_frame_size_error(session, &iframe->frame);
+      rv = session_handle_frame_size_error(session);
       if (nghttp2_is_fatal(rv)) {
         return rv;
       }

--- a/lib/nghttp2_stream.c
+++ b/lib/nghttp2_stream.c
@@ -449,8 +449,8 @@ static void validate_tree(nghttp2_stream *stream) {
   check_sum_dep(stream);
   check_dep_prev(stream);
 }
-#else /* !STREAM_DEP_DEBUG */
-static void validate_tree(nghttp2_stream *stream _U_) {}
+#else  /* !STREAM_DEP_DEBUG */
+static void validate_tree(nghttp2_stream *stream) { (void)stream; }
 #endif /* !STREAM_DEP_DEBUG*/
 
 static int stream_update_dep_on_attach_item(nghttp2_stream *stream) {

--- a/lib/nghttp2_submit.c
+++ b/lib/nghttp2_submit.c
@@ -217,7 +217,7 @@ int nghttp2_submit_ping(nghttp2_session *session, uint8_t flags,
   return nghttp2_session_add_ping(session, flags, opaque_data);
 }
 
-int nghttp2_submit_priority(nghttp2_session *session, uint8_t flags _U_,
+int nghttp2_submit_priority(nghttp2_session *session, uint8_t flags,
                             int32_t stream_id,
                             const nghttp2_priority_spec *pri_spec) {
   int rv;
@@ -225,6 +225,7 @@ int nghttp2_submit_priority(nghttp2_session *session, uint8_t flags _U_,
   nghttp2_frame *frame;
   nghttp2_priority_spec copy_pri_spec;
   nghttp2_mem *mem;
+  (void)flags;
 
   mem = &session->mem;
 
@@ -264,8 +265,10 @@ int nghttp2_submit_priority(nghttp2_session *session, uint8_t flags _U_,
   return 0;
 }
 
-int nghttp2_submit_rst_stream(nghttp2_session *session, uint8_t flags _U_,
+int nghttp2_submit_rst_stream(nghttp2_session *session, uint8_t flags,
                               int32_t stream_id, uint32_t error_code) {
+  (void)flags;
+
   if (stream_id == 0) {
     return NGHTTP2_ERR_INVALID_ARGUMENT;
   }
@@ -273,9 +276,11 @@ int nghttp2_submit_rst_stream(nghttp2_session *session, uint8_t flags _U_,
   return nghttp2_session_add_rst_stream(session, stream_id, error_code);
 }
 
-int nghttp2_submit_goaway(nghttp2_session *session, uint8_t flags _U_,
+int nghttp2_submit_goaway(nghttp2_session *session, uint8_t flags,
                           int32_t last_stream_id, uint32_t error_code,
                           const uint8_t *opaque_data, size_t opaque_data_len) {
+  (void)flags;
+
   if (session->goaway_flags & NGHTTP2_GOAWAY_TERM_ON_SEND) {
     return 0;
   }
@@ -296,12 +301,13 @@ int nghttp2_submit_shutdown_notice(nghttp2_session *session) {
                                     NGHTTP2_GOAWAY_AUX_SHUTDOWN_NOTICE);
 }
 
-int nghttp2_submit_settings(nghttp2_session *session, uint8_t flags _U_,
+int nghttp2_submit_settings(nghttp2_session *session, uint8_t flags,
                             const nghttp2_settings_entry *iv, size_t niv) {
+  (void)flags;
   return nghttp2_session_add_settings(session, NGHTTP2_FLAG_NONE, iv, niv);
 }
 
-int32_t nghttp2_submit_push_promise(nghttp2_session *session, uint8_t flags _U_,
+int32_t nghttp2_submit_push_promise(nghttp2_session *session, uint8_t flags,
                                     int32_t stream_id, const nghttp2_nv *nva,
                                     size_t nvlen,
                                     void *promised_stream_user_data) {
@@ -312,6 +318,7 @@ int32_t nghttp2_submit_push_promise(nghttp2_session *session, uint8_t flags _U_,
   int32_t promised_stream_id;
   int rv;
   nghttp2_mem *mem;
+  (void)flags;
 
   mem = &session->mem;
 
@@ -365,11 +372,13 @@ int32_t nghttp2_submit_push_promise(nghttp2_session *session, uint8_t flags _U_,
   return promised_stream_id;
 }
 
-int nghttp2_submit_window_update(nghttp2_session *session, uint8_t flags _U_,
+int nghttp2_submit_window_update(nghttp2_session *session, uint8_t flags,
                                  int32_t stream_id,
                                  int32_t window_size_increment) {
   int rv;
   nghttp2_stream *stream = 0;
+  (void)flags;
+
   if (window_size_increment == 0) {
     return 0;
   }
@@ -410,11 +419,12 @@ int nghttp2_submit_window_update(nghttp2_session *session, uint8_t flags _U_,
 }
 
 int nghttp2_session_set_local_window_size(nghttp2_session *session,
-                                          uint8_t flags _U_, int32_t stream_id,
+                                          uint8_t flags, int32_t stream_id,
                                           int32_t window_size) {
   int32_t window_size_increment;
   nghttp2_stream *stream;
   int rv;
+  (void)flags;
 
   if (window_size < 0) {
     return NGHTTP2_ERR_INVALID_ARGUMENT;
@@ -476,7 +486,7 @@ int nghttp2_session_set_local_window_size(nghttp2_session *session,
   return 0;
 }
 
-int nghttp2_submit_altsvc(nghttp2_session *session, uint8_t flags _U_,
+int nghttp2_submit_altsvc(nghttp2_session *session, uint8_t flags,
                           int32_t stream_id, const uint8_t *origin,
                           size_t origin_len, const uint8_t *field_value,
                           size_t field_value_len) {
@@ -488,6 +498,7 @@ int nghttp2_submit_altsvc(nghttp2_session *session, uint8_t flags _U_,
   nghttp2_frame *frame;
   nghttp2_ext_altsvc *altsvc;
   int rv;
+  (void)flags;
 
   mem = &session->mem;
 

--- a/tests/failmalloc.c
+++ b/tests/failmalloc.c
@@ -37,7 +37,7 @@ static int init_suite1(void) { return 0; }
 
 static int clean_suite1(void) { return 0; }
 
-int main(int argc _U_, char *argv[] _U_) {
+int main() {
   CU_pSuite pSuite = NULL;
   unsigned int num_tests_failed;
 

--- a/tests/failmalloc_test.c
+++ b/tests/failmalloc_test.c
@@ -59,29 +59,39 @@ static void data_feed_init(data_feed *df, nghttp2_bufs *bufs) {
   df->datalimit = df->data + data_length;
 }
 
-static ssize_t null_send_callback(nghttp2_session *session _U_,
-                                  const uint8_t *data _U_, size_t len,
-                                  int flags _U_, void *user_data _U_) {
+static ssize_t null_send_callback(nghttp2_session *session, const uint8_t *data,
+                                  size_t len, int flags, void *user_data) {
+  (void)session;
+  (void)data;
+  (void)flags;
+  (void)user_data;
+
   return (ssize_t)len;
 }
 
-static ssize_t data_feed_recv_callback(nghttp2_session *session _U_,
-                                       uint8_t *data, size_t len, int flags _U_,
-                                       void *user_data) {
+static ssize_t data_feed_recv_callback(nghttp2_session *session, uint8_t *data,
+                                       size_t len, int flags, void *user_data) {
   data_feed *df = ((my_user_data *)user_data)->df;
   size_t avail = (size_t)(df->datalimit - df->datamark);
   size_t wlen = nghttp2_min(avail, len);
+  (void)session;
+  (void)flags;
+
   memcpy(data, df->datamark, wlen);
   df->datamark += wlen;
   return (ssize_t)wlen;
 }
 
 static ssize_t fixed_length_data_source_read_callback(
-    nghttp2_session *session _U_, int32_t stream_id _U_, uint8_t *buf _U_,
-    size_t len, uint32_t *data_flags, nghttp2_data_source *source _U_,
-    void *user_data) {
+    nghttp2_session *session, int32_t stream_id, uint8_t *buf, size_t len,
+    uint32_t *data_flags, nghttp2_data_source *source, void *user_data) {
   my_user_data *ud = (my_user_data *)user_data;
   size_t wlen;
+  (void)session;
+  (void)stream_id;
+  (void)buf;
+  (void)source;
+
   if (len < ud->data_source_length) {
     wlen = len;
   } else {

--- a/tests/main.c
+++ b/tests/main.c
@@ -47,7 +47,7 @@ static int init_suite1(void) { return 0; }
 
 static int clean_suite1(void) { return 0; }
 
-int main(int argc _U_, char *argv[] _U_) {
+int main() {
   CU_pSuite pSuite = NULL;
   unsigned int num_tests_failed;
 

--- a/tests/malloc_wrapper.c
+++ b/tests/malloc_wrapper.c
@@ -39,19 +39,29 @@ int nghttp2_nmalloc = 0;
     }                                                                          \
   } while (0)
 
-static void *my_malloc(size_t size, void *mud _U_) {
+static void *my_malloc(size_t size, void *mud) {
+  (void)mud;
+
   CHECK_PREREQ;
   return malloc(size);
 }
 
-static void my_free(void *ptr, void *mud _U_) { free(ptr); }
+static void my_free(void *ptr, void *mud) {
+  (void)mud;
 
-static void *my_calloc(size_t nmemb, size_t size, void *mud _U_) {
+  free(ptr);
+}
+
+static void *my_calloc(size_t nmemb, size_t size, void *mud) {
+  (void)mud;
+
   CHECK_PREREQ;
   return calloc(nmemb, size);
 }
 
-static void *my_realloc(void *ptr, size_t size, void *mud _U_) {
+static void *my_realloc(void *ptr, size_t size, void *mud) {
+  (void)mud;
+
   CHECK_PREREQ;
   return realloc(ptr, size);
 }

--- a/tests/nghttp2_map_test.c
+++ b/tests/nghttp2_map_test.c
@@ -100,7 +100,12 @@ static void shuffle(int *a, int n) {
   }
 }
 
-static int eachfun(nghttp2_map_entry *entry _U_, void *ptr _U_) { return 0; }
+static int eachfun(nghttp2_map_entry *entry, void *ptr) {
+  (void)entry;
+  (void)ptr;
+
+  return 0;
+}
 
 #define NUM_ENT 6000
 static strentry arr[NUM_ENT];

--- a/tests/nghttp2_pq_test.c
+++ b/tests/nghttp2_pq_test.c
@@ -127,8 +127,10 @@ static int node_less(const void *lhs, const void *rhs) {
   return ln->key < rn->key;
 }
 
-static int node_update(nghttp2_pq_entry *item, void *arg _U_) {
+static int node_update(nghttp2_pq_entry *item, void *arg) {
   node *nd = (node *)item;
+  (void)arg;
+
   if ((nd->key % 2) == 0) {
     nd->key *= -1;
     return 1;

--- a/tests/nghttp2_test_helper.c
+++ b/tests/nghttp2_test_helper.c
@@ -53,16 +53,14 @@ int unpack_frame(nghttp2_frame *frame, const uint8_t *in, size_t len) {
   switch (frame->hd.type) {
   case NGHTTP2_HEADERS:
     payloadoff = ((frame->hd.flags & NGHTTP2_FLAG_PADDED) > 0);
-    rv = nghttp2_frame_unpack_headers_payload(
-        &frame->headers, payload + payloadoff, payloadlen - payloadoff);
+    rv = nghttp2_frame_unpack_headers_payload(&frame->headers,
+                                              payload + payloadoff);
     break;
   case NGHTTP2_PRIORITY:
-    nghttp2_frame_unpack_priority_payload(&frame->priority, payload,
-                                          payloadlen);
+    nghttp2_frame_unpack_priority_payload(&frame->priority, payload);
     break;
   case NGHTTP2_RST_STREAM:
-    nghttp2_frame_unpack_rst_stream_payload(&frame->rst_stream, payload,
-                                            payloadlen);
+    nghttp2_frame_unpack_rst_stream_payload(&frame->rst_stream, payload);
     break;
   case NGHTTP2_SETTINGS:
     rv = nghttp2_frame_unpack_settings_payload2(
@@ -70,18 +68,17 @@ int unpack_frame(nghttp2_frame *frame, const uint8_t *in, size_t len) {
     break;
   case NGHTTP2_PUSH_PROMISE:
     rv = nghttp2_frame_unpack_push_promise_payload(&frame->push_promise,
-                                                   payload, payloadlen);
+                                                   payload);
     break;
   case NGHTTP2_PING:
-    nghttp2_frame_unpack_ping_payload(&frame->ping, payload, payloadlen);
+    nghttp2_frame_unpack_ping_payload(&frame->ping, payload);
     break;
   case NGHTTP2_GOAWAY:
     nghttp2_frame_unpack_goaway_payload2(&frame->goaway, payload, payloadlen,
                                          mem);
     break;
   case NGHTTP2_WINDOW_UPDATE:
-    nghttp2_frame_unpack_window_update_payload(&frame->window_update, payload,
-                                               payloadlen);
+    nghttp2_frame_unpack_window_update_payload(&frame->window_update, payload);
     break;
   case NGHTTP2_ALTSVC:
     assert(payloadlen > 2);


### PR DESCRIPTION
Instead use (void)VAR for better compiler compatibility.

Fixes #840 