### PR TITLE
#1202 Replaced config.h with more unique name nghttp_user_config.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,7 +396,7 @@ if(NOT ENABLE_THREADS OR NOT HAVE_STD_FUTURE)
 endif()
 
 add_definitions(-DHAVE_CONFIG_H)
-configure_file(cmakeconfig.h.in config.h)
+configure_file(cmakeconfig.h.in nghttp2_config.h)
 # autotools-compatible names
 # Sphinx expects relative paths in the .rst files. Use the fact that the files
 # below are all one directory level deep.
@@ -442,7 +442,7 @@ foreach(name
 endforeach()
 
 include_directories(
-  "${CMAKE_CURRENT_BINARY_DIR}" # for config.h
+  "${CMAKE_CURRENT_BINARY_DIR}" # for nghttp2_config.h
 )
 # For use in src/CMakeLists.txt
 set(PKGDATADIR "${CMAKE_INSTALL_FULL_DATADIR}/${CMAKE_PROJECT_NAME}")

--- a/lib/nghttp2_buf.h
+++ b/lib/nghttp2_buf.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_BUF_H
 #define NGHTTP2_BUF_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <nghttp2/nghttp2.h>
 

--- a/lib/nghttp2_callbacks.h
+++ b/lib/nghttp2_callbacks.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_CALLBACKS_H
 #define NGHTTP2_CALLBACKS_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <nghttp2/nghttp2.h>
 

--- a/lib/nghttp2_debug.h
+++ b/lib/nghttp2_debug.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_DEBUG_H
 #define NGHTTP2_DEBUG_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <nghttp2/nghttp2.h>
 

--- a/lib/nghttp2_frame.h
+++ b/lib/nghttp2_frame.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_FRAME_H
 #define NGHTTP2_FRAME_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <nghttp2/nghttp2.h>
 #include "nghttp2_hd.h"

--- a/lib/nghttp2_hd.h
+++ b/lib/nghttp2_hd.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_HD_H
 #define NGHTTP2_HD_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <nghttp2/nghttp2.h>
 

--- a/lib/nghttp2_hd_huffman.h
+++ b/lib/nghttp2_hd_huffman.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_HD_HUFFMAN_H
 #define NGHTTP2_HD_HUFFMAN_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <nghttp2/nghttp2.h>
 

--- a/lib/nghttp2_helper.h
+++ b/lib/nghttp2_helper.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_HELPER_H
 #define NGHTTP2_HELPER_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <string.h>
 #include <stddef.h>

--- a/lib/nghttp2_http.h
+++ b/lib/nghttp2_http.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_HTTP_H
 #define NGHTTP2_HTTP_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <nghttp2/nghttp2.h>
 #include "nghttp2_session.h"

--- a/lib/nghttp2_int.h
+++ b/lib/nghttp2_int.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_INT_H
 #define NGHTTP2_INT_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <nghttp2/nghttp2.h>
 

--- a/lib/nghttp2_map.h
+++ b/lib/nghttp2_map.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_MAP_H
 #define NGHTTP2_MAP_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <nghttp2/nghttp2.h>
 #include "nghttp2_int.h"

--- a/lib/nghttp2_mem.h
+++ b/lib/nghttp2_mem.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_MEM_H
 #define NGHTTP2_MEM_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <nghttp2/nghttp2.h>
 

--- a/lib/nghttp2_net.h
+++ b/lib/nghttp2_net.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_NET_H
 #define NGHTTP2_NET_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #ifdef HAVE_ARPA_INET_H
 #  include <arpa/inet.h>

--- a/lib/nghttp2_npn.h
+++ b/lib/nghttp2_npn.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_NPN_H
 #define NGHTTP2_NPN_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <nghttp2/nghttp2.h>
 

--- a/lib/nghttp2_option.h
+++ b/lib/nghttp2_option.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_OPTION_H
 #define NGHTTP2_OPTION_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <nghttp2/nghttp2.h>
 

--- a/lib/nghttp2_outbound_item.h
+++ b/lib/nghttp2_outbound_item.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_OUTBOUND_ITEM_H
 #define NGHTTP2_OUTBOUND_ITEM_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <nghttp2/nghttp2.h>
 #include "nghttp2_frame.h"

--- a/lib/nghttp2_pq.h
+++ b/lib/nghttp2_pq.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_PQ_H
 #define NGHTTP2_PQ_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <nghttp2/nghttp2.h>
 #include "nghttp2_int.h"

--- a/lib/nghttp2_priority_spec.h
+++ b/lib/nghttp2_priority_spec.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_PRIORITY_SPEC_H
 #define NGHTTP2_PRIORITY_SPEC_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <nghttp2/nghttp2.h>
 

--- a/lib/nghttp2_queue.h
+++ b/lib/nghttp2_queue.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_QUEUE_H
 #define NGHTTP2_QUEUE_H
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <nghttp2/nghttp2.h>
 

--- a/lib/nghttp2_rcbuf.h
+++ b/lib/nghttp2_rcbuf.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_RCBUF_H
 #define NGHTTP2_RCBUF_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <nghttp2/nghttp2.h>
 

--- a/lib/nghttp2_session.h
+++ b/lib/nghttp2_session.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_SESSION_H
 #define NGHTTP2_SESSION_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <nghttp2/nghttp2.h>
 #include "nghttp2_map.h"

--- a/lib/nghttp2_stream.h
+++ b/lib/nghttp2_stream.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_STREAM_H
 #define NGHTTP2_STREAM_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <nghttp2/nghttp2.h>
 #include "nghttp2_outbound_item.h"

--- a/lib/nghttp2_submit.h
+++ b/lib/nghttp2_submit.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_SUBMIT_H
 #define NGHTTP2_SUBMIT_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <nghttp2/nghttp2.h>
 

--- a/lib/nghttp2_version.c
+++ b/lib/nghttp2_version.c
@@ -22,9 +22,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <nghttp2/nghttp2.h>
 

--- a/src/base64_test.h
+++ b/src/base64_test.h
@@ -25,9 +25,7 @@
 #ifndef BASE64_TEST_H
 #define BASE64_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif // HAVE_CONFIG_H
+#include "nghttp2_config.h"
 
 namespace nghttp2 {
 

--- a/src/buffer_test.h
+++ b/src/buffer_test.h
@@ -25,9 +25,7 @@
 #ifndef BUFFER_TEST_H
 #define BUFFER_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif // HAVE_CONFIG_H
+#include "nghttp2_config.h"
 
 namespace nghttp2 {
 

--- a/src/comp_helper.h
+++ b/src/comp_helper.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_COMP_HELPER_H
 #define NGHTTP2_COMP_HELPER_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <jansson.h>
 

--- a/src/deflatehd.cc
+++ b/src/deflatehd.cc
@@ -22,9 +22,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif // HAVE_CONFIG_H
+#include "nghttp2_config.h"
 
 #ifdef HAVE_UNISTD_H
 #  include <unistd.h>

--- a/src/http2_test.h
+++ b/src/http2_test.h
@@ -25,9 +25,7 @@
 #ifndef SHRPX_HTTP2_TEST_H
 #define SHRPX_HTTP2_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif // HAVE_CONFIG_H
+#include "nghttp2_config.h"
 
 namespace shrpx {
 

--- a/src/inflatehd.cc
+++ b/src/inflatehd.cc
@@ -22,9 +22,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif // HAVE_CONFIG_H
+#include "nghttp2_config.h"
 
 #ifdef HAVE_UNISTD_H
 #  include <unistd.h>

--- a/src/memchunk_test.h
+++ b/src/memchunk_test.h
@@ -25,9 +25,7 @@
 #ifndef MEMCHUNK_TEST_H
 #define MEMCHUNK_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif // HAVE_CONFIG_H
+#include "nghttp2_config.h"
 
 namespace nghttp2 {
 

--- a/src/network.h
+++ b/src/network.h
@@ -25,9 +25,7 @@
 #ifndef NETWORK_H
 #define NETWORK_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif // HAVE_CONFIG_H
+#include "nghttp2_config.h"
 
 #include <sys/types.h>
 #ifdef HAVE_SYS_SOCKET_H

--- a/src/nghttp2_config.h
+++ b/src/nghttp2_config.h
@@ -26,7 +26,7 @@
 #define NGHTTP2_CONFIG_H
 
 #ifdef HAVE_CONFIG_H
-#  include <config.h>
+#  include "nghttp2_user_config.h"
 #endif // HAVE_CONFIG_H
 
 #endif // NGHTTP2_CONFIG_H

--- a/src/nghttp2_gzip.h
+++ b/src/nghttp2_gzip.h
@@ -24,9 +24,7 @@
  */
 #ifndef NGHTTP2_GZIP_H
 
-#  ifdef HAVE_CONFIG_H
-#    include <config.h>
-#  endif /* HAVE_CONFIG_H */
+#  include "nghttp2_config.h"
 #  include <zlib.h>
 
 #  include <nghttp2/nghttp2.h>

--- a/src/nghttp2_gzip_test.h
+++ b/src/nghttp2_gzip_test.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_GZIP_TEST_H
 #define NGHTTP2_GZIP_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/shrpx-unittest.cc
+++ b/src/shrpx-unittest.cc
@@ -22,9 +22,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif // HAVE_CONFIG_H
+#include "nghttp2_config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/shrpx_config_test.h
+++ b/src/shrpx_config_test.h
@@ -25,9 +25,7 @@
 #ifndef SHRPX_CONFIG_TEST_H
 #define SHRPX_CONFIG_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif // HAVE_CONFIG_H
+#include "nghttp2_config.h"
 
 namespace shrpx {
 

--- a/src/shrpx_downstream_test.h
+++ b/src/shrpx_downstream_test.h
@@ -25,9 +25,7 @@
 #ifndef SHRPX_DOWNSTREAM_TEST_H
 #define SHRPX_DOWNSTREAM_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif // HAVE_CONFIG_H
+#include "nghttp2_config.h"
 
 namespace shrpx {
 

--- a/src/shrpx_http_test.h
+++ b/src/shrpx_http_test.h
@@ -25,9 +25,7 @@
 #ifndef SHRPX_HTTP_TEST_H
 #define SHRPX_HTTP_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif // HAVE_CONFIG_H
+#include "nghttp2_config.h"
 
 namespace shrpx {
 

--- a/src/shrpx_router_test.h
+++ b/src/shrpx_router_test.h
@@ -25,9 +25,7 @@
 #ifndef SHRPX_ROUTER_TEST_H
 #define SHRPX_ROUTER_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif // HAVE_CONFIG_H
+#include "nghttp2_config.h"
 
 namespace shrpx {
 

--- a/src/shrpx_tls_test.h
+++ b/src/shrpx_tls_test.h
@@ -25,9 +25,7 @@
 #ifndef SHRPX_TLS_TEST_H
 #define SHRPX_TLS_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif // HAVE_CONFIG_H
+#include "nghttp2_config.h"
 
 namespace shrpx {
 

--- a/src/shrpx_worker_test.h
+++ b/src/shrpx_worker_test.h
@@ -25,9 +25,7 @@
 #ifndef SHRPX_WORKER_TEST_H
 #define SHRPX_WORKER_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif // HAVE_CONFIG_H
+#include "nghttp2_config.h"
 
 namespace shrpx {
 

--- a/src/template_test.h
+++ b/src/template_test.h
@@ -25,9 +25,7 @@
 #ifndef TEMPLATE_TEST_H
 #define TEMPLATE_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif // HAVE_CONFIG_H
+#include "nghttp2_config.h"
 
 namespace nghttp2 {
 

--- a/src/timegm.h
+++ b/src/timegm.h
@@ -25,9 +25,7 @@
 #ifndef TIMEGM_H
 #define TIMEGM_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/util_test.h
+++ b/src/util_test.h
@@ -25,9 +25,7 @@
 #ifndef UTIL_TEST_H
 #define UTIL_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif // HAVE_CONFIG_H
+#include "nghttp2_config.h"
 
 namespace shrpx {
 

--- a/src/xsi_strerror.h
+++ b/src/xsi_strerror.h
@@ -25,9 +25,7 @@
 #ifndef XSI_STRERROR_H
 #define XSI_STRERROR_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <stddef.h>
 

--- a/tests/failmalloc.c
+++ b/tests/failmalloc.c
@@ -22,9 +22,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/tests/failmalloc_test.h
+++ b/tests/failmalloc_test.h
@@ -25,9 +25,7 @@
 #ifndef FAILMALLOC_TEST_H
 #define FAILMALLOC_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 void test_nghttp2_session_send(void);
 void test_nghttp2_session_send_server(void);

--- a/tests/main.c
+++ b/tests/main.c
@@ -22,9 +22,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/tests/malloc_wrapper.h
+++ b/tests/malloc_wrapper.h
@@ -25,9 +25,7 @@
 #ifndef MALLOC_WRAPPER_H
 #define MALLOC_WRAPPER_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include <stdlib.h>
 

--- a/tests/nghttp2_buf_test.h
+++ b/tests/nghttp2_buf_test.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_BUF_TEST_H
 #define NGHTTP2_BUF_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 void test_nghttp2_bufs_add(void);
 void test_nghttp2_bufs_add_stack_buffer_overflow_bug(void);

--- a/tests/nghttp2_frame_test.h
+++ b/tests/nghttp2_frame_test.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_FRAME_TEST_H
 #define NGHTTP2_FRAME_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 void test_nghttp2_frame_pack_headers(void);
 void test_nghttp2_frame_pack_headers_frame_too_large(void);

--- a/tests/nghttp2_hd_test.h
+++ b/tests/nghttp2_hd_test.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_HD_TEST_H
 #define NGHTTP2_HD_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 void test_nghttp2_hd_deflate(void);
 void test_nghttp2_hd_deflate_same_indexed_repr(void);

--- a/tests/nghttp2_helper_test.h
+++ b/tests/nghttp2_helper_test.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_HELPER_TEST_H
 #define NGHTTP2_HELPER_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 void test_nghttp2_adjust_local_window_size(void);
 void test_nghttp2_check_header_name(void);

--- a/tests/nghttp2_map_test.h
+++ b/tests/nghttp2_map_test.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_MAP_TEST_H
 #define NGHTTP2_MAP_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 void test_nghttp2_map(void);
 void test_nghttp2_map_functional(void);

--- a/tests/nghttp2_npn_test.h
+++ b/tests/nghttp2_npn_test.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_NPN_TEST_H
 #define NGHTTP2_NPN_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 void test_nghttp2_npn(void);
 

--- a/tests/nghttp2_pq_test.h
+++ b/tests/nghttp2_pq_test.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_PQ_TEST_H
 #define NGHTTP2_PQ_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 void test_nghttp2_pq(void);
 void test_nghttp2_pq_update(void);

--- a/tests/nghttp2_queue_test.h
+++ b/tests/nghttp2_queue_test.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_QUEUE_TEST_H
 #define NGHTTP2_QUEUE_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 void test_nghttp2_queue(void);
 

--- a/tests/nghttp2_session_test.h
+++ b/tests/nghttp2_session_test.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_SESSION_TEST_H
 #define NGHTTP2_SESSION_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 void test_nghttp2_session_recv(void);
 void test_nghttp2_session_recv_invalid_stream_id(void);

--- a/tests/nghttp2_stream_test.h
+++ b/tests/nghttp2_stream_test.h
@@ -25,8 +25,6 @@
 #ifndef NGHTTP2_STREAM_TEST_H
 #define NGHTTP2_STREAM_TEST_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #endif /* NGHTTP2_STREAM_TEST_H */

--- a/tests/nghttp2_test_helper.h
+++ b/tests/nghttp2_test_helper.h
@@ -25,9 +25,7 @@
 #ifndef NGHTTP2_TEST_HELPER_H
 #define NGHTTP2_TEST_HELPER_H
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include "nghttp2_config.h"
 
 #include "nghttp2_frame.h"
 #include "nghttp2_hd.h"


### PR DESCRIPTION
-- Merged two solution into one (use everywhere nghttp2_config.h).
-- replace config.h with nghttp2_user_config.h

Hello, This is kindly request to replace config.h file name with some less common name, more specific to your project. Otherwise i have a conflict due to combining with other github projects which are using same file name inside their projects.