### PR TITLE
Add a CMake option to disable shared library

### DIFF
--- a/CMakeOptions.txt
+++ b/CMakeOptions.txt
@@ -15,6 +15,7 @@ option(ENABLE_PYTHON_BINDINGS "Build Python bindings"
 option(ENABLE_FAILMALLOC "Build failmalloc test program" ON)
 option(ENABLE_LIB_ONLY  "Build libnghttp2 only.  This is a short hand for -DENABLE_APP=0 -DENABLE_EXAMPLES=0 -DENABLE_HPACK_TOOLS=0 -DENABLE_PYTHON_BINDINGS=0")
 option(ENABLE_STATIC_LIB "Build libnghttp2 in static mode also")
+option(ENABLE_SHARED_LIB "Build libnghttp2 as a shared library" ON)
 
 option(WITH_LIBXML2     "Use libxml2"
   ${WITH_LIBXML2_DEFAULT})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -38,16 +38,21 @@ if(WIN32)
 endif()
 
 # Public shared library
-add_library(nghttp2 SHARED ${NGHTTP2_SOURCES} ${NGHTTP2_RES})
-set_target_properties(nghttp2 PROPERTIES
-  COMPILE_FLAGS "${WARNCFLAGS}"
-  VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
-  C_VISIBILITY_PRESET hidden
-)
-target_include_directories(nghttp2 INTERFACE
+if(ENABLE_SHARED_LIB)
+  add_library(nghttp2 SHARED ${NGHTTP2_SOURCES} ${NGHTTP2_RES})
+  set_target_properties(nghttp2 PROPERTIES
+    COMPILE_FLAGS "${WARNCFLAGS}"
+    VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
+    C_VISIBILITY_PRESET hidden
+  )
+  target_include_directories(nghttp2 INTERFACE
     "${CMAKE_CURRENT_BINARY_DIR}/includes"
     "${CMAKE_CURRENT_SOURCE_DIR}/includes"
-    )
+  )
+
+  install(TARGETS nghttp2
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+endif()
 
 if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
   # Static library (for unittests because of symbol visibility)
@@ -64,8 +69,6 @@ if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
   endif()
 endif()
 
-install(TARGETS nghttp2
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libnghttp2.pc"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")


### PR DESCRIPTION
Adds a CMake option `ENABLE_SHARED_LIB` (default ON) that determines if the shared library is built.

Signed-off-by: Brendan Heinonen <brendan@heinonen.co>