### PR TITLE
Reduce libxml2 version requirement to 2.6.26

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ else()
   set(ENABLE_PYTHON_BINDINGS_DEFAULT OFF)
 endif()
 
-find_package(LibXml2 2.7.7)
+find_package(LibXml2 2.6.26)
 set(WITH_LIBXML2_DEFAULT    ${LIBXML2_FOUND})
 find_package(Jemalloc)
 set(WITH_JEMALLOC_DEFAULT   ${JEMALLOC_FOUND})

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ enabled.  SPDY support will be removed soon.
 To enable ``-a`` option (getting linked assets from the downloaded
 resource) in ``nghttp``, the following package is required:
 
-* libxml2 >= 2.7.7
+* libxml2 >= 2.6.26
 
 To enable systemd support in nghttpx, the following package is
 required:

--- a/configure.ac
+++ b/configure.ac
@@ -410,7 +410,7 @@ if test "x${request_systemd}" = "xyes" &&
 fi
 
 # libxml2 (for src/nghttp)
-PKG_CHECK_MODULES([LIBXML2], [libxml-2.0 >= 2.7.7],
+PKG_CHECK_MODULES([LIBXML2], [libxml-2.0 >= 2.6.26],
                   [have_libxml2=yes], [have_libxml2=no])
 if test "x${have_libxml2}" = "xyes"; then
   AC_DEFINE([HAVE_LIBXML2], [1], [Define to 1 if you have `libxml2` library.])


### PR DESCRIPTION
It's currently set at 2.7.7 but reducing this down to 2.6.26 allows nghttp2 to be built on RHEL5