### PR TITLE
nghttpx: Fix path matching bug

### DIFF
--- a/src/shrpx_worker.cc
+++ b/src/shrpx_worker.cc
@@ -505,18 +505,6 @@ size_t match_downstream_addr_group_host(
   const auto &rev_wildcard_router = routerconf.rev_wildcard_router;
   const auto &wildcard_patterns = routerconf.wildcard_patterns;
 
-  if (path.empty() || path[0] != '/') {
-    auto group = router.match(host, StringRef::from_lit("/"));
-    if (group != -1) {
-      if (LOG_ENABLED(INFO)) {
-        LOG(INFO) << "Found pattern with query " << host
-                  << ", matched pattern=" << groups[group]->pattern;
-      }
-      return group;
-    }
-    return catch_all;
-  }
-
   if (LOG_ENABLED(INFO)) {
     LOG(INFO) << "Perform mapping selection, using host=" << host
               << ", path=" << path;
@@ -601,6 +589,10 @@ size_t match_downstream_addr_group(
   auto fragment = std::find(std::begin(raw_path), std::end(raw_path), '#');
   auto query = std::find(std::begin(raw_path), fragment, '?');
   auto path = StringRef{std::begin(raw_path), query};
+
+  if (path.empty() || path[0] != '/') {
+    path = StringRef::from_lit("/");
+  }
 
   if (hostport.empty()) {
     return match_downstream_addr_group_host(routerconf, hostport, path, groups,

--- a/src/shrpx_worker_test.cc
+++ b/src/shrpx_worker_test.cc
@@ -197,6 +197,10 @@ void test_shrpx_worker_match_downstream_addr_group(void) {
   g2->pattern = ImmutableString::from_lit(".nghttp2.org");
   groups.push_back(std::move(g2));
 
+  auto g3 = std::make_shared<DownstreamAddrGroup>();
+  g3->pattern = ImmutableString::from_lit(".local");
+  groups.push_back(std::move(g3));
+
   wp.emplace_back(StringRef::from_lit("git.nghttp2.org"));
   wcrouter.add_route(StringRef::from_lit("gro.2ptthgn.tig"), 0);
   wp.back().router.add_route(StringRef::from_lit("/echo/"), 10);
@@ -205,6 +209,10 @@ void test_shrpx_worker_match_downstream_addr_group(void) {
   wcrouter.add_route(StringRef::from_lit("gro.2ptthgn."), 1);
   wp.back().router.add_route(StringRef::from_lit("/echo/"), 11);
   wp.back().router.add_route(StringRef::from_lit("/echo/foxtrot"), 12);
+
+  wp.emplace_back(StringRef::from_lit(".local"));
+  wcrouter.add_route(StringRef::from_lit("lacol."), 2);
+  wp.back().router.add_route(StringRef::from_lit("/"), 13);
 
   CU_ASSERT(11 == match_downstream_addr_group(
                       routerconf, StringRef::from_lit("git.nghttp2.org"),
@@ -230,6 +238,10 @@ void test_shrpx_worker_match_downstream_addr_group(void) {
   CU_ASSERT(0 == match_downstream_addr_group(
                      routerconf, StringRef::from_lit("nghttp2.org"),
                      StringRef::from_lit("/echo"), groups, 255, balloc));
+
+  CU_ASSERT(13 == match_downstream_addr_group(
+                      routerconf, StringRef::from_lit("test.local"),
+                      StringRef{}, groups, 255, balloc));
 }
 
 } // namespace shrpx


### PR DESCRIPTION
Previously, if path is empty or path does not start with "/", nghttpx
did not try to match with wildcard pattern.  This commit fixes it.

This will fix the issue reported in #733 