### PR TITLE
pulled default NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS to 1073741824

### DIFF
--- a/src/asio_server_http2_handler.cc
+++ b/src/asio_server_http2_handler.cc
@@ -298,7 +298,7 @@ int http2_handler::start() {
     return -1;
   }
 
-  nghttp2_settings_entry ent{NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, 100};
+  nghttp2_settings_entry ent{NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, 1073741824};
   nghttp2_submit_settings(session_, NGHTTP2_FLAG_NONE, &ent, 1);
 
   return 0;


### PR DESCRIPTION
We need to get rid of the default 100 HTTP/2 streams as default... default should be unlimited (ideally ((1U << 31) - 1))