### PR TITLE
Fix #1119: Overwrite of first header on mruby call to env.req.set_header(..)

### DIFF
--- a/src/shrpx_mruby_module_request.cc
+++ b/src/shrpx_mruby_module_request.cc
@@ -246,8 +246,9 @@ mrb_value request_mod_header(mrb_state *mrb, mrb_value self, bool repl) {
         continue;
       }
       if (i != p) {
-        headers[p++] = std::move(kv);
+        headers[p] = std::move(kv);
       }
+      ++p;
     }
     headers.resize(p);
   }


### PR DESCRIPTION
Fixes #1119.

Fixes a simple logic bug where the first header will be overwritten when the replacement header is not equal to the first header in the header hashmap. In this scenario, after `p == i == 0`, then `p == (i - 1)`, which iteratively overwrites the previous value, starting with index 0 (the first header), then resizes the array to `size() - 1`.

This patch fixes the bug so that `p != i` iff at least one header key has matched the replacement header key.