### PR TITLE
Travis: Update to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,8 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
-    - llvm-toolchain-trusty-7
     packages:
     - g++-8
-    - clang-7
     - autoconf
     - automake
     - autotools-dev
@@ -35,7 +33,6 @@ addons:
 before_install:
   - $CC --version
   - if [ "$CXX" = "g++" ]; then export CXX="g++-8" CC="gcc-8"; fi
-  - if [ "$CXX" = "clang++" ]; then export CXX="clang++-7" CC="clang-7"; fi
   - $CC --version
   - go version
   - cmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 env:
   matrix:
     - CI_BUILD=cmake


### PR DESCRIPTION
It is now possible to use Xenial (Ubuntu 16.04) on Travis

Also no longer need to get external clang (on Travis Xenial, it is clang-7)