### PR TITLE
Fix getting long serial numbers for openssl < 1.1

### DIFF
--- a/src/shrpx_tls.cc
+++ b/src/shrpx_tls.cc
@@ -2046,9 +2046,9 @@ StringRef get_x509_serial(BlockAllocator &balloc, X509 *x) {
     return StringRef{};
   }
 
-  std::array<uint8_t, 8> b;
+  std::array<uint8_t, 20> b;
   auto n = BN_bn2bin(bn, b.data());
-  assert(n == b.size());
+  assert(n <= 20);
 
   return util::format_hex(balloc, StringRef{std::begin(b), std::end(b)});
 #endif // !OPENSSL_1_1_API


### PR DESCRIPTION
From https://www.ietf.org/rfc/rfc5280.txt

> As noted in Section 4.1.2.2, serial numbers can be expected to
> contain long integers.  Certificate users MUST be able to handle
> serialNumber values up to 20 octets in length.  Conforming CAs MUST
> NOT use serialNumber values longer than 20 octets.

Without this, nghttpx will fatal.

    jbraeg$ openssl x509 -in ~/test_certs/client.crt -serial -noout
    serial=E0CFDFC7CEA10DF8AAF715C37FAEB410

    jbraeg$ curl -k --key ~/test_certs/client.key --cert ~/test_certs/client.crt https://192.168.98.100:3000/; echo
    curl: (56) Unexpected EOF

    ...
    Assertion failed: n == b.size() (shrpx_tls.cc: get_x509_serial: 2051)
    2019-01-03T20:25:21.289Z 1 1 f84316ae NOTICE (shrpx_log.cc:895) Worker process: [9] exited abnormally with status 0x06; exit status 0; signal Aborted(6)
    2019-01-03T20:25:21.290Z 1 1 f84316ae NOTICE (shrpx.cc:4311) Shutdown momentarily