### PR TITLE
nghttpx: Verify OCSP response

### DIFF
--- a/gennghttpxfun.py
+++ b/gennghttpxfun.py
@@ -167,6 +167,7 @@ OPTIONS = [
     "no-add-x-forwarded-proto",
     "no-strip-incoming-x-forwarded-proto",
     "ocsp-startup",
+    "no-verify-ocsp",
 ]
 
 LOGVARS = [

--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -2240,6 +2240,8 @@ SSL/TLS:
               the  attempts  fail.  This  feature  is  useful if  OCSP
               responses   must    be   available    before   accepting
               connections.
+  --no-verify-ocsp
+              nghttpx does not verify OCSP response.
   --no-ocsp   Disable OCSP stapling.
   --tls-session-cache-memcached=<HOST>,<PORT>[;tls]
               Specify  address of  memcached server  to store  session
@@ -3191,6 +3193,7 @@ int main(int argc, char **argv) {
         {SHRPX_OPT_BACKEND_NO_TLS.c_str(), no_argument, &flag, 27},
         {SHRPX_OPT_OCSP_STARTUP.c_str(), no_argument, &flag, 28},
         {SHRPX_OPT_FRONTEND_NO_TLS.c_str(), no_argument, &flag, 29},
+        {SHRPX_OPT_NO_VERIFY_OCSP.c_str(), no_argument, &flag, 30},
         {SHRPX_OPT_BACKEND_TLS_SNI_FIELD.c_str(), required_argument, &flag, 31},
         {SHRPX_OPT_DH_PARAM_FILE.c_str(), required_argument, &flag, 33},
         {SHRPX_OPT_READ_RATE.c_str(), required_argument, &flag, 34},
@@ -3548,6 +3551,11 @@ int main(int argc, char **argv) {
       case 29:
         // --frontend-no-tls
         cmdcfgs.emplace_back(SHRPX_OPT_FRONTEND_NO_TLS,
+                             StringRef::from_lit("yes"));
+        break;
+      case 30:
+        // --no-verify-ocsp
+        cmdcfgs.emplace_back(SHRPX_OPT_NO_VERIFY_OCSP,
                              StringRef::from_lit("yes"));
         break;
       case 31:

--- a/src/shrpx_config.cc
+++ b/src/shrpx_config.cc
@@ -1651,6 +1651,11 @@ int option_lookup_token(const char *name, size_t namelen) {
         return SHRPX_OPTID_NO_SERVER_PUSH;
       }
       break;
+    case 'p':
+      if (util::strieq_l("no-verify-ocs", name, 13)) {
+        return SHRPX_OPTID_NO_VERIFY_OCSP;
+      }
+      break;
     case 's':
       if (util::strieq_l("backend-no-tl", name, 13)) {
         return SHRPX_OPTID_BACKEND_NO_TLS;
@@ -3428,6 +3433,10 @@ int parse_config(Config *config, int optid, const StringRef &opt,
     return 0;
   case SHRPX_OPTID_OCSP_STARTUP:
     config->tls.ocsp.startup = util::strieq_l("yes", optarg);
+
+    return 0;
+  case SHRPX_OPTID_NO_VERIFY_OCSP:
+    config->tls.ocsp.no_verify = util::strieq_l("yes", optarg);
 
     return 0;
   case SHRPX_OPTID_CONF:

--- a/src/shrpx_config.h
+++ b/src/shrpx_config.h
@@ -342,6 +342,7 @@ constexpr auto SHRPX_OPT_NO_ADD_X_FORWARDED_PROTO =
 constexpr auto SHRPX_OPT_NO_STRIP_INCOMING_X_FORWARDED_PROTO =
     StringRef::from_lit("no-strip-incoming-x-forwarded-proto");
 constexpr auto SHRPX_OPT_OCSP_STARTUP = StringRef::from_lit("ocsp-startup");
+constexpr auto SHRPX_OPT_NO_VERIFY_OCSP = StringRef::from_lit("no-verify-ocsp");
 
 constexpr size_t SHRPX_OBFUSCATED_NODE_LENGTH = 8;
 
@@ -563,6 +564,7 @@ struct TLSConfig {
     StringRef fetch_ocsp_response_file;
     bool disabled;
     bool startup;
+    bool no_verify;
   } ocsp;
 
   // Client verification configurations
@@ -1045,6 +1047,7 @@ enum {
   SHRPX_OPTID_NO_SERVER_PUSH,
   SHRPX_OPTID_NO_SERVER_REWRITE,
   SHRPX_OPTID_NO_STRIP_INCOMING_X_FORWARDED_PROTO,
+  SHRPX_OPTID_NO_VERIFY_OCSP,
   SHRPX_OPTID_NO_VIA,
   SHRPX_OPTID_NPN_LIST,
   SHRPX_OPTID_OCSP_STARTUP,

--- a/src/shrpx_connection_handler.cc
+++ b/src/shrpx_connection_handler.cc
@@ -620,7 +620,11 @@ void ConnectionHandler::handle_ocsp_complete() {
               << " finished successfully";
   }
 
-  if (tls::verify_ocsp_response(ssl_ctx, ocsp_.resp.data(),
+  auto config = get_config();
+  auto &tlsconf = config->tls;
+
+  if (tlsconf.ocsp.no_verify ||
+      tls::verify_ocsp_response(ssl_ctx, ocsp_.resp.data(),
                                 ocsp_.resp.size()) == 0) {
 #ifndef OPENSSL_IS_BORINGSSL
 #ifdef HAVE_ATOMIC_STD_SHARED_PTR

--- a/src/shrpx_connection_handler.cc
+++ b/src/shrpx_connection_handler.cc
@@ -620,8 +620,9 @@ void ConnectionHandler::handle_ocsp_complete() {
               << " finished successfully";
   }
 
+  if (tls::verify_ocsp_response(ssl_ctx, ocsp_.resp.data(),
+                                ocsp_.resp.size()) == 0) {
 #ifndef OPENSSL_IS_BORINGSSL
-  {
 #ifdef HAVE_ATOMIC_STD_SHARED_PTR
     std::atomic_store_explicit(
         &tls_ctx_data->ocsp_data,
@@ -632,10 +633,10 @@ void ConnectionHandler::handle_ocsp_complete() {
     tls_ctx_data->ocsp_data =
         std::make_shared<std::vector<uint8_t>>(std::move(ocsp_.resp));
 #endif // !HAVE_ATOMIC_STD_SHARED_PTR
-  }
 #else  // OPENSSL_IS_BORINGSSL
-  SSL_CTX_set_ocsp_response(ssl_ctx, ocsp_.resp.data(), ocsp_.resp.size());
+    SSL_CTX_set_ocsp_response(ssl_ctx, ocsp_.resp.data(), ocsp_.resp.size());
 #endif // OPENSSL_IS_BORINGSSL
+  }
 
   ++ocsp_.next;
   proceed_next_cert_ocsp();

--- a/src/shrpx_tls.h
+++ b/src/shrpx_tls.h
@@ -264,6 +264,11 @@ X509 *load_certificate(const char *filename);
 // TLS version string.
 int proto_version_from_string(const StringRef &v);
 
+// Verifies OCSP response |ocsp_resp| of length |ocsp_resplen|.  This
+// function returns 0 if it succeeds, or -1.
+int verify_ocsp_response(SSL_CTX *ssl_ctx, const uint8_t *ocsp_resp,
+                         size_t ocsp_resplen);
+
 } // namespace tls
 
 } // namespace shrpx


### PR DESCRIPTION
At least we should make sure that the OCSP response is targeted to the
expected certificate.  This is important because we pass the file path
to the external script, and if the file is replaced because of
renewal, and nghttpx has not reloaded its configuration, the
certificate nghttpx has loaded and the one included in the file
differ.  Verifying the OCSP response detects this, and avoids to send
wrong OCSP response.