### PR TITLE
nghttp2::asio_nghttp2::client. Add callbacks to session constructor

### DIFF
--- a/src/asio_client_session.cc
+++ b/src/asio_client_session.cc
@@ -54,6 +54,27 @@ session::session(boost::asio::io_service &io_service,
 }
 
 session::session(boost::asio::io_service &io_service, const std::string &host,
+                 const std::string &service, connect_cb ccb, error_cb ecb)
+    : impl_(std::make_shared<session_tcp_impl>(
+          io_service, host, service, boost::posix_time::seconds(60))) {
+  impl_->on_connect(ccb);
+  impl_->on_error(ecb);
+  impl_->start_resolve(host, service);
+}
+
+session::session(boost::asio::io_service &io_service,
+                 const boost::asio::ip::tcp::endpoint &local_endpoint,
+                 const std::string &host, const std::string &service,
+                 connect_cb ccb, error_cb ecb)
+    : impl_(std::make_shared<session_tcp_impl>(
+          io_service, local_endpoint, host, service,
+          boost::posix_time::seconds(60))) {
+  impl_->on_connect(ccb);
+  impl_->on_error(ecb);
+  impl_->start_resolve(host, service);
+}
+
+session::session(boost::asio::io_service &io_service, const std::string &host,
                  const std::string &service,
                  const boost::posix_time::time_duration &connect_timeout)
     : impl_(std::make_shared<session_tcp_impl>(io_service, host, service,
@@ -70,6 +91,29 @@ session::session(boost::asio::io_service &io_service,
   impl_->start_resolve(host, service);
 }
 
+session::session(boost::asio::io_service &io_service, const std::string &host,
+                 const std::string &service,
+                 const boost::posix_time::time_duration &connect_timeout,
+                 connect_cb ccb, error_cb ecb)
+    : impl_(std::make_shared<session_tcp_impl>(io_service, host, service,
+                                               connect_timeout)) {
+  impl_->on_connect(ccb);
+  impl_->on_error(ecb);
+  impl_->start_resolve(host, service);
+}
+
+session::session(boost::asio::io_service &io_service,
+                 const boost::asio::ip::tcp::endpoint &local_endpoint,
+                 const std::string &host, const std::string &service,
+                 const boost::posix_time::time_duration &connect_timeout,
+                 connect_cb ccb, error_cb ecb)
+    : impl_(std::make_shared<session_tcp_impl>(io_service, local_endpoint, host,
+                                               service, connect_timeout)) {
+  impl_->on_connect(ccb);
+  impl_->on_error(ecb);
+  impl_->start_resolve(host, service);
+}
+
 session::session(boost::asio::io_service &io_service,
                  boost::asio::ssl::context &tls_ctx, const std::string &host,
                  const std::string &service)
@@ -80,10 +124,32 @@ session::session(boost::asio::io_service &io_service,
 
 session::session(boost::asio::io_service &io_service,
                  boost::asio::ssl::context &tls_ctx, const std::string &host,
+                 const std::string &service, connect_cb ccb, error_cb ecb)
+    : impl_(std::make_shared<session_tls_impl>(
+          io_service, tls_ctx, host, service, boost::posix_time::seconds(60))) {
+  impl_->on_connect(ccb);
+  impl_->on_error(ecb);
+  impl_->start_resolve(host, service);
+}
+
+session::session(boost::asio::io_service &io_service,
+                 boost::asio::ssl::context &tls_ctx, const std::string &host,
                  const std::string &service,
                  const boost::posix_time::time_duration &connect_timeout)
     : impl_(std::make_shared<session_tls_impl>(io_service, tls_ctx, host,
                                                service, connect_timeout)) {
+  impl_->start_resolve(host, service);
+}
+
+session::session(boost::asio::io_service &io_service,
+                 boost::asio::ssl::context &tls_ctx, const std::string &host,
+                 const std::string &service,
+                 const boost::posix_time::time_duration &connect_timeout,
+                 connect_cb ccb, error_cb ecb)
+    : impl_(std::make_shared<session_tls_impl>(io_service, tls_ctx, host,
+                                               service, connect_timeout)) {
+  impl_->on_connect(ccb);
+  impl_->on_error(ecb);
   impl_->start_resolve(host, service);
 }
 
@@ -156,6 +222,6 @@ const nghttp2_priority_spec *priority_spec::get() const {
 
 const bool priority_spec::valid() const { return valid_; }
 
-} // namespace client
-} // namespace asio_http2
-} // namespace nghttp2
+}  // namespace client
+}  // namespace asio_http2
+}  // namespace nghttp2

