### PR TITLE
get rid of sys/types.h

### DIFF
--- a/lib/includes/nghttp2/nghttp2.h
+++ b/lib/includes/nghttp2/nghttp2.h
@@ -35,6 +35,10 @@
 extern "C" {
 #endif
 
+#ifdef HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
 #include <stdlib.h>
 #if defined(_MSC_VER) && (_MSC_VER < 1800)
 /* MSVC < 2013 does not have inttypes.h because it is not C99
@@ -44,7 +48,11 @@ extern "C" {
 #else /* !defined(_MSC_VER) || (_MSC_VER >= 1800) */
 #  include <inttypes.h>
 #endif /* !defined(_MSC_VER) || (_MSC_VER >= 1800) */
-#include <sys/types.h>
+
+#if !defined(HAS_NO_SYS_TYPES)
+#  include <sys/types.h>
+#endif
+
 #include <stdarg.h>
 
 #include <nghttp2/nghttp2ver.h>


### PR DESCRIPTION
Hi,
some compilers doesn't support "sys/types.h". I am forbidding this header file through macro defined in config.h folder. 