### PR TITLE
nghttpx: Add more TLS related attributes to mruby Env object

### DIFF
--- a/doc/nghttpx.h2r
+++ b/doc/nghttpx.h2r
@@ -376,6 +376,26 @@ respectively.
 
         Return the subject name of a client certificate.
 
+    .. rb:attr_reader:: tls_cipher
+
+        Return a TLS cipher negotiated in this connection.
+
+    .. rb:attr_reader:: tls_protocol
+
+        Return a TLS protocol version negotiated in this connection.
+
+    .. rb:attr_reader:: tls_session_id
+
+        Return a session ID for this connection in hex string.
+
+    .. rb:attr_reader:: tls_session_reused
+
+        Return true if, and only if a SSL/TLS session is reused.
+
+    .. rb:attr_reader:: alpn
+
+        Return ALPN identifier negotiated in this connection.
+
 .. rb:class:: Request
 
     Object to represent request from client.  The modification to

--- a/src/shrpx_client_handler.cc
+++ b/src/shrpx_client_handler.cc
@@ -1481,6 +1481,8 @@ void ClientHandler::set_tls_sni(const StringRef &sni) {
 
 StringRef ClientHandler::get_tls_sni() const { return sni_; }
 
+StringRef ClientHandler::get_alpn() const { return alpn_; }
+
 BlockAllocator &ClientHandler::get_block_allocator() { return balloc_; }
 
 } // namespace shrpx

--- a/src/shrpx_client_handler.h
+++ b/src/shrpx_client_handler.h
@@ -166,6 +166,9 @@ public:
   // Returns TLS SNI extension value client sent in this connection.
   StringRef get_tls_sni() const;
 
+  // Returns ALPN negotiated in this connection.
+  StringRef get_alpn() const;
+
   BlockAllocator &get_block_allocator();
 
 private:


### PR DESCRIPTION
The added attributes are:

* tls_cipher
* tls_protocol
* tls_session_id
* tls_session_reused
* alpn

See #1031 