### PR TITLE
nghttpx: Wildcard path matching

### DIFF
--- a/src/shrpx-unittest.cc
+++ b/src/shrpx-unittest.cc
@@ -130,6 +130,8 @@ int main(int argc, char *argv[]) {
       !CU_add_test(pSuite, "http_create_via_header_value",
                    shrpx::test_shrpx_http_create_via_header_value) ||
       !CU_add_test(pSuite, "router_match", shrpx::test_shrpx_router_match) ||
+      !CU_add_test(pSuite, "router_match_wildcard",
+                   shrpx::test_shrpx_router_match_wildcard) ||
       !CU_add_test(pSuite, "router_match_prefix",
                    shrpx::test_shrpx_router_match_prefix) ||
       !CU_add_test(pSuite, "util_streq", shrpx::test_util_streq) ||

--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -1688,6 +1688,18 @@ Connections:
               match  against  "nghttp2.org".   The exact  hosts  match
               takes precedence over the wildcard hosts match.
 
+              If path  part ends with  "*", it is treated  as wildcard
+              path.  The  wildcard path  behaves differently  from the
+              normal path.  For normal path,  match is made around the
+              boundary of path component  separator,"/".  On the other
+              hand, the wildcard  path does not take  into account the
+              path component  separator.  All paths which  include the
+              wildcard  path  without  last  "*" as  prefix,  and  are
+              strictly longer than wildcard  path without last "*" are
+              matched.  "*"  must match  at least one  character.  For
+              example,  the   pattern  "/foo*"  matches   "/foo/"  and
+              "/foobar".  But it does not match "/foo", or "/fo".
+
               If <PATTERN> is omitted or  empty string, "/" is used as
               pattern,  which  matches  all request  paths  (catch-all
               pattern).  The catch-all backend must be given.

--- a/src/shrpx_router_test.cc
+++ b/src/shrpx_router_test.cc
@@ -33,6 +33,7 @@ namespace shrpx {
 struct Pattern {
   StringRef pattern;
   size_t idx;
+  bool wildcard;
 };
 
 void test_shrpx_router_match(void) {
@@ -86,6 +87,59 @@ void test_shrpx_router_match(void) {
   idx = router.match(StringRef{}, StringRef::from_lit("/alpha"));
 
   CU_ASSERT(5 == idx);
+}
+
+void test_shrpx_router_match_wildcard(void) {
+  constexpr auto patterns = std::array<Pattern, 6>{{
+      {StringRef::from_lit("nghttp2.org/"), 0},
+      {StringRef::from_lit("nghttp2.org/"), 1, true},
+      {StringRef::from_lit("nghttp2.org/alpha/"), 2},
+      {StringRef::from_lit("nghttp2.org/alpha/"), 3, true},
+      {StringRef::from_lit("nghttp2.org/bravo"), 4},
+      {StringRef::from_lit("nghttp2.org/bravo"), 5, true},
+  }};
+
+  Router router;
+
+  for (auto &p : patterns) {
+    router.add_route(p.pattern, p.idx, p.wildcard);
+  }
+
+  CU_ASSERT(0 ==
+            router.match(StringRef::from_lit("nghttp2.org"),
+                         StringRef::from_lit("/")));
+
+  CU_ASSERT(1 ==
+            router.match(StringRef::from_lit("nghttp2.org"),
+                         StringRef::from_lit("/a")));
+
+  CU_ASSERT(1 ==
+            router.match(StringRef::from_lit("nghttp2.org"),
+                         StringRef::from_lit("/charlie")));
+
+  CU_ASSERT(2 ==
+            router.match(StringRef::from_lit("nghttp2.org"),
+                         StringRef::from_lit("/alpha")));
+
+  CU_ASSERT(2 ==
+            router.match(StringRef::from_lit("nghttp2.org"),
+                         StringRef::from_lit("/alpha/")));
+
+  CU_ASSERT(3 ==
+            router.match(StringRef::from_lit("nghttp2.org"),
+                         StringRef::from_lit("/alpha/b")));
+
+  CU_ASSERT(4 ==
+            router.match(StringRef::from_lit("nghttp2.org"),
+                         StringRef::from_lit("/bravo")));
+
+  CU_ASSERT(5 ==
+            router.match(StringRef::from_lit("nghttp2.org"),
+                         StringRef::from_lit("/bravocharlie")));
+
+  CU_ASSERT(5 ==
+            router.match(StringRef::from_lit("nghttp2.org"),
+                         StringRef::from_lit("/bravo/")));
 }
 
 void test_shrpx_router_match_prefix(void) {

--- a/src/shrpx_router_test.h
+++ b/src/shrpx_router_test.h
@@ -32,6 +32,7 @@
 namespace shrpx {
 
 void test_shrpx_router_match(void);
+void test_shrpx_router_match_wildcard(void);
 void test_shrpx_router_match_prefix(void);
 
 } // namespace shrpx


### PR DESCRIPTION
This commit adds wildcard path matching.  If path pattern given in
backend option ends with "\*", it is considered as wildcard path.  "\*"
must match at least one character.  All paths which include wildcard
path without last "\*" as prefix, and are strictly longer than wildcard
path without last "\*" are matched.

Fixes #914 