### PR TITLE
Use __has_declspec_attribute for shared builds

### DIFF
--- a/lib/includes/nghttp2/nghttp2.h
+++ b/lib/includes/nghttp2/nghttp2.h
@@ -31,6 +31,11 @@
 #  define WIN32
 #endif
 
+/* Compatibility for non-Clang compilers */
+#ifndef __has_declspec_attribute
+#  define __has_declspec_attribute(x) 0
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -51,7 +56,7 @@ extern "C" {
 
 #ifdef NGHTTP2_STATICLIB
 #  define NGHTTP2_EXTERN
-#elif defined(WIN32)
+#elif defined(WIN32) || (__has_declspec_attribute(dllexport) && __has_declspec_attribute(dllimport))
 #  ifdef BUILDING_NGHTTP2
 #    define NGHTTP2_EXTERN __declspec(dllexport)
 #  else /* !BUILDING_NGHTTP2 */


### PR DESCRIPTION
Clang compilation targets may support `__declspec` attributes. Because of that it has a `__has_declspec_attribute` [check](https://clang.llvm.org/docs/LanguageExtensions.html#has-declspec-attribute).

Currently nghttp2 just assumes that `__declspec` is Windows only. This adds a compatibility macro and checks whether `dllimport` and `dllexport` are available.