### PR TITLE
Fix compilation with gcc5, stdc++14

### DIFF
--- a/src/shrpx_api_downstream_connection.cc
+++ b/src/shrpx_api_downstream_connection.cc
@@ -42,6 +42,7 @@ namespace {
 // List of API endpoints
 const std::array<APIEndpoint, 2> &apis() {
   static const auto apis = new std::array<APIEndpoint, 2>{
+    {
       APIEndpoint{
           StringRef::from_lit("/api/v1beta1/backendconfig"),
           true,
@@ -54,6 +55,7 @@ const std::array<APIEndpoint, 2> &apis() {
           (1 << API_METHOD_GET),
           &APIDownstreamConnection::handle_configrevision,
       },
+    }
   };
 
   return *apis;


### PR DESCRIPTION
Fixes:
shrpx_api_downstream_connection.cc:57:3: error: array must be initialized with a brace-enclosed initializer