### PR TITLE
nghttpx: Run OCSP at startup

### DIFF
--- a/gennghttpxfun.py
+++ b/gennghttpxfun.py
@@ -166,6 +166,7 @@ OPTIONS = [
     "single-process",
     "no-add-x-forwarded-proto",
     "no-strip-incoming-x-forwarded-proto",
+    "ocsp-startup",
 ]
 
 LOGVARS = [

--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -2234,6 +2234,12 @@ SSL/TLS:
               Set interval to update OCSP response cache.
               Default: )"
       << util::duration_str(config->tls.ocsp.update_interval) << R"(
+  --ocsp-startup
+              Start  accepting connections  after initial  attempts to
+              get OCSP responses  finish.  It does not  matter some of
+              the  attempts  fail.  This  feature  is  useful if  OCSP
+              responses   must    be   available    before   accepting
+              connections.
   --no-ocsp   Disable OCSP stapling.
   --tls-session-cache-memcached=<HOST>,<PORT>[;tls]
               Specify  address of  memcached server  to store  session
@@ -3183,6 +3189,7 @@ int main(int argc, char **argv) {
         {SHRPX_OPT_BACKEND_HTTP_PROXY_URI.c_str(), required_argument, &flag,
          26},
         {SHRPX_OPT_BACKEND_NO_TLS.c_str(), no_argument, &flag, 27},
+        {SHRPX_OPT_OCSP_STARTUP.c_str(), no_argument, &flag, 28},
         {SHRPX_OPT_FRONTEND_NO_TLS.c_str(), no_argument, &flag, 29},
         {SHRPX_OPT_BACKEND_TLS_SNI_FIELD.c_str(), required_argument, &flag, 31},
         {SHRPX_OPT_DH_PARAM_FILE.c_str(), required_argument, &flag, 33},
@@ -3531,6 +3538,11 @@ int main(int argc, char **argv) {
       case 27:
         // --backend-no-tls
         cmdcfgs.emplace_back(SHRPX_OPT_BACKEND_NO_TLS,
+                             StringRef::from_lit("yes"));
+        break;
+      case 28:
+        // --ocsp-startup
+        cmdcfgs.emplace_back(SHRPX_OPT_OCSP_STARTUP,
                              StringRef::from_lit("yes"));
         break;
       case 29:

--- a/src/shrpx_config.cc
+++ b/src/shrpx_config.cc
@@ -1591,6 +1591,11 @@ int option_lookup_token(const char *name, size_t namelen) {
         return SHRPX_OPTID_HTTP2_BRIDGE;
       }
       break;
+    case 'p':
+      if (util::strieq_l("ocsp-startu", name, 11)) {
+        return SHRPX_OPTID_OCSP_STARTUP;
+      }
+      break;
     case 'y':
       if (util::strieq_l("client-prox", name, 11)) {
         return SHRPX_OPTID_CLIENT_PROXY;
@@ -3419,6 +3424,10 @@ int parse_config(Config *config, int optid, const StringRef &opt,
     return 0;
   case SHRPX_OPTID_NO_STRIP_INCOMING_X_FORWARDED_PROTO:
     config->http.xfp.strip_incoming = !util::strieq_l("yes", optarg);
+
+    return 0;
+  case SHRPX_OPTID_OCSP_STARTUP:
+    config->tls.ocsp.startup = util::strieq_l("yes", optarg);
 
     return 0;
   case SHRPX_OPTID_CONF:

--- a/src/shrpx_config.h
+++ b/src/shrpx_config.h
@@ -341,6 +341,7 @@ constexpr auto SHRPX_OPT_NO_ADD_X_FORWARDED_PROTO =
     StringRef::from_lit("no-add-x-forwarded-proto");
 constexpr auto SHRPX_OPT_NO_STRIP_INCOMING_X_FORWARDED_PROTO =
     StringRef::from_lit("no-strip-incoming-x-forwarded-proto");
+constexpr auto SHRPX_OPT_OCSP_STARTUP = StringRef::from_lit("ocsp-startup");
 
 constexpr size_t SHRPX_OBFUSCATED_NODE_LENGTH = 8;
 
@@ -561,6 +562,7 @@ struct TLSConfig {
     ev_tstamp update_interval;
     StringRef fetch_ocsp_response_file;
     bool disabled;
+    bool startup;
   } ocsp;
 
   // Client verification configurations
@@ -1045,6 +1047,7 @@ enum {
   SHRPX_OPTID_NO_STRIP_INCOMING_X_FORWARDED_PROTO,
   SHRPX_OPTID_NO_VIA,
   SHRPX_OPTID_NPN_LIST,
+  SHRPX_OPTID_OCSP_STARTUP,
   SHRPX_OPTID_OCSP_UPDATE_INTERVAL,
   SHRPX_OPTID_PADDING,
   SHRPX_OPTID_PID_FILE,

--- a/src/shrpx_connection_handler.h
+++ b/src/shrpx_connection_handler.h
@@ -174,6 +174,8 @@ public:
   void
   worker_replace_downstream(std::shared_ptr<DownstreamConfig> downstreamconf);
 
+  void set_enable_acceptor_on_ocsp_completion(bool f);
+
 private:
   // Stores all SSL_CTX objects.
   std::vector<SSL_CTX *> all_ssl_ctx_;
@@ -220,6 +222,9 @@ private:
   size_t tls_ticket_key_memcached_fail_count_;
   unsigned int worker_round_robin_cnt_;
   bool graceful_shutdown_;
+  // true if acceptors should be enabled after the initial ocsp update
+  // has finished.
+  bool enable_acceptor_on_ocsp_completion_;
 };
 
 } // namespace shrpx

--- a/src/shrpx_worker_process.cc
+++ b/src/shrpx_worker_process.cc
@@ -547,6 +547,11 @@ int worker_process_event_loop(WorkerProcessConfig *wpconf) {
   ev_io_start(loop, &ipcev);
 
   if (tls::upstream_tls_enabled(config->conn) && !config->tls.ocsp.disabled) {
+    if (config->tls.ocsp.startup) {
+      conn_handler.set_enable_acceptor_on_ocsp_completion(true);
+      conn_handler.disable_acceptor();
+    }
+
     conn_handler.proceed_next_cert_ocsp();
   }
 


### PR DESCRIPTION
With --ocsp-startup option, nghttpx starts accepting connections after
initial attempts to get OCSP responses finish.  It does not matter
some of the attempts fail.  This feature is useful if OCSP responses
must be available before accepting connections.