### PR TITLE
adding an accessor for enabling CONNECT

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -39,6 +39,7 @@ set(APIDOCS
   nghttp2_option_set_no_auto_ping_ack.rst
   nghttp2_option_set_no_auto_window_update.rst
   nghttp2_option_set_no_http_messaging.rst
+  nghttp2_option_set_enable_connect_protocol.rst
   nghttp2_option_set_no_recv_client_magic.rst
   nghttp2_option_set_peer_max_concurrent_streams.rst
   nghttp2_option_set_user_recv_extension_type.rst

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -64,6 +64,7 @@ APIDOCS= \
 	nghttp2_option_set_no_auto_window_update.rst \
 	nghttp2_option_set_no_closed_streams.rst \
 	nghttp2_option_set_no_http_messaging.rst \
+	nghttp2_option_set_enable_connect_protocol.rst \
 	nghttp2_option_set_no_recv_client_magic.rst \
 	nghttp2_option_set_peer_max_concurrent_streams.rst \
 	nghttp2_option_set_user_recv_extension_type.rst \

--- a/lib/includes/nghttp2/nghttp2.h
+++ b/lib/includes/nghttp2/nghttp2.h
@@ -2537,6 +2537,17 @@ NGHTTP2_EXTERN void nghttp2_option_set_no_http_messaging(nghttp2_option *option,
 /**
  * @function
  *
+ * By default, nghttp2 library does not allow the CONNECT method.  For
+ * applications which wish to use CONNECT to allow websockets to traverse an
+ * HTTP/2 hop, give a nonzero |val| to enable CONNECT support.
+ * See `RFC 8441 <https://tools.ietf.org/html/rfc8441>`_ for details.
+ */
+NGHTTP2_EXTERN void nghttp2_option_set_enable_connect_protocol(nghttp2_option *option,
+                                                         int val);
+
+/**
+ * @function
+ *
  * RFC 7540 does not enforce any limit on the number of incoming
  * reserved streams (in RFC 7540 terms, streams in reserved (remote)
  * state).  This only affects client side, since only server can push

--- a/lib/nghttp2_option.c
+++ b/lib/nghttp2_option.c
@@ -59,6 +59,11 @@ void nghttp2_option_set_no_http_messaging(nghttp2_option *option, int val) {
   option->no_http_messaging = val;
 }
 
+void nghttp2_option_set_enable_connect_protocol(nghttp2_option *option, int val) {
+  option->opt_set_mask |= NGHTTP2_SETTINGS_ENABLE_CONNECT_PROTOCOL;
+  option->no_http_messaging = val;
+}
+
 void nghttp2_option_set_max_reserved_remote_streams(nghttp2_option *option,
                                                     uint32_t val) {
   option->opt_set_mask |= NGHTTP2_OPT_MAX_RESERVED_REMOTE_STREAMS;


### PR DESCRIPTION
As a follow-up to #1231, allowing setting NGHTTP2_SETTINGS_ENABLE_CONNECT_PROTOCOL via nghttp2_option_set_enable_connect_protocol.