### PR TITLE
Add max_concurrent_streams configuration to asio server

### DIFF
--- a/src/asio_server.cc
+++ b/src/asio_server.cc
@@ -45,9 +45,11 @@ namespace asio_http2 {
 namespace server {
 
 server::server(std::size_t io_service_pool_size,
+               uint32_t max_concurrent_streams,
                const boost::posix_time::time_duration &tls_handshake_timeout,
                const boost::posix_time::time_duration &read_timeout)
     : io_service_pool_(io_service_pool_size),
+      max_concurrent_streams(max_concurrent_streams),
       tls_handshake_timeout_(tls_handshake_timeout),
       read_timeout_(read_timeout) {}
 
@@ -130,7 +132,7 @@ void server::start_accept(boost::asio::ssl::context &tls_context,
   }
 
   auto new_connection = std::make_shared<connection<ssl_socket>>(
-      mux, tls_handshake_timeout_, read_timeout_,
+      mux, tls_handshake_timeout_, read_timeout_, max_concurrent_streams_,
       io_service_pool_.get_io_service(), tls_context);
 
   acceptor.async_accept(
@@ -169,7 +171,7 @@ void server::start_accept(tcp::acceptor &acceptor, serve_mux &mux) {
   }
 
   auto new_connection = std::make_shared<connection<tcp::socket>>(
-      mux, tls_handshake_timeout_, read_timeout_,
+      mux, tls_handshake_timeout_, read_timeout_, max_concurrent_streams_,
       io_service_pool_.get_io_service());
 
   acceptor.async_accept(

--- a/src/asio_server.h
+++ b/src/asio_server.h
@@ -64,6 +64,7 @@ using ssl_socket = boost::asio::ssl::stream<tcp::socket>;
 class server : private boost::noncopyable {
 public:
   explicit server(std::size_t io_service_pool_size,
+                  uint32_t max_concurrent_streams,
                   const boost::posix_time::time_duration &tls_handshake_timeout,
                   const boost::posix_time::time_duration &read_timeout);
 
@@ -103,6 +104,8 @@ private:
   std::vector<tcp::acceptor> acceptors_;
 
   std::unique_ptr<boost::asio::ssl::context> ssl_ctx_;
+
+  uint32_t max_concurrent_streams_;
 
   boost::posix_time::time_duration tls_handshake_timeout_;
   boost::posix_time::time_duration read_timeout_;

--- a/src/asio_server_http2.cc
+++ b/src/asio_server_http2.cc
@@ -52,17 +52,22 @@ http2 &http2::operator=(http2 &&other) noexcept {
   return *this;
 }
 
-boost::system::error_code http2::listen_and_serve(boost::system::error_code &ec,
-                                                  const std::string &address,
-                                                  const std::string &port,
-                                                  bool asynchronous) {
-  return impl_->listen_and_serve(ec, nullptr, address, port, asynchronous);
+boost::system::error_code http2::listen_and_serve(
+  boost::system::error_code &ec,
+  const std::string &address,
+  const std::string &port,
+  bool asynchronous,
+  uint32_t max_concurrent_streams) {
+  return impl_->listen_and_serve(ec, nullptr, address, port,
+                                 max_concurrent_streams, asynchronous);
 }
 
 boost::system::error_code http2::listen_and_serve(
     boost::system::error_code &ec, boost::asio::ssl::context &tls_context,
-    const std::string &address, const std::string &port, bool asynchronous) {
-  return impl_->listen_and_serve(ec, &tls_context, address, port, asynchronous);
+    const std::string &address, const std::string &port, bool asynchronous,
+    uint32_t max_concurrent_streams) {
+  return impl_->listen_and_serve(ec, &tls_context, address, port, 
+                                 max_concurrent_streams, asynchronous);
 }
 
 void http2::num_threads(size_t num_threads) { impl_->num_threads(num_threads); }

--- a/src/asio_server_http2_handler.cc
+++ b/src/asio_server_http2_handler.cc
@@ -235,9 +235,11 @@ int on_frame_not_send_callback(nghttp2_session *session,
 } // namespace
 
 http2_handler::http2_handler(boost::asio::io_service &io_service,
+                             uint32_t max_concurrent_streams,
                              boost::asio::ip::tcp::endpoint ep,
                              connection_write writefun, serve_mux &mux)
-    : writefun_(writefun),
+    : max_concurrent_streams_(max_concurrent_streams),
+      writefun_(writefun),
       mux_(mux),
       io_service_(io_service),
       remote_ep_(ep),
@@ -298,7 +300,7 @@ int http2_handler::start() {
     return -1;
   }
 
-  nghttp2_settings_entry ent{NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, 100};
+  nghttp2_settings_entry ent{NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, max_concurrent_streams_};
   nghttp2_submit_settings(session_, NGHTTP2_FLAG_NONE, &ent, 1);
 
   return 0;

--- a/src/asio_server_http2_handler.h
+++ b/src/asio_server_http2_handler.h
@@ -54,6 +54,7 @@ using connection_write = std::function<void(void)>;
 class http2_handler : public std::enable_shared_from_this<http2_handler> {
 public:
   http2_handler(boost::asio::io_service &io_service,
+                uint32_t max_concurrent_streams,
                 boost::asio::ip::tcp::endpoint ep, connection_write writefun,
                 serve_mux &mux);
 
@@ -152,6 +153,7 @@ public:
 
 private:
   std::map<int32_t, std::shared_ptr<stream>> streams_;
+  uint32_t max_concurrent_streams_;
   connection_write writefun_;
   serve_mux &mux_;
   boost::asio::io_service &io_service_;

--- a/src/asio_server_http2_impl.cc
+++ b/src/asio_server_http2_impl.cc
@@ -45,9 +45,11 @@ http2_impl::http2_impl()
 
 boost::system::error_code http2_impl::listen_and_serve(
     boost::system::error_code &ec, boost::asio::ssl::context *tls_context,
-    const std::string &address, const std::string &port, bool asynchronous) {
+    const std::string &address, const std::string &port, 
+    uint32_t max_concurrent_streams, bool asynchronous) {
   server_.reset(
-      new server(num_threads_, tls_handshake_timeout_, read_timeout_));
+      new server(num_threads_, max_concurrent_streams, tls_handshake_timeout_,
+      read_timeout_));
   return server_->listen_and_serve(ec, tls_context, address, port, backlog_,
                                    mux_, asynchronous);
 }

--- a/src/asio_server_http2_impl.h
+++ b/src/asio_server_http2_impl.h
@@ -44,7 +44,8 @@ public:
   http2_impl();
   boost::system::error_code listen_and_serve(
       boost::system::error_code &ec, boost::asio::ssl::context *tls_context,
-      const std::string &address, const std::string &port, bool asynchronous);
+      const std::string &address, const std::string &port,
+      uint32_t max_concurrent_streams, bool asynchronous);
   void num_threads(size_t num_threads);
   void backlog(int backlog);
   void tls_handshake_timeout(const boost::posix_time::time_duration &t);


### PR DESCRIPTION
Enable configuration for max_concurrent_streams parameter to nghttp2::asio_http2, since it is hardcoded to 100.

Done through the nghttp2::asio_http2::server interface, defaults to 100 if not set.