--- a/src/includes/nghttp2/asio_http2_client.h
+++ b/src/includes/nghttp2/asio_http2_client.h
@@ -36,7 +36,7 @@ namespace client {
 class response_impl;
 
 class response {
-public:
+ public:
   // Application must not call this directly.
   response();
   ~response();
@@ -58,7 +58,7 @@ public:
   // Application must not call this directly.
   response_impl &impl() const;
 
-private:
+ private:
   std::unique_ptr<response_impl> impl_;
 };
 
@@ -72,7 +72,7 @@ using connect_cb =
 class request_impl;
 
 class request {
-public:
+ public:
   // Application must not call this directly.
   request();
   ~request();
@@ -114,13 +114,13 @@ public:
   // Application must not call this directly.
   request_impl &impl() const;
 
-private:
+ private:
   std::unique_ptr<request_impl> impl_;
 };
 
 // Wrapper around an nghttp2_priority_spec.
 class priority_spec {
-public:
+ public:
   // The default ctor is used only by sentinel values.
   priority_spec() = default;
 
@@ -135,7 +135,7 @@ public:
   // values).
   const bool valid() const;
 
-private:
+ private:
   nghttp2_priority_spec spec_;
   bool valid_ = false;
 };
@@ -143,7 +143,7 @@ private:
 class session_impl;
 
 class session {
-public:
+ public:
   // Starts HTTP/2 session by connecting to |host| and |service|
   // (e.g., "80") using clear text TCP connection with connect timeout
   // 60 seconds.
@@ -154,6 +154,18 @@ public:
   session(boost::asio::io_service &io_service,
           const boost::asio::ip::tcp::endpoint &local_endpoint,
           const std::string &host, const std::string &service);
+
+  // Starts HTTP/2 session by connecting to |host| and |service|
+  // (e.g., "80") using clear text TCP connection with connect timeout
+  // 60 seconds and given connect/error callbacks.
+  session(boost::asio::io_service &io_service, const std::string &host,
+          const std::string &service, connect_cb ccb, error_cb ecb);
+
+  // Same as previous but with pegged local endpoint
+  session(boost::asio::io_service &io_service,
+          const boost::asio::ip::tcp::endpoint &local_endpoint,
+          const std::string &host, const std::string &service, connect_cb ccb,
+          error_cb ecb);
 
   // Starts HTTP/2 session by connecting to |host| and |service|
   // (e.g., "80") using clear text TCP connection with given connect
@@ -169,11 +181,33 @@ public:
           const boost::posix_time::time_duration &connect_timeout);
 
   // Starts HTTP/2 session by connecting to |host| and |service|
+  // (e.g., "80") using clear text TCP connection with given connect
+  // timeout and connect/error callbacks.
+  session(boost::asio::io_service &io_service, const std::string &host,
+          const std::string &service,
+          const boost::posix_time::time_duration &connect_timeout,
+          connect_cb ccb, error_cb ecb);
+
+  // Same as previous but with pegged local endpoint
+  session(boost::asio::io_service &io_service,
+          const boost::asio::ip::tcp::endpoint &local_endpoint,
+          const std::string &host, const std::string &service,
+          const boost::posix_time::time_duration &connect_timeout,
+          connect_cb ccb, error_cb ecb);
+
+  // Starts HTTP/2 session by connecting to |host| and |service|
   // (e.g., "443") using encrypted SSL/TLS connection with connect
   // timeout 60 seconds.
   session(boost::asio::io_service &io_service,
           boost::asio::ssl::context &tls_context, const std::string &host,
           const std::string &service);
+
+  // Starts HTTP/2 session by connecting to |host| and |service|
+  // (e.g., "443") using encrypted SSL/TLS connection with connect
+  // timeout 60 seconds and connect/error callbacks.
+  session(boost::asio::io_service &io_service,
+          boost::asio::ssl::context &tls_context, const std::string &host,
+          const std::string &service, connect_cb ccb, error_cb ecb);
 
   // Starts HTTP/2 session by connecting to |host| and |service|
   // (e.g., "443") using encrypted SSL/TLS connection with given
@@ -182,6 +216,15 @@ public:
           boost::asio::ssl::context &tls_context, const std::string &host,
           const std::string &service,
           const boost::posix_time::time_duration &connect_timeout);
+
+  // Starts HTTP/2 session by connecting to |host| and |service|
+  // (e.g., "443") using encrypted SSL/TLS connection with given
+  // connect timeout and connect/error callbacks.
+  session(boost::asio::io_service &io_service,
+          boost::asio::ssl::context &tls_context, const std::string &host,
+          const std::string &service,
+          const boost::posix_time::time_duration &connect_timeout,
+          connect_cb ccb, error_cb ecb);
 
   ~session();
 
@@ -233,20 +276,19 @@ public:
                         generator_cb cb, header_map h = header_map{},
                         priority_spec prio = priority_spec()) const;
 
-private:
+ private:
   std::shared_ptr<session_impl> impl_;
 };
 
 // configure |tls_ctx| for client use.  Currently, we just set NPN
 // callback for HTTP/2.
-boost::system::error_code
-configure_tls_context(boost::system::error_code &ec,
-                      boost::asio::ssl::context &tls_ctx);
+boost::system::error_code configure_tls_context(
+    boost::system::error_code &ec, boost::asio::ssl::context &tls_ctx);
 
-} // namespace client
+}  // namespace client
 
-} // namespace asio_http2
+}  // namespace asio_http2
 
-} // namespace nghttp2
+}  // namespace nghttp2
 
-#endif // ASIO_HTTP2_CLIENT_H
+#endif  // ASIO_HTTP2_CLIENT_H


### PR DESCRIPTION
This PR adds on_connect and on_error callbacks to nghttp2::asio_http2::client session objects. The goal is to avoid race conditions upon connections being successful or not.
The current implementation separates the session object connection (which is performed in the constructor) from the callbacks that are going to be executed when the connection is successful or not. This creates a situation where it might happen that the connection is established (or not), and callbacks are still not present, rendering the object in an unknown state to the caller.
Connection timeouts do not work here either, because those are for timeouts and this situation happens even in successful connections, or rejected ones.
The PR adds the possibility of setting up the callbacks in the constructor, making use of the RAII pattern. This way, there is no situation where the callbacks are not going to be called because they are set even before the connection is initiated.