### PR TITLE
Update .gitmodules to use relative paths

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "third-party/mruby"]
 	path = third-party/mruby
-	url = https://github.com/mruby/mruby
+	url = ../../mruby/mruby
 [submodule "third-party/neverbleed"]
 	path = third-party/neverbleed
-	url = https://github.com/h2o/neverbleed.git
+	url = ../../h2o/neverbleed.git


### PR DESCRIPTION
To be able to mirror project and dependencies it is extremely helpful to use relative paths.