### PR TITLE
check for BIO_{get,set}_data and BIO_set_init

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -359,6 +359,11 @@ PKG_CHECK_MODULES([OPENSSL], [openssl >= 1.0.1],
 if test "x${have_openssl}" = "xno"; then
   AC_MSG_NOTICE($OPENSSL_PKG_ERRORS)
 fi
+save_LIBS=$LIBS
+LIBS=$OPENSSL_LIBS
+AC_CHECK_FUNCS(BIO_set_data BIO_get_data BIO_set_init)
+LIBS=$save_LIBS
+
 
 # c-ares (for src)
 PKG_CHECK_MODULES([LIBCARES], [libcares >= 1.7.5], [have_libcares=yes],

--- a/src/shrpx_connection.cc
+++ b/src/shrpx_connection.cc
@@ -44,13 +44,15 @@ using namespace nghttp2;
 
 namespace shrpx {
 
-#if !OPENSSL_1_1_API
-
+#ifndef HAVE_BIO_GET_DATA
 void *BIO_get_data(BIO *bio) { return bio->ptr; }
+#endif
+#ifndef HAVE_BIO_SET_DATA
 void BIO_set_data(BIO *bio, void *ptr) { bio->ptr = ptr; }
+#endif
+#ifndef HAVE_BIO_SET_INIT
 void BIO_set_init(BIO *bio, int init) { bio->init = init; }
-
-#endif // !OPENSSL_1_1_API
+#endif
 
 Connection::Connection(struct ev_loop *loop, int fd, SSL *ssl,
                        MemchunkPool *mcpool, ev_tstamp write_timeout,


### PR DESCRIPTION
LibreSSL implements those functions since 2.7 so to fix build failure
with newer LibreSSL we need to check if those functions are implemented
in stead of just check for OpenSSL 1.1.

fixes #1156

Signed-off-by: Natanael Copa <ncopa@alpinelinux.org>