### PR TITLE
asio: support boost-1.70

### DIFF
--- a/src/asio_server_connection.h
+++ b/src/asio_server_connection.h
@@ -51,6 +51,12 @@
 #include "util.h"
 #include "template.h"
 
+#if BOOST_VERSION >= 107000
+#define GET_IO_SERVICE(s) ((boost::asio::io_context&)(s).get_executor().context())
+#else
+#define GET_IO_SERVICE(s) ((s).get_io_service())
+#endif
+
 namespace nghttp2 {
 
 namespace asio_http2 {
@@ -71,7 +77,7 @@ public:
       SocketArgs &&... args)
       : socket_(std::forward<SocketArgs>(args)...),
         mux_(mux),
-        deadline_(socket_.get_io_service()),
+        deadline_(GET_IO_SERVICE(socket_)),
         tls_handshake_timeout_(tls_handshake_timeout),
         read_timeout_(read_timeout),
         writing_(false),
@@ -82,7 +88,7 @@ public:
     boost::system::error_code ec;
 
     handler_ = std::make_shared<http2_handler>(
-        socket_.get_io_service(), socket_.lowest_layer().remote_endpoint(ec),
+        GET_IO_SERVICE(socket_), socket_.lowest_layer().remote_endpoint(ec),
         [this]() { do_write(); }, mux_);
     if (handler_->start() != 0) {
       stop();


### PR DESCRIPTION
In boost 1.70, deprecated get_io_context() has finally been removed.
Introduce GET_IO_SERVICE macro that based on boost version uses
old get_io_service() interface (boost < 1.70), or get_executor().context()
for boost 1.70+.

Commit based on idea seen in monero-project/monero@17769db9462e5201befcb05f86ccbaeabf35caf8