### PR TITLE
nghttpx: Add --single-process option

### DIFF
--- a/gennghttpxfun.py
+++ b/gennghttpxfun.py
@@ -165,6 +165,7 @@ OPTIONS = [
     "single-thread",
     "add-x-forwarded-proto",
     "strip-incoming-x-forwarded-proto",
+    "single-process",
 ]
 
 LOGVARS = [

--- a/src/shrpx_config.cc
+++ b/src/shrpx_config.cc
@@ -1620,6 +1620,9 @@ int option_lookup_token(const char *name, size_t namelen) {
       if (util::strieq_l("client-cipher", name, 13)) {
         return SHRPX_OPTID_CLIENT_CIPHERS;
       }
+      if (util::strieq_l("single-proces", name, 13)) {
+        return SHRPX_OPTID_SINGLE_PROCESS;
+      }
       break;
     case 't':
       if (util::strieq_l("tls-proto-lis", name, 13)) {
@@ -3373,6 +3376,10 @@ int parse_config(Config *config, int optid, const StringRef &opt,
     return 0;
   case SHRPX_OPTID_STRIP_INCOMING_X_FORWARDED_PROTO:
     config->http.xfp.strip_incoming = util::strieq_l("yes", optarg);
+
+    return 0;
+  case SHRPX_OPTID_SINGLE_PROCESS:
+    config->single_process = util::strieq_l("yes", optarg);
 
     return 0;
   case SHRPX_OPTID_CONF:

--- a/src/shrpx_config.h
+++ b/src/shrpx_config.h
@@ -340,6 +340,7 @@ constexpr auto SHRPX_OPT_ADD_X_FORWARDED_PROTO =
     StringRef::from_lit("add-x-forwarded-proto");
 constexpr auto SHRPX_OPT_STRIP_INCOMING_X_FORWARDED_PROTO =
     StringRef::from_lit("strip-incoming-x-forwarded-proto");
+constexpr auto SHRPX_OPT_SINGLE_PROCESS = StringRef::from_lit("single-process");
 
 constexpr size_t SHRPX_OBFUSCATED_NODE_LENGTH = 8;
 
@@ -872,6 +873,7 @@ struct Config {
         verbose{false},
         daemon{false},
         http2_proxy{false},
+        single_process{false},
         single_thread{false},
         ev_loop_flags{0} {}
   ~Config();
@@ -913,6 +915,9 @@ struct Config {
   bool verbose;
   bool daemon;
   bool http2_proxy;
+  // Run nghttpx in single process mode.  With this mode, signal
+  // handling is omitted.
+  bool single_process;
   bool single_thread;
   // flags passed to ev_default_loop() and ev_loop_new()
   int ev_loop_flags;
@@ -1049,6 +1054,7 @@ enum {
   SHRPX_OPTID_RESPONSE_HEADER_FIELD_BUFFER,
   SHRPX_OPTID_RLIMIT_NOFILE,
   SHRPX_OPTID_SERVER_NAME,
+  SHRPX_OPTID_SINGLE_PROCESS,
   SHRPX_OPTID_SINGLE_THREAD,
   SHRPX_OPTID_STREAM_READ_TIMEOUT,
   SHRPX_OPTID_STREAM_WRITE_TIMEOUT,


### PR DESCRIPTION
With --single-process option, nghttpx will run in a single process
mode where master and worker are unified into one process.  nghttpx
still spawns additional process for neverbleed.  In the single process
mode, signal handling is disabled.

Fixes #869 