### PR TITLE
Fixed accidental compiler flags concatenation for MSVC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ endif()
 foreach(_build_type "Release" "MinSizeRel" "RelWithDebInfo")
   foreach(_lang C CXX)
     string(TOUPPER "CMAKE_${_lang}_FLAGS_${_build_type}" _var)
-    string(REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" "" ${_var} "${${_var}}")
+    string(REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" " " ${_var} "${${_var}}")
   endforeach()
 endforeach()
 


### PR DESCRIPTION
Your CMake script replaces /DNDEBUG compiler option with empty script.

But if CMAKE_C_FLAGS_{build} contains /DNDEBUG in the middle of other compiler switches then replacing it with empty string concatenates neighboring switches into one. And that make Visual Studio unhappy because it can not recognize that we have 2 switches and not 1.
In my case `/Oi /Gy /DNDEBUG /Z7` became `/Oi /Gy/Z7` and VS for some reason thinks that /Gy/Z7 is a single /GZ switch.

This patch eliminate the issue. In general extra space should not matter and in this particular case it will solve the problem with switches.
