### PR TITLE
Enabling timing-based load-testing in h2load

### DIFF
--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -260,7 +260,7 @@ void rate_period_timeout_w_cb(struct ev_loop *loop, ev_timer *w, int revents) {
     assert(worker->nclients == worker->clients.size());
   }
 }
-} // namespace
+}  // namespace
 
 namespace {
 // Called when the duration for infinite number of requests are over
@@ -983,9 +983,9 @@ int Client::connection_made() {
   record_connect_time();
 
   if (!config.timing_script) {
-    auto nreq = config.is_timing_based_mode() ? 
-      std::max(req_left, session->max_concurrent_streams()) : 
-      std::min(req_left, session->max_concurrent_streams());
+    auto nreq = config.is_timing_based_mode()
+                    ? std::max(req_left, session->max_concurrent_streams())
+                    : std::min(req_left, session->max_concurrent_streams());
     for (; nreq > 0; --nreq) {
       if (submit_request() != 0) {
         process_request_failure();

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -2003,7 +2003,7 @@ int main(int argc, char **argv) {
         {"rate", required_argument, nullptr, 'r'},
         {"connection-active-timeout", required_argument, nullptr, 'T'},
         {"connection-inactivity-timeout", required_argument, nullptr, 'N'},
-        {"duration", required_argument, &flag, 'D'},
+        {"duration", required_argument, nullptr, 'D'},
         {"timing-script-file", required_argument, &flag, 3},
         {"base-uri", required_argument, nullptr, 'B'},
         {"npn-list", required_argument, &flag, 4},

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -778,7 +778,6 @@ void Client::on_header(int32_t stream_id, const uint8_t *name, size_t namelen,
 }
 
 void Client::on_status_code(int32_t stream_id, uint16_t status) {
-
   auto itr = streams.find(stream_id);
   if (itr == std::end(streams)) {
     return;

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -1308,10 +1308,9 @@ Worker::Worker(uint32_t id, SSL_CTX *ssl_ctx, size_t req_todo, size_t nclients,
   if (config->is_timing_based_mode()) {
     duration_watcher.data = this;
 
-    ev_timer_init(&warmup_watcher, warmup_timeout_cb, 
-                  config->warm_up_time, 0.);
+    ev_timer_init(&warmup_watcher, warmup_timeout_cb, config->warm_up_time, 0.);
     warmup_watcher.data = this;
-    current_phase = Phase::INITIAL_IDLE;    
+    current_phase = Phase::INITIAL_IDLE;
   } else {
     current_phase = Phase::MAIN_DURATION;
   }

--- a/src/h2load.h
+++ b/src/h2load.h
@@ -85,6 +85,10 @@ struct Config {
   // rate at which connections should be made
   size_t rate;
   ev_tstamp rate_period;
+  // amount of time for main measurements in timing-based test
+  ev_tstamp duration;
+  // amount of time to wait before starting measurements in timing-based test
+  ev_tstamp warm_up_time;
   // amount of time to wait for activity on a given connection
   ev_tstamp conn_active_timeout;
   // amount of time to wait after the last request is made on a connection
@@ -118,6 +122,7 @@ struct Config {
   ~Config();
 
   bool is_rate_mode() const;
+  bool is_timing_based_mode() const;
   bool has_base_uri() const;
 };
 
@@ -215,6 +220,15 @@ struct Stats {
 
 enum ClientState { CLIENT_IDLE, CLIENT_CONNECTED };
 
+// This type tells whether the client is in warmup phase or not or is over
+enum class Phase { 
+  INITIAL_IDLE, // Initial idle state before warm-up phase
+  WARM_UP, // Warm up phase when no measurements are done
+  MAIN_DURATION, // Main measurement phase; if timing-based
+                 // test is not run, this is the default phase
+  DURATION_OVER // This phase occurs after the measurements are over
+};
+
 struct Client;
 
 // We use systematic sampling method
@@ -253,6 +267,13 @@ struct Worker {
   ev_timer timeout_watcher;
   // The next client ID this worker assigns
   uint32_t next_client_id;
+  // Keeps track of the current phase (for timing-based experiment) for the worker
+  Phase current_phase;
+  // We need to keep track of the clients in order to stop them when needed
+  std::vector<Client*> clients;
+  // This is only active when there is not a bounded number of requests specified
+  ev_timer duration_watcher;
+  ev_timer warmup_watcher;
 
   Worker(uint32_t id, SSL_CTX *ssl_ctx, size_t nreq_todo, size_t nclients,
          size_t rate, size_t max_samples, Config *config);
@@ -263,6 +284,8 @@ struct Worker {
   void sample_client_stat(ClientStat *cstat);
   void report_progress();
   void report_rate_progress();
+  // This function calls the destructors of all the clients.
+  void stop_all_clients();
 };
 
 struct Stream {

--- a/src/h2load.h
+++ b/src/h2load.h
@@ -286,6 +286,8 @@ struct Worker {
   void report_rate_progress();
   // This function calls the destructors of all the clients.
   void stop_all_clients();
+  // This function frees a client from the list of clients for this Worker.
+  void free_client(Client*);
 };
 
 struct Stream {


### PR DESCRIPTION
This option will enable timing-based load-testing in h2load. Users can specify warm-up and main duration of the load-test. There will be no finite number of requests given.` h2load` will try to generate as many requests as possible, both during warm-up and the main duration period. However, statistics such as the total `req/s` will be calculated only for the main duration period.
For this test to run, we can invoke h2load by the following command, for example:
`h2load -c 10 -t 2 -D 5 --warm-up-time 5 -n 0 https://localhost:4500`

The above says that there will be 10 clients for 2 threads with 5 seconds of warm-up time and 5 seconds of main duration of load-test. `-n` needs to be set to zero for timing-based test.