### PR TITLE
nghttp: Add -y, --no-verify-peer option to suppress peer verify warn

### DIFF
--- a/src/nghttp.h
+++ b/src/nghttp.h
@@ -96,6 +96,7 @@ struct Config {
   bool hexdump;
   bool no_push;
   bool expect_continue;
+  bool verify_peer;
 };
 
 enum class RequestState { INITIAL, ON_REQUEST, ON_RESPONSE, ON_COMPLETE };


### PR DESCRIPTION
Fixes #902 