### PR TITLE
nghttpx: Fix broken trailing slash handling

### DIFF
--- a/src/shrpx_router.cc
+++ b/src/shrpx_router.cc
@@ -220,9 +220,16 @@ const RNode *match_partial(bool *pattern_is_wildcard, const RNode *node,
           return node;
         }
 
+        // The last '/' handling, see below.
+        node = find_next_node(node, '/');
+        if (node != nullptr && node->index != -1 && node->len == 1) {
+          return node;
+        }
+
         return nullptr;
       }
 
+      // The last '/' handling, see below.
       if (node->index != -1 && offset + n + 1 == node->len &&
           node->s[node->len - 1] == '/') {
         return node;
@@ -261,6 +268,13 @@ const RNode *match_partial(bool *pattern_is_wildcard, const RNode *node,
       if (node->len == n) {
         // Complete match with this node
         if (node->index != -1) {
+          *pattern_is_wildcard = false;
+          return node;
+        }
+
+        // The last '/' handling, see below.
+        node = find_next_node(node, '/');
+        if (node != nullptr && node->index != -1 && node->len == 1) {
           *pattern_is_wildcard = false;
           return node;
         }

--- a/src/shrpx_router_test.cc
+++ b/src/shrpx_router_test.cc
@@ -45,6 +45,9 @@ void test_shrpx_router_match(void) {
       {StringRef::from_lit("www.nghttp2.org/alpha/"), 4},
       {StringRef::from_lit("/alpha"), 5},
       {StringRef::from_lit("example.com/alpha/"), 6},
+      {StringRef::from_lit("nghttp2.org/alpha/bravo2/"), 7},
+      {StringRef::from_lit("www2.nghttp2.org/alpha/"), 8},
+      {StringRef::from_lit("www2.nghttp2.org/alpha2/"), 9},
   };
 
   Router router;
@@ -83,6 +86,13 @@ void test_shrpx_router_match(void) {
   // matches pattern when last '/' is missing in path
   idx = router.match(StringRef::from_lit("nghttp2.org"),
                      StringRef::from_lit("/alpha/bravo"));
+
+  CU_ASSERT(3 == idx);
+
+  idx = router.match(StringRef::from_lit("www2.nghttp2.org"),
+                     StringRef::from_lit("/alpha"));
+
+  CU_ASSERT(8 == idx);
 
   idx = router.match(StringRef{}, StringRef::from_lit("/alpha"));
 


### PR DESCRIPTION
nghttpx allows a pattern with trailing slash to match a request path
without it.  Previously, under certain pattern registration, this does
not work.