### PR TITLE
asio_client_session_impl.cc: user is not notified about closed session when remote server sent GOAWAY

### DIFF
--- a/src/asio_client_session_impl.cc
+++ b/src/asio_client_session_impl.cc
@@ -710,6 +710,7 @@ void session_impl::do_write() {
 
   if (wblen_ == 0) {
     if (should_stop()) {
+      call_error_cb(make_error_code(static_cast<nghttp2_error>(NGHTTP2_INTERNAL_ERROR)));
       stop();
     }
     return;


### PR DESCRIPTION
This pull-requests is attempting to fix the situating where established session is going to be terminated by remote side by GOAWAY frame and consequent remote connection drop.

asio_client_session then stops the session as connection drop was detected but on_error callback is not fired and user is not notified about closed session.

I'm not sure whether the "fix" is a proper way how to solve this issue, but in my tests it works fine.

Attached you can find tcpdump illustrating the issue (port 8080). There is only one request sent, http2 server responds with 301 (positive answer) code and after 1s it tries to close the idle connection by GOAWAY frame.

Any other attempt to send request out will fail as user is not informed about dropped connection.

[tcpdump.pcap.gz](https://github.com/nghttp2/nghttp2/files/3595146/tcpdump.pcap.gz)




