### PR TITLE
Add option to use system http-parser lib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -137,6 +137,11 @@ AC_ARG_WITH([cython],
                     [Use cython in given PATH])],
     [cython_path=$withval], [])
 
+AC_ARG_WITH([bundled-http_parser],
+    [AS_HELP_STRING([--without-bundled-http_parser],
+		    [don't use bundled http_parser third party lib[default=yes]])],
+    [request_bundled_http_parser=$withval], [request_bundled_http_parser=yes])
+
 dnl Define variables
 AC_ARG_VAR([CYTHON], [the Cython executable])
 
@@ -529,7 +534,7 @@ fi
 
 AM_CONDITIONAL([ENABLE_EXAMPLES], [ test "x${enable_examples}" = "xyes" ])
 
-# third-party only be built when needed
+# third-party only be built when needed or not disabled by user
 
 enable_third_party=no
 have_mruby=no
@@ -538,7 +543,17 @@ if test "x${enable_examples}" = "xyes" ||
    test "x${enable_app}" = "xyes" ||
    test "x${enable_hpack_tools}" = "xyes" ||
    test "x${enable_asio_lib}" = "xyes"; then
-  enable_third_party=yes
+  AS_IF([test "x${request_bundled_http_parser}" != "xno"],
+	[enable_third_party=yes],
+	[
+	 AC_CHECK_LIB([http_parser], [http_parser_parse_url], [
+		      HTTP_PARSER_LIBS="-lhttp_parser"
+		      AC_SUBST([HTTP_PARSER_LIBS])
+		      AC_DEFINE(SYSTEM_HTTP_PARSER, [1], [Use system http-parser lib])
+	 ],[
+		      AC_MSG_ERROR([System http-parser is requested but could not be found.])
+	 ])
+  ])
 
   # mruby (for src/nghttpx)
   if test "x${request_mruby}" = "xyes"; then
@@ -558,6 +573,7 @@ if test "x${enable_examples}" = "xyes" ||
   fi
 fi
 
+AM_CONDITIONAL([SYSTEM_HTTP_PARSER], [ test "x${request_bundled_http_parser}" = "xno" ])
 AM_CONDITIONAL([ENABLE_THIRD_PARTY], [ test "x${enable_third_party}" = "xyes" ])
 AM_CONDITIONAL([HAVE_MRUBY], [test "x${have_mruby}" = "xyes"])
 AM_CONDITIONAL([HAVE_NEVERBLEED], [test "x${have_neverbleed}" = "xyes"])

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -35,8 +35,19 @@ AM_CPPFLAGS = \
 	@LIBEVENT_OPENSSL_CFLAGS@ \
 	@OPENSSL_CFLAGS@ \
 	@DEFS@
-LDADD = $(top_builddir)/lib/libnghttp2.la \
-	$(top_builddir)/third-party/libhttp-parser.la \
+LDADD = $(top_builddir)/lib/libnghttp2.la
+
+if SYSTEM_HTTP_PARSER
+
+LDADD += @HTTP_PARSER_LIBS@
+
+else
+
+LDADD += $(top_builddir)/third-party/libhttp-parser.la
+
+endif
+
+LDADD += \
 	@LIBEVENT_OPENSSL_LIBS@ \
 	@OPENSSL_LIBS@ \
 	@APPLDFLAGS@
@@ -60,8 +71,19 @@ noinst_PROGRAMS += asio-sv asio-sv2 asio-cl asio-cl2
 # one.
 ASIOCPPFLAGS = ${AM_CPPFLAGS} ${BOOST_CPPFLAGS}
 ASIOLDADD = $(top_builddir)/lib/libnghttp2.la \
-	$(top_builddir)/src/libnghttp2_asio.la @JEMALLOC_LIBS@ \
-	$(top_builddir)/third-party/libhttp-parser.la \
+	$(top_builddir)/src/libnghttp2_asio.la @JEMALLOC_LIBS@
+
+if SYSTEM_HTTP_PARSER
+
+LDADD += @HTTP_PARSER_LIBS@
+
+else
+
+LDADD += $(top_builddir)/third-party/libhttp-parser.la
+
+endif
+
+LDADD += \
 	@OPENSSL_LIBS@ \
 	${BOOST_LDFLAGS} \
 	${BOOST_ASIO_LIB} \

--- a/examples/libevent-client.c
+++ b/examples/libevent-client.c
@@ -65,7 +65,11 @@ char *strndup(const char *s, size_t size);
 
 #include <nghttp2/nghttp2.h>
 
+#ifdef SYSTEM_HTTP_PARSER
+#include <http_parser.h>
+#else
 #include "http-parser/http_parser.h"
+#endif
 
 #define ARRLEN(x) (sizeof(x) / sizeof(x[0]))
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -48,8 +48,19 @@ AM_CPPFLAGS = \
 	@ZLIB_CFLAGS@ \
 	@DEFS@
 
-LDADD = $(top_builddir)/lib/libnghttp2.la \
-	$(top_builddir)/third-party/libhttp-parser.la \
+LDADD = $(top_builddir)/lib/libnghttp2.la
+
+if SYSTEM_HTTP_PARSER
+
+LDADD += @HTTP_PARSER_LIBS@
+
+else # SYSTEM_HTTP_PARSER
+
+LDADD += $(top_builddir)/third-party/libhttp-parser.la
+
+endif # SYSTEM_HTTP_PARSER
+
+LDADD += \
 	@JEMALLOC_LIBS@ \
 	@LIBXML2_LIBS@ \
 	@LIBEV_LIBS@ \
@@ -59,6 +70,7 @@ LDADD = $(top_builddir)/lib/libnghttp2.la \
 	@JANSSON_LIBS@ \
 	@ZLIB_LIBS@ \
 	@APPLDFLAGS@
+
 
 if ENABLE_APP
 
@@ -261,9 +273,19 @@ libnghttp2_asio_la_SOURCES = \
 
 libnghttp2_asio_la_CPPFLAGS = ${AM_CPPFLAGS} ${BOOST_CPPFLAGS}
 libnghttp2_asio_la_LDFLAGS = -no-undefined -version-info 1:0:0
-libnghttp2_asio_la_LIBADD = \
-	$(top_builddir)/lib/libnghttp2.la \
-	$(top_builddir)/third-party/libhttp-parser.la \
+libnghttp2_asio_la_LIBADD = $(top_builddir)/lib/libnghttp2.la
+
+if SYSTEM_HTTP_PARSER
+
+libnghttp2_asio_la_LIBADD += @HTTP_PARSER_LIBS@
+
+else # SYSTEM_HTTP_PARSER
+
+libnghttp2_asio_la_LIBADD += $(top_builddir)/third-party/libhttp-parser.la
+
+endif # SYSTEM_HTTP_PARSER
+
+libnghttp2_asio_la_LIBADD += \
 	@OPENSSL_LIBS@ \
 	${BOOST_LDFLAGS} \
 	${BOOST_ASIO_LIB} \

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -48,7 +48,11 @@
 
 #include <openssl/err.h>
 
+#ifdef SYSTEM_HTTP_PARSER
+#include <http_parser.h>
+#else
 #include "http-parser/http_parser.h"
+#endif
 
 #include "h2load_http1_session.h"
 #include "h2load_http2_session.h"

--- a/src/h2load_http1_session.cc
+++ b/src/h2load_http1_session.cc
@@ -34,7 +34,11 @@
 #include <iostream>
 #include <fstream>
 
+#ifdef SYSTEM_HTTP_PARSER
+#include <http_parser.h>
+#else
 #include "http-parser/http_parser.h"
+#endif
 
 using namespace nghttp2;
 

--- a/src/http2.h
+++ b/src/http2.h
@@ -35,7 +35,11 @@
 
 #include <nghttp2/nghttp2.h>
 
+#ifdef SYSTEM_HTTP_PARSER
+#include <http_parser.h>
+#else
 #include "http-parser/http_parser.h"
+#endif
 
 #include "util.h"
 #include "memchunk.h"

--- a/src/http2_test.cc
+++ b/src/http2_test.cc
@@ -30,7 +30,11 @@
 
 #include <CUnit/CUnit.h>
 
+#ifdef SYSTEM_HTTP_PARSER
+#include <http_parser.h>
+#else
 #include "http-parser/http_parser.h"
+#endif
 
 #include "http2.h"
 #include "util.h"

--- a/src/nghttp.h
+++ b/src/nghttp.h
@@ -47,7 +47,11 @@
 
 #include <nghttp2/nghttp2.h>
 
+#ifdef SYSTEM_HTTP_PARSER
+#include <http_parser.h>
+#else
 #include "http-parser/http_parser.h"
+#endif
 
 #include "memchunk.h"
 #include "http2.h"

--- a/src/shrpx_config.cc
+++ b/src/shrpx_config.cc
@@ -51,7 +51,11 @@
 
 #include <nghttp2/nghttp2.h>
 
+#ifdef SYSTEM_HTTP_PARSER
+#include <http_parser.h>
+#else
 #include "http-parser/http_parser.h"
+#endif
 
 #include "shrpx_log.h"
 #include "shrpx_tls.h"

--- a/src/shrpx_downstream.cc
+++ b/src/shrpx_downstream.cc
@@ -26,7 +26,11 @@
 
 #include <cassert>
 
+#ifdef SYSTEM_HTTP_PARSER
+#include <http_parser.h>
+#else
 #include "http-parser/http_parser.h"
+#endif
 
 #include "shrpx_upstream.h"
 #include "shrpx_client_handler.h"

--- a/src/shrpx_http2_downstream_connection.cc
+++ b/src/shrpx_http2_downstream_connection.cc
@@ -28,7 +28,11 @@
 #  include <unistd.h>
 #endif // HAVE_UNISTD_H
 
+#ifdef SYSTEM_HTTP_PARSER
+#include <http_parser.h>
+#else
 #include "http-parser/http_parser.h"
+#endif
 
 #include "shrpx_client_handler.h"
 #include "shrpx_upstream.h"

--- a/src/shrpx_http2_session.h
+++ b/src/shrpx_http2_session.h
@@ -36,7 +36,11 @@
 
 #include <nghttp2/nghttp2.h>
 
+#ifdef SYSTEM_HTTP_PARSER
+#include <http_parser.h>
+#else
 #include "http-parser/http_parser.h"
+#endif
 
 #include "shrpx_connection.h"
 #include "buffer.h"

--- a/src/shrpx_http_downstream_connection.h
+++ b/src/shrpx_http_downstream_connection.h
@@ -27,7 +27,11 @@
 
 #include "shrpx.h"
 
+#ifdef SYSTEM_HTTP_PARSER
+#include <http_parser.h>
+#else
 #include "http-parser/http_parser.h"
+#endif
 
 #include "shrpx_downstream_connection.h"
 #include "shrpx_io_control.h"

--- a/src/shrpx_https_upstream.h
+++ b/src/shrpx_https_upstream.h
@@ -30,7 +30,11 @@
 #include <cinttypes>
 #include <memory>
 
+#ifdef SYSTEM_HTTP_PARSER
+#include <http_parser.h>
+#else
 #include "http-parser/http_parser.h"
+#endif
 
 #include "shrpx_upstream.h"
 #include "memchunk.h"

--- a/src/util.h
+++ b/src/util.h
@@ -47,7 +47,11 @@
 #include <map>
 #include <random>
 
+#ifdef SYSTEM_HTTP_PARSER
+#include <http_parser.h>
+#else
 #include "http-parser/http_parser.h"
+#endif
 
 #include "template.h"
 #include "network.h"


### PR DESCRIPTION
instead of bundled third-party one. The default is still unchanged. If no
use of system http-parser lib is explicitly requested, the bundled copy will
still be used.

This was first reported as Gentoo downstream bug: https://bugs.gentoo.org/675772
which was also the motivation to write this patch as Gentoo has the strict policy to not use bundled libs for security reasons.

I have only changed the autotools bases build environment as Gentoo is using that to build nghttp2 instead of the cmake build system.