### PR TITLE
lib: add nghttp2_rcbuf_is_static()

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -49,6 +49,7 @@ set(APIDOCS
   nghttp2_rcbuf_decref.rst
   nghttp2_rcbuf_get_buf.rst
   nghttp2_rcbuf_incref.rst
+  nghttp2_rcbuf_is_static.rst
   nghttp2_select_next_protocol.rst
   nghttp2_session_callbacks_del.rst
   nghttp2_session_callbacks_new.rst

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -74,6 +74,7 @@ APIDOCS= \
 	nghttp2_rcbuf_decref.rst \
 	nghttp2_rcbuf_get_buf.rst \
 	nghttp2_rcbuf_incref.rst \
+	nghttp2_rcbuf_is_static.rst \
 	nghttp2_select_next_protocol.rst \
 	nghttp2_session_callbacks_del.rst \
 	nghttp2_session_callbacks_new.rst \

--- a/lib/includes/nghttp2/nghttp2.h
+++ b/lib/includes/nghttp2/nghttp2.h
@@ -470,6 +470,15 @@ NGHTTP2_EXTERN void nghttp2_rcbuf_decref(nghttp2_rcbuf *rcbuf);
 NGHTTP2_EXTERN nghttp2_vec nghttp2_rcbuf_get_buf(nghttp2_rcbuf *rcbuf);
 
 /**
+ * @function
+ *
+ * Returns 1 if the underlying buffer is statically allocated,
+ * and 0 otherwise. This can be useful for language bindings that wish to avoid
+ * creating duplicate strings for these buffers.
+ */
+NGHTTP2_EXTERN int nghttp2_rcbuf_is_static(const nghttp2_rcbuf *rcbuf);
+
+/**
  * @enum
  *
  * The flags for header field name/value pair.

--- a/lib/nghttp2_rcbuf.c
+++ b/lib/nghttp2_rcbuf.c
@@ -96,3 +96,7 @@ nghttp2_vec nghttp2_rcbuf_get_buf(nghttp2_rcbuf *rcbuf) {
   nghttp2_vec res = {rcbuf->base, rcbuf->len};
   return res;
 }
+
+int nghttp2_rcbuf_is_static(const nghttp2_rcbuf *rcbuf) {
+  return rcbuf->ref == -1;
+}


### PR DESCRIPTION
Add a `nghttp2_rcbuf_is_static()` method to tell whether a rcbuf
is statically allocated.

This can be useful for language bindings that wish to avoid
creating duplicate strings for these buffers; concretely, I am
planning to use this in the Node HTTP/2 module that is being
introduced.