### PR TITLE
Add support for building C library only with import to Visual Studio 2017

### DIFF
--- a/lib/includes/nghttp2/nghttp2.h
+++ b/lib/includes/nghttp2/nghttp2.h
@@ -52,6 +52,13 @@ extern "C" {
 #include <sys/types.h>
 #include <stdarg.h>
 
+#if defined(_MSC_VER)
+/* ssize_t is part of the Posix standard but not the C standard. 
+   It is not supported in MSVC. */
+#  include <BaseTsd.h>
+#  define ssize_t SSIZE_T
+#endif
+
 #include <nghttp2/nghttp2ver.h>
 
 #ifdef NGHTTP2_STATICLIB


### PR DESCRIPTION
I pulled in all of the files under /lib to Visual Studio 2017 and found that in order to build I needed to add the definition for ssize_t.
This was the only change needed in addition to adding BUILDING_NGHTTP2 to the project level preprocessor definitions. 