### PR TITLE
nghttpx: Fix unchanged log level on configuration reload

### DIFF
--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -1559,6 +1559,7 @@ void fill_default_config(Config *config) {
   }
 
   loggingconf.syslog_facility = LOG_DAEMON;
+  loggingconf.severity = NOTICE;
 
   auto &connconf = config->conn;
   {
@@ -3201,6 +3202,7 @@ void reload_config(WorkerProcess *wp) {
   // configuration can be obtained from get_config().
 
   auto old_config = replace_config(std::move(new_config));
+  Log::set_severity_level(get_config()->logging.severity);
 
   auto pid = fork_worker_process(ipc_fd, iaddrs);
 
@@ -3208,6 +3210,7 @@ void reload_config(WorkerProcess *wp) {
     LOG(ERROR) << "Failed to process new configuration";
 
     new_config = replace_config(std::move(old_config));
+    Log::set_severity_level(get_config()->logging.severity);
     close_not_inherited_fd(new_config.get(), iaddrs);
 
     return;

--- a/src/shrpx_config.cc
+++ b/src/shrpx_config.cc
@@ -2682,13 +2682,16 @@ int parse_config(Config *config, int optid, const StringRef &opt,
 
     return 0;
   }
-  case SHRPX_OPTID_LOG_LEVEL:
-    if (Log::set_severity_level_by_name(optarg) == -1) {
+  case SHRPX_OPTID_LOG_LEVEL: {
+    auto level = Log::get_severity_level_by_name(optarg);
+    if (level == -1) {
       LOG(ERROR) << opt << ": Invalid severity level: " << optarg;
       return -1;
     }
+    config->logging.severity = level;
 
     return 0;
+  }
   case SHRPX_OPTID_DAEMON:
     config->daemon = util::strieq_l("yes", optarg);
 

--- a/src/shrpx_config.h
+++ b/src/shrpx_config.h
@@ -808,6 +808,7 @@ struct LoggingConfig {
     bool syslog;
   } error;
   int syslog_facility;
+  int severity;
 };
 
 struct RateLimitConfig {

--- a/src/shrpx_log.cc
+++ b/src/shrpx_log.cc
@@ -116,11 +116,10 @@ int Log::severity_thres_ = NOTICE;
 
 void Log::set_severity_level(int severity) { severity_thres_ = severity; }
 
-int Log::set_severity_level_by_name(const StringRef &name) {
+int Log::get_severity_level_by_name(const StringRef &name) {
   for (size_t i = 0, max = array_size(SEVERITY_STR); i < max; ++i) {
     if (name == SEVERITY_STR[i]) {
-      severity_thres_ = i;
-      return 0;
+      return i;
     }
   }
   return -1;

--- a/src/shrpx_log.h
+++ b/src/shrpx_log.h
@@ -180,7 +180,9 @@ public:
     }
   }
   static void set_severity_level(int severity);
-  static int set_severity_level_by_name(const StringRef &name);
+  // Returns the severity level by |name|.  Returns -1 if |name| is
+  // unknown.
+  static int get_severity_level_by_name(const StringRef &name);
   static bool log_enabled(int severity) { return severity >= severity_thres_; }
 
   enum {


### PR DESCRIPTION
Previously, if log-level is not mentioned in configuration file and
reload happens, the log level was not set to the default value NOTICE.
Instead, the log level stayed the same.  This commit fixes this bug.