### PR TITLE
Patch for clang bug "can not install nghttp2 1.36.0 to mac OS Yosemite"

### DIFF
--- a/src/shrpx_client_handler.cc
+++ b/src/shrpx_client_handler.cc
@@ -958,7 +958,7 @@ ClientHandler::get_downstream_connection(int &err, Downstream *downstream) {
     auto dconn = addr->dconn_pool->pop_downstream_connection();
     if (dconn) {
       dconn->set_client_handler(this);
-      return dconn;
+      return std::move(dconn);
     }
 
     if (LOG_ENABLED(INFO)) {
@@ -969,7 +969,7 @@ ClientHandler::get_downstream_connection(int &err, Downstream *downstream) {
     dconn = std::make_unique<HttpDownstreamConnection>(group, addr, conn_.loop,
                                                        worker_);
     dconn->set_client_handler(this);
-    return dconn;
+    return std::move(dconn);
   }
 
   if (LOG_ENABLED(INFO)) {
@@ -980,7 +980,7 @@ ClientHandler::get_downstream_connection(int &err, Downstream *downstream) {
   auto http2session = get_http2_session(group, addr);
   auto dconn = std::make_unique<Http2DownstreamConnection>(http2session);
   dconn->set_client_handler(this);
-  return dconn;
+  return std::move(dconn);
 }
 
 MemchunkPool *ClientHandler::get_mcpool() { return worker_->get_mcpool(); }


### PR DESCRIPTION
I got the following errors:
with mac OS Yosemite
```
$brew upgrade nghttp2

Updating Homebrew...
Warning: You are using macOS 10.10.
We (and Apple) do not provide support for this old version.
You will encounter build failures with some formulae.
Please create pull requests instead of asking for help on Homebrew's GitHub,
Discourse, Twitter or IRC. You are responsible for resolving any issues you
experience, as you are running this old version.

==> Upgrading 1 outdated package:
nghttp2 1.35.0_1 -> 1.36.0
==> Upgrading nghttp2
==> Downloading https://github.com/nghttp2/nghttp2/releases/download/v1.36.0/nghttp2-1.36.0.tar.xz
Already downloaded: /Users/sat/Library/Caches/Homebrew/downloads/fa60541b22d2a29d4f2d2dc594f6c8a8992ee7639430af98c8364c0a9453190d--nghttp2-1.36.0.tar.xz
==> ./configure --prefix=/usr/local/Cellar/nghttp2/1.36.0 --disable-silent-rules --enable-app --disable-python-bindin
==> make
Last 15 lines from /Users/sat/Library/Logs/Homebrew/nghttp2/02.make:
mv -f .deps/libnghttpx_a-shrpx_connection_handler.Tpo .deps/libnghttpx_a-shrpx_connection_handler.Po
clang++ -std=c++14 -DHAVE_CONFIG_H -I. -I..  -DPKGDATADIR='"/usr/local/Cellar/nghttp2/1.36.0/share/nghttp2"' -I../lib/includes -I../lib/includes -I../lib -I../src/includes -I../third-party -I/usr/include/libxml2 -I/usr/local/Cellar/openssl/1.0.2q/include -I/usr/local/Cellar/c-ares/1.15.0/include -I/usr/local/Cellar/jansson/2.12/include -DHAVE_CONFIG_H      -g -O2 -MT libnghttpx_a-shrpx_http_downstream_connection.o -MD -MP -MF .deps/libnghttpx_a-shrpx_http_downstream_connection.Tpo -c -o libnghttpx_a-shrpx_http_downstream_connection.o `test -f 'shrpx_http_downstream_connection.cc' || echo './'`shrpx_http_downstream_connection.cc
1 error generated.
make[3]: *** [libnghttpx_a-shrpx_client_handler.o] Error 1
make[3]: *** Waiting for unfinished jobs....
mv -f .deps/libnghttpx_a-shrpx_downstream_connection.Tpo .deps/libnghttpx_a-shrpx_downstream_connection.Po
mv -f .deps/libnghttpx_a-shrpx_https_upstream.Tpo .deps/libnghttpx_a-shrpx_https_upstream.Po
mv -f .deps/libnghttpx_a-shrpx_downstream.Tpo .deps/libnghttpx_a-shrpx_downstream.Po
mv -f .deps/libnghttpx_a-shrpx_http2_upstream.Tpo .deps/libnghttpx_a-shrpx_http2_upstream.Po
mv -f .deps/nghttpx-shrpx.Tpo .deps/nghttpx-shrpx.Po
mv -f .deps/libnghttpx_a-shrpx_http_downstream_connection.Tpo .deps/libnghttpx_a-shrpx_http_downstream_connection.Po
mv -f .deps/libnghttpx_a-shrpx_config.Tpo .deps/libnghttpx_a-shrpx_config.Po
make[2]: *** [all-recursive] Error 1
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2

Do not report this issue to Homebrew/brew or Homebrew/core!


Error: You are using macOS 10.10.
We (and Apple) do not provide support for this old version.
You will encounter build failures with some formulae.
Please create pull requests instead of asking for help on Homebrew's GitHub,
Discourse, Twitter or IRC. You are responsible for resolving any issues you
experience, as you are running this old version.
```

Reference:
Similar case on MacPorts
https://trac.macports.org/ticket/57960