### PR TITLE
fix code for reuse addr on asio client

### DIFF
--- a/src/asio_client_session_tcp_impl.cc
+++ b/src/asio_client_session_tcp_impl.cc
@@ -40,7 +40,8 @@ session_tcp_impl::session_tcp_impl(
     const std::string &host, const std::string &service,
     const boost::posix_time::time_duration &connect_timeout)
     : session_impl(io_service, connect_timeout),
-      socket_(io_service, tcp::v4()) {
+      socket_(io_service) {
+  socket_.open(local_endpoint.protocol());
   boost::asio::socket_base::reuse_address option(true);
   socket_.set_option(option);
   socket_.bind(local_endpoint);


### PR DESCRIPTION
Hi Tatsuhiro,

I revisited the asio client local endpoint code and I think it makes more sense to do it like this.
The previous code might be problematic if local_endpoint is ipv6.

Best regards,
Alexandros