### PR TITLE
Use NGHTTP2_REFUSED_STREAM for streams which are closed by GOAWAY

### DIFF
--- a/lib/nghttp2_session.c
+++ b/lib/nghttp2_session.c
@@ -2417,19 +2417,16 @@ static int session_close_stream_on_goaway(nghttp2_session *session,
   nghttp2_stream *stream, *next_stream;
   nghttp2_close_stream_on_goaway_arg arg = {session, NULL, last_stream_id,
                                             incoming};
-  uint32_t error_code;
 
   rv = nghttp2_map_each(&session->streams, find_stream_on_goaway_func, &arg);
   assert(rv == 0);
-
-  error_code =
-      session->server && incoming ? NGHTTP2_REFUSED_STREAM : NGHTTP2_CANCEL;
 
   stream = arg.head;
   while (stream) {
     next_stream = stream->closed_next;
     stream->closed_next = NULL;
-    rv = nghttp2_session_close_stream(session, stream->stream_id, error_code);
+    rv = nghttp2_session_close_stream(session, stream->stream_id,
+                                      NGHTTP2_REFUSED_STREAM);
 
     /* stream may be deleted here */
 


### PR DESCRIPTION
The error code NGHTTP2_REFUSED_STREAM is passed to
nghttp2_on_stream_close callback when a stream is closed because its
stream ID is strictly larger than incoming or outgoing GOAWAY.