### PR TITLE
nghttp2_session: Allow for compiling library with -DNDEBUG set

### DIFF
--- a/lib/nghttp2_session.c
+++ b/lib/nghttp2_session.c
@@ -7150,6 +7150,7 @@ uint32_t nghttp2_session_get_remote_settings(nghttp2_session *session,
   }
 
   assert(0);
+  abort(); /* if NDEBUG is set */
 }
 
 uint32_t nghttp2_session_get_local_settings(nghttp2_session *session,
@@ -7170,6 +7171,7 @@ uint32_t nghttp2_session_get_local_settings(nghttp2_session *session,
   }
 
   assert(0);
+  abort(); /* if NDEBUG is set */
 }
 
 static int nghttp2_session_upgrade_internal(nghttp2_session *session,


### PR DESCRIPTION
Hi,

This is a very small fix for building with -DNDEBUG set (as described in 0c49e5d56e3). If assert is compiled out, these functions otherwise fail to compile as they don't return a value.

Can replace the `assert(0)`s entirely if that's desirable, but I noticed abort() isn't used anywhere else in the library code so I figure this keeps consistency - if NDEBUG is not set then the abort() call should be compiled out as unreachable code.

Thanks for all your work maintaining this library. :)
