### PR TITLE
Maintain full HTTP/1.1 support in forward proxy mode

### DIFF
--- a/src/shrpx_https_upstream.cc
+++ b/src/shrpx_https_upstream.cc
@@ -383,6 +383,7 @@ int htp_hdrs_completecb(http_parser *htp) {
 
       if (host) {
         req.authority = host->value;
+        req.no_authority = false;
       }
 
       if (handler->get_ssl()) {


### PR DESCRIPTION
Currently, HTTP/1.1 requests are only supported in
forward proxy mode if they contain an absolute URI path.
With this change, HTTP/1.1 requests with a local path
are treated like an equivalent HTTP/2 request, i.e. relying
on the Host header to indicate the destination domain.