### PR TITLE
cmake: add ENABLE_STATIC_LIB option to build static lib

### DIFF
--- a/CMakeOptions.txt
+++ b/CMakeOptions.txt
@@ -14,6 +14,7 @@ option(ENABLE_PYTHON_BINDINGS "Build Python bindings"
   ${ENABLE_PYTHON_BINDINGS_DEFAULT})
 option(ENABLE_FAILMALLOC "Build failmalloc test program" ON)
 option(ENABLE_LIB_ONLY  "Build libnghttp2 only.  This is a short hand for -DENABLE_APP=0 -DENABLE_EXAMPLES=0 -DENABLE_HPACK_TOOLS=0 -DENABLE_PYTHON_BINDINGS=0")
+option(ENABLE_STATIC_LIB "Build libnghttp2 in static mode also")
 
 option(WITH_LIBXML2     "Use libxml2"
   ${WITH_LIBXML2_DEFAULT})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -49,7 +49,7 @@ target_include_directories(nghttp2 INTERFACE
     "${CMAKE_CURRENT_SOURCE_DIR}/includes"
     )
 
-if(HAVE_CUNIT)
+if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
   # Static library (for unittests because of symbol visibility)
   add_library(nghttp2_static STATIC ${NGHTTP2_SOURCES})
   set_target_properties(nghttp2_static PROPERTIES
@@ -58,6 +58,10 @@ if(HAVE_CUNIT)
     ARCHIVE_OUTPUT_NAME nghttp2
   )
   target_compile_definitions(nghttp2_static PUBLIC "-DNGHTTP2_STATICLIB")
+  if(ENABLE_STATIC_LIB)
+    install(TARGETS nghttp2_static
+      DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+  endif()
 endif()
 
 install(TARGETS nghttp2


### PR DESCRIPTION
When using the `ENABLE_LIB_ONLY` option, only the shared library was built. This new option allows to build the static library as well.
