### PR TITLE
Refactoring include directories

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,11 +7,8 @@ if(ENABLE_EXAMPLES)
     COMPILE_FLAGS "${WARNCXXFLAGS} ${CXX1XCXXFLAGS}")
 
   include_directories(
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/lib/includes
-    ${CMAKE_BINARY_DIR}/lib/includes
-    ${CMAKE_SOURCE_DIR}/src/includes
-    ${CMAKE_SOURCE_DIR}/third-party
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    "${CMAKE_CURRENT_SOURCE_DIR}/../third-party"
 
     ${LIBEVENT_INCLUDE_DIRS}
     ${OPENSSL_INCLUDE_DIRS}

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -44,6 +44,10 @@ set_target_properties(nghttp2 PROPERTIES
   VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
   C_VISIBILITY_PRESET hidden
 )
+target_include_directories(nghttp2 INTERFACE
+    "${CMAKE_CURRENT_BINARY_DIR}/includes"
+    "${CMAKE_CURRENT_SOURCE_DIR}/includes"
+    )
 
 if(HAVE_CUNIT)
   # Static library (for unittests because of symbol visibility)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,11 +8,8 @@ set_source_files_properties(${cxx_sources} PROPERTIES
   COMPILE_FLAGS "${WARNCXXFLAGS} ${CXX1XCXXFLAGS}")
 
 include_directories(
-  "${CMAKE_SOURCE_DIR}/lib/includes"
-  "${CMAKE_BINARY_DIR}/lib/includes"
-  "${CMAKE_SOURCE_DIR}/lib"
-  "${CMAKE_SOURCE_DIR}/src/includes"
-  "${CMAKE_SOURCE_DIR}/third-party"
+  "${CMAKE_CURRENT_SOURCE_DIR}/includes"
+  "${CMAKE_CURRENT_SOURCE_DIR}/../third-party"
 
   ${JEMALLOC_INCLUDE_DIRS}
   ${SPDYLAY_INCLUDE_DIRS}
@@ -251,6 +248,11 @@ if(ENABLE_ASIO_LIB)
   target_include_directories(nghttp2_asio PRIVATE
     ${OPENSSL_INCLUDE_DIRS}
     ${Boost_INCLUDE_DIRS}
+  )
+  target_include_directories(nghttp2_asio INTERFACE
+    "${CMAKE_CURRENT_BINARY_DIR}/../lib/includes"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../lib/includes"
+    "${CMAKE_CURRENT_SOURCE_DIR}/includes"
   )
   target_link_libraries(nghttp2_asio
     nghttp2


### PR DESCRIPTION
Refactoring include directories for build as CMake subdirectory (add_subdirectory(nghttp2))
Example: https://github.com/dvetutnev/tst_nghttp2