### PR TITLE
Support specifying stream priority via session::submit()

### DIFF
--- a/src/asio_client_session.cc
+++ b/src/asio_client_session.cc
@@ -96,28 +96,47 @@ boost::asio::io_service &session::io_service() const {
 
 const request *session::submit(boost::system::error_code &ec,
                                const std::string &method,
-                               const std::string &uri, header_map h) const {
-  return impl_->submit(ec, method, uri, generator_cb(), std::move(h));
+                               const std::string &uri, header_map h,
+                               priority_spec prio) const {
+  return impl_->submit(ec, method, uri, generator_cb(), std::move(h),
+                       std::move(prio));
 }
 
 const request *session::submit(boost::system::error_code &ec,
                                const std::string &method,
                                const std::string &uri, std::string data,
-                               header_map h) const {
+                               header_map h, priority_spec prio) const {
   return impl_->submit(ec, method, uri, string_generator(std::move(data)),
-                       std::move(h));
+                       std::move(h), std::move(prio));
 }
 
 const request *session::submit(boost::system::error_code &ec,
                                const std::string &method,
                                const std::string &uri, generator_cb cb,
-                               header_map h) const {
-  return impl_->submit(ec, method, uri, std::move(cb), std::move(h));
+                               header_map h, priority_spec prio) const {
+  return impl_->submit(ec, method, uri, std::move(cb), std::move(h),
+                       std::move(prio));
 }
 
 void session::read_timeout(const boost::posix_time::time_duration &t) {
   impl_->read_timeout(t);
 }
+
+priority_spec::priority_spec(const int32_t stream_id, const int32_t weight,
+                             const bool exclusive)
+    : valid_(true) {
+  nghttp2_priority_spec_init(&spec_, stream_id, weight, exclusive);
+}
+
+const nghttp2_priority_spec *priority_spec::get() const {
+  if (!valid_) {
+    return nullptr;
+  }
+
+  return &spec_;
+}
+
+const bool priority_spec::valid() const { return valid_; }
 
 } // namespace client
 } // namespace asio_http2

--- a/src/asio_client_session_impl.cc
+++ b/src/asio_client_session_impl.cc
@@ -479,7 +479,7 @@ std::unique_ptr<stream> session_impl::create_stream() {
 const request *session_impl::submit(boost::system::error_code &ec,
                                     const std::string &method,
                                     const std::string &uri, generator_cb cb,
-                                    header_map h) {
+                                    header_map h, priority_spec prio) {
   ec.clear();
 
   if (stopped_) {
@@ -559,7 +559,7 @@ const request *session_impl::submit(boost::system::error_code &ec,
     prdptr = &prd;
   }
 
-  auto stream_id = nghttp2_submit_request(session_, nullptr, nva.data(),
+  auto stream_id = nghttp2_submit_request(session_, prio.get(), nva.data(),
                                           nva.size(), prdptr, strm.get());
   if (stream_id < 0) {
     ec = make_error_code(static_cast<nghttp2_error>(stream_id));

--- a/src/asio_client_session_impl.h
+++ b/src/asio_client_session_impl.h
@@ -70,7 +70,7 @@ public:
 
   const request *submit(boost::system::error_code &ec,
                         const std::string &method, const std::string &uri,
-                        generator_cb cb, header_map h);
+                        generator_cb cb, header_map h, priority_spec spec);
 
   virtual void start_connect(tcp::resolver::iterator endpoint_it) = 0;
   virtual tcp::socket &socket() = 0;

--- a/src/includes/nghttp2/asio_http2_client.h
+++ b/src/includes/nghttp2/asio_http2_client.h
@@ -118,6 +118,28 @@ private:
   std::unique_ptr<request_impl> impl_;
 };
 
+// Wrapper around an nghttp2_priority_spec.
+class priority_spec {
+public:
+  // The default ctor is used only by sentinel values.
+  priority_spec() = default;
+
+  // Create a priority spec with the given priority settings.
+  explicit priority_spec(const int32_t stream_id, const int32_t weight,
+                         const bool exclusive = false);
+
+  // Return a pointer to a valid nghttp2 priority spec, or null.
+  const nghttp2_priority_spec *get() const;
+
+  // Indicates whether or not this spec is valid (i.e. was constructed with
+  // values).
+  const bool valid() const;
+
+private:
+  nghttp2_priority_spec spec_;
+  bool valid_ = false;
+};
+
 class session_impl;
 
 class session {
@@ -177,7 +199,8 @@ public:
   // succeeds, or nullptr and |ec| contains error message.
   const request *submit(boost::system::error_code &ec,
                         const std::string &method, const std::string &uri,
-                        header_map h = header_map{}) const;
+                        header_map h = header_map{},
+                        priority_spec prio = priority_spec()) const;
 
   // Submits request to server using |method| (e.g., "GET"), |uri|
   // (e.g., "http://localhost/") and optionally additional header
@@ -186,7 +209,8 @@ public:
   // contains error message.
   const request *submit(boost::system::error_code &ec,
                         const std::string &method, const std::string &uri,
-                        std::string data, header_map h = header_map{}) const;
+                        std::string data, header_map h = header_map{},
+                        priority_spec prio = priority_spec()) const;
 
   // Submits request to server using |method| (e.g., "GET"), |uri|
   // (e.g., "http://localhost/") and optionally additional header
@@ -195,7 +219,8 @@ public:
   // nullptr and |ec| contains error message.
   const request *submit(boost::system::error_code &ec,
                         const std::string &method, const std::string &uri,
-                        generator_cb cb, header_map h = header_map{}) const;
+                        generator_cb cb, header_map h = header_map{},
+                        priority_spec prio = priority_spec()) const;
 
 private:
   std::shared_ptr<session_impl> impl_;


### PR DESCRIPTION
i noticed that the C++ API doesn't pass along priority (just passes `nullptr` currently), so i thought a clean way to do this (without exposing the underlying nghttp2 types) would be to just create a simple wrapper that could be passed along, whose sentinel value would result in the same `nullptr` argument to `nghttp2_submit_request` (i.e. no specified priority), but when properly constructed, would pass an `nghttp2_priority_spec*`.

for convenience, it also seemed reasonable that `priority_spec` ctor should be easily usable by providing the most common arguments first, i.e., trivially used to represent weight (e.g. `priority_spec(4.0)`).

i need this on my end, so happy to make any adjustments you'd like!