### PR TITLE
Ignore Content-Length and Transfer-Encoding in 200 response to CONNECT request

### DIFF
--- a/lib/nghttp2_http.c
+++ b/lib/nghttp2_http.c
@@ -263,10 +263,13 @@ static int http_response_on_header(nghttp2_stream *stream, nghttp2_hd_nv *nv,
       stream->content_length = 0;
       return NGHTTP2_ERR_REMOVE_HTTP_HEADER;
     }
-    if (stream->status_code / 100 == 1 ||
-        (stream->status_code / 100 == 2 &&
-         (stream->http_flags & NGHTTP2_HTTP_FLAG_METH_CONNECT))) {
+    if (stream->status_code / 100 == 1) {
       return NGHTTP2_ERR_HTTP_HEADER;
+    }
+    /* https://tools.ietf.org/html/rfc7230#section-3.3.3 */
+    if (stream->status_code / 100 == 2 &&
+        (stream->http_flags & NGHTTP2_HTTP_FLAG_METH_CONNECT)) {
+      return NGHTTP2_ERR_REMOVE_HTTP_HEADER;
     }
     if (stream->content_length != -1) {
       return NGHTTP2_ERR_HTTP_HEADER;

--- a/src/shrpx_downstream.cc
+++ b/src/shrpx_downstream.cc
@@ -573,6 +573,18 @@ void FieldStore::append_last_trailer_value(const char *data, size_t len) {
                                   trailers_, data, len);
 }
 
+void FieldStore::erase_content_length_and_transfer_encoding() {
+  for (auto &kv : headers_) {
+    switch (kv.token) {
+    case http2::HD_CONTENT_LENGTH:
+    case http2::HD_TRANSFER_ENCODING:
+      kv.name = StringRef{};
+      kv.token = -1;
+      break;
+    }
+  }
+}
+
 void Downstream::set_request_start_time(
     std::chrono::high_resolution_clock::time_point time) {
   request_start_time_ = std::move(time);

--- a/src/shrpx_downstream.h
+++ b/src/shrpx_downstream.h
@@ -119,6 +119,10 @@ public:
 
   bool trailer_key_prev() const { return trailer_key_prev_; }
 
+  // erase_content_length_and_transfer_encoding erases content-length
+  // and transfer-encoding header fields.
+  void erase_content_length_and_transfer_encoding();
+
   // content-length, -1 if it is unknown.
   int64_t content_length;
 

--- a/src/shrpx_http_downstream_connection.cc
+++ b/src/shrpx_http_downstream_connection.cc
@@ -935,18 +935,15 @@ int htp_hdrs_completecb(llhttp_t *htp) {
       return -1;
     }
     if (resp.fs.content_length == 0) {
-      auto cl = resp.fs.header(http2::HD_CONTENT_LENGTH);
-      assert(cl);
-      http2::erase_header(cl);
+      resp.fs.erase_content_length_and_transfer_encoding();
     } else if (resp.fs.content_length != -1) {
       return -1;
     }
   } else if (resp.http_status / 100 == 1 ||
              (resp.http_status / 100 == 2 && req.method == HTTP_CONNECT)) {
-    if (resp.fs.header(http2::HD_CONTENT_LENGTH) ||
-        resp.fs.header(http2::HD_TRANSFER_ENCODING)) {
-      return -1;
-    }
+    // Server MUST NOT send Content-Length and Transfer-Encoding in
+    // these responses.
+    resp.fs.erase_content_length_and_transfer_encoding();
   } else if (resp.fs.parse_content_length() != 0) {
     downstream->set_response_state(DownstreamState::MSG_BAD_HEADER);
     return -1;


### PR DESCRIPTION
Ignore Content-Length and Transfer-Encoding in 200 response to CONNECT request as per RFC 7230.

I found that a well known server sends content-length: 0 in 101 response to HTTP Upgrade.  nghttpx now ignores content-length in this case.
