### PR TITLE
Adding timing-sensitive load test option in h2load.

### DIFF
--- a/src/h2load.h
+++ b/src/h2load.h
@@ -85,6 +85,8 @@ struct Config {
   // rate at which connections should be made
   size_t rate;
   ev_tstamp rate_period;
+  // amount of time to wait before starting measurements
+  ev_tstamp warm_up_time;
   // amount of time to wait for activity on a given connection
   ev_tstamp conn_active_timeout;
   // amount of time to wait after the last request is made on a connection
@@ -306,11 +308,21 @@ struct Client {
   int fd;
   ev_timer conn_active_watcher;
   ev_timer conn_inactivity_watcher;
+  // This is only active when there are theoretically infinite number of requests
+  ev_timer duration_watcher;
+  ev_timer warmup_watcher;
   std::string selected_proto;
   bool new_connection_requested;
   // true if the current connection will be closed, and no more new
   // request cannot be processed.
   bool final;
+  // This variable tells us whether the client is in warmup phase or not or is over
+  // 0 - Not in warm-up phase, this is the initial state in timing experiment
+  // 1 - In warmup phase. This happens after the first connect. 
+  //   - All statistics are skipped/reversed in this phase
+  // 2 - Main duration phase, in timing experiment; Otherwise, the normal phase
+  // 3 - Main duration is over
+  int warmup;
 
   enum { ERR_CONNECT_FAIL = -100 };
 


### PR DESCRIPTION
Arguments are not well checked right now. Need suggestions. So to run our timing test, we need to run:
`./src/h2load -n 0 -c 5 -r 5 --rate-period 10 -t 1 --warm-up-time 5 https://localhost:4500`
This will create 5 clients and have 5 seconds of warm-up time. The main test duration is given as the `rate-period` argument, in this case, which is 10 seconds. Number of connections (`n`) should be `0`. This helps us to know that infinite number of connections are to be tried. Currently, multiple threads are not tried. So, `t` should be `1`.
We also need to check whether previous benchmarks are working fine.