### PR TITLE
Move the parse of session->ob_reg after session->ob_syn.

### DIFF
--- a/lib/nghttp2_session.c
+++ b/lib/nghttp2_session.c
@@ -2349,13 +2349,6 @@ nghttp2_session_pop_next_ob_item(nghttp2_session *session) {
     return item;
   }
 
-  item = nghttp2_outbound_queue_top(&session->ob_reg);
-  if (item) {
-    nghttp2_outbound_queue_pop(&session->ob_reg);
-    item->queued = 0;
-    return item;
-  }
-
   if (!session_is_outgoing_concurrent_streams_max(session)) {
     item = nghttp2_outbound_queue_top(&session->ob_syn);
     if (item) {
@@ -2363,6 +2356,13 @@ nghttp2_session_pop_next_ob_item(nghttp2_session *session) {
       item->queued = 0;
       return item;
     }
+  }
+
+  item = nghttp2_outbound_queue_top(&session->ob_reg);
+  if (item) {
+    nghttp2_outbound_queue_pop(&session->ob_reg);
+    item->queued = 0;
+    return item;
   }
 
   if (session->remote_window_size > 0) {


### PR DESCRIPTION
This is tentative change. Feedback is very welcome! Thanks!

HTTP2 extension frames are stored in session->ob_reg, and HTTP2 headers are stored in session->session->ob_syn. When session->ob_reg is processed before session->session->ob_syn, extension frames can be handled before a stream is created (a stream can only be created after headers are received.). This change moves session->session->ob_reg after session->session->ob_syn.

I run test locally, and didn't see new failures caused by the change.