### PR TITLE
cmake: Fix libevent version detection

### DIFF
--- a/cmake/FindLibevent.cmake
+++ b/cmake/FindLibevent.cmake
@@ -40,6 +40,9 @@ if(LIBEVENT_INCLUDE_DIR)
     # Libevent 2.0
     file(STRINGS "${LIBEVENT_INCLUDE_DIR}/event2/event-config.h"
       LIBEVENT_VERSION REGEX "${_version_regex}")
+    if("${LIBEVENT_VERSION}" STREQUAL "")
+      set(LIBEVENT_VERSION ${PC_LIBEVENT_VERSION})
+    endif()
   else()
     # Libevent 1.4
     file(STRINGS "${LIBEVENT_INCLUDE_DIR}/event-config.h"


### PR DESCRIPTION
On my x86_64 Gentoo Linux, the CMake build won't find libevent because Gentoo wraps include files via multilib-aware wrappers. This means that the "real" include file lives in `/usr/include/x86_64-pc-linux-gnu/event2/event-config.h`, and that there's a proxy file at `/usr/include/event2/event-config.h` which check the compile target's architecture and includes the real file from a correct directory.

In other words, nghttp2's CMake `FindLibevent.cmake` reads a wrong file and ends up not detecting the libevent's version.

This patch fixes it by simply using the version reported by `pkg-config` as the libevent's version if the original method fails. I will be happy to change this patch to always check version from pkg-config if you're OK with that.