### PR TITLE
Fix build failing with make

### DIFF
--- a/src/shrpx_api_downstream_connection.cc
+++ b/src/shrpx_api_downstream_connection.cc
@@ -41,7 +41,7 @@ namespace shrpx {
 namespace {
 // List of API endpoints
 const std::array<APIEndpoint, 2> &apis() {
-  static const auto apis = new std::array<APIEndpoint, 2>{
+  static const auto apis = new std::array<APIEndpoint, 2>{{
       APIEndpoint{
           StringRef::from_lit("/api/v1beta1/backendconfig"),
           true,
@@ -54,7 +54,7 @@ const std::array<APIEndpoint, 2> &apis() {
           (1 << API_METHOD_GET),
           &APIDownstreamConnection::handle_configrevision,
       },
-  };
+  }};
 
   return *apis;
 }


### PR DESCRIPTION
Issue:
Error while building with make: array must be initialized with a brace enclosed initializer

Fix:
Enclosing array initialisation with proper braces.