### PR TITLE
nghttpx: Pool h1 backend connection per address

### DIFF
--- a/src/shrpx_http_downstream_connection.cc
+++ b/src/shrpx_http_downstream_connection.cc
@@ -807,16 +807,6 @@ int HttpDownstreamConnection::end_upload_data() {
 
 namespace {
 void remove_from_pool(HttpDownstreamConnection *dconn) {
-  auto &group = dconn->get_downstream_addr_group();
-  auto &shared_addr = group->shared_addr;
-
-  if (shared_addr->affinity.type == SessionAffinity::NONE) {
-    auto &dconn_pool =
-        dconn->get_downstream_addr_group()->shared_addr->dconn_pool;
-    dconn_pool.remove_downstream_connection(dconn);
-    return;
-  }
-
   auto addr = dconn->get_addr();
   auto &dconn_pool = addr->dconn_pool;
   dconn_pool->remove_downstream_connection(dconn);

--- a/src/shrpx_worker.cc
+++ b/src/shrpx_worker.cc
@@ -164,12 +164,6 @@ void Worker::replace_downstream_config(
     g->retired = true;
 
     auto &shared_addr = g->shared_addr;
-
-    if (shared_addr->affinity.type == SessionAffinity::NONE) {
-      shared_addr->dconn_pool.remove_all();
-      continue;
-    }
-
     for (auto &addr : shared_addr->addrs) {
       addr.dconn_pool->remove_all();
     }
@@ -307,10 +301,8 @@ void Worker::replace_downstream_config(
       std::shuffle(std::begin(shared_addr->addrs), std::end(shared_addr->addrs),
                    randgen_);
 
-      if (shared_addr->affinity.type != SessionAffinity::NONE) {
-        for (auto &addr : shared_addr->addrs) {
-          addr.dconn_pool = std::make_unique<DownstreamConnectionPool>();
-        }
+      for (auto &addr : shared_addr->addrs) {
+        addr.dconn_pool = std::make_unique<DownstreamConnectionPool>();
       }
 
       dst->shared_addr = shared_addr;

--- a/src/shrpx_worker.h
+++ b/src/shrpx_worker.h
@@ -164,7 +164,6 @@ struct SharedDownstreamAddr {
   // TODO Verify that this approach performs better in performance
   // wise.
   DList<Http2Session> http2_avail_freelist;
-  DownstreamConnectionPool dconn_pool;
   // Configuration for session affinity
   AffinityConfig affinity;
   // Next http/1.1 downstream address index in addrs.


### PR DESCRIPTION
Pool HTTP/1.1 backend connection per address and reuse it only when
the next round robin index refers to this address.  Previously if
there is a pooled connection, there is no round robin selection.