### PR TITLE
Travis osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,20 @@
 dist: xenial
+os:
+  - linux
+compiler:
+  - clang
+  - gcc
 env:
   matrix:
     - CI_BUILD=cmake
     - CI_BUILD=autotools
+matrix:
+  include:
+    - os: osx
+      compiler: clang
+      osx_image: xcode10.2
+      env: CI_BUILD=autotools
 language: cpp
-compiler:
-  - clang
-  - gcc
 sudo: required
 addons:
   apt:
@@ -30,6 +38,13 @@ addons:
     - libc-ares-dev
     - cmake
     - cmake-data
+  homebrew:
+    packages:
+      - libev
+      - libevent
+      - c-ares
+      - cunit
+      - libressl
 before_install:
   - $CC --version
   - if [ "$CXX" = "g++" ]; then export CXX="g++-8" CC="gcc-8"; fi
@@ -37,13 +52,15 @@ before_install:
   - go version
   - cmake --version
 before_script:
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then CPPFLAGS=-fsanitize=address LDFLAGS="-fsanitize=address -fuse-ld=gold"; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then PKG_CONFIG_PATH=/usr/local/opt/libressl/lib/pkgconfig:/usr/local/opt/libxml2/lib/pkgconfig; fi
   # Now build nghttp2
   - if [ "$CI_BUILD" = "autotools" ]; then autoreconf -i; fi
   - git submodule update --init
-  - if [ "$CI_BUILD" = "autotools" ]; then ./configure --with-mruby; fi
+  - if [ "$CI_BUILD" = "autotools" ]; then ./configure --with-mruby PKG_CONFIG_PATH=$PKG_CONFIG_PATH; fi
   - if [ "$CI_BUILD" = "cmake" ]; then cmake -DENABLE_WERROR=1 -DWITH_MRUBY=1 -DWITH_NEVERBLEED=1; fi
 script:
-  - if [ "$CI_BUILD" = "autotools" ]; then make distcheck DISTCHECK_CONFIGURE_FLAGS="--with-mruby --with-neverbleed --enable-werror CPPFLAGS=-fsanitize=address LDFLAGS=\"-fsanitize=address -fuse-ld=gold\""; fi
+  - if [ "$CI_BUILD" = "autotools" ]; then make distcheck DISTCHECK_CONFIGURE_FLAGS="--with-mruby --with-neverbleed --enable-werror CPPFLAGS=$CPPFLAGS LDFLAGS=\"$LDFLAGS\" PKG_CONFIG_PATH=$PKG_CONFIG_PATH"; fi
   - if [ "$CI_BUILD" = "cmake" ]; then make check; fi
   # As of April, 23, 2016, golang http2 build fails, probably because
   # the default go version is too old.

--- a/configure.ac
+++ b/configure.ac
@@ -899,7 +899,7 @@ AC_MSG_NOTICE([summary of build options:
       Failmalloc:     ${enable_failmalloc}
     Libs:
       OpenSSL:        ${have_openssl} (CFLAGS='${OPENSSL_CFLAGS}' LIBS='${OPENSSL_LIBS}')
-      Libxml2:        ${have_libxml2} (CFLAGS='${LIBXML2_CPPFLAGS}' LIBS='${LIBXML2_LIBS}')
+      Libxml2:        ${have_libxml2} (CFLAGS='${LIBXML2_CFLAGS}' LIBS='${LIBXML2_LIBS}')
       Libev:          ${have_libev} (CFLAGS='${LIBEV_CFLAGS}' LIBS='${LIBEV_LIBS}')
       Libc-ares       ${have_libcares} (CFLAGS='${LIBCARES_CFLAGS}' LIBS='${LIBCARES_LIBS}')
       Libevent(SSL):  ${have_libevent_openssl} (CFLAGS='${LIBEVENT_OPENSSL_CFLAGS}' LIBS='${LIBEVENT_OPENSSL_LIBS}')

--- a/src/nghttpd.cc
+++ b/src/nghttpd.cc
@@ -435,7 +435,7 @@ int main(int argc, char **argv) {
 #ifdef __sgi
     if (daemon(0, 0, 0, 0) == -1) {
 #else
-    if (daemon(0, 0) == -1) {
+    if (util::daemonize(0, 0) == -1) {
 #endif
       perror("daemon");
       exit(EXIT_FAILURE);

--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -1148,7 +1148,7 @@ int call_daemon() {
     return 0;
   }
 #  endif // HAVE_LIBSYSTEMD
-  return daemon(0, 0);
+  return util::daemonize(0, 0);
 #endif   // !__sgi
 }
 } // namespace

--- a/src/util.h
+++ b/src/util.h
@@ -772,6 +772,10 @@ StringRef extract_host(const StringRef &hostport);
 // Returns new std::mt19937 object.
 std::mt19937 make_mt19937();
 
+// daemonize calls daemon(3).  If __APPLE__ is defined, it implements
+// daemon() using fork().
+int daemonize(int nochdir, int noclose);
+
 } // namespace util
 
 } // namespace nghttp2


### PR DESCRIPTION
Enable OSX build on travis to make sure that nghttp2 can be built on it.
I observed that at least xcode 10.2 can compile nghttp2 successfully.
