### PR TITLE
nghttpx: Fix bug that mruby is incorrectly shared between backends

### DIFF
--- a/src/shrpx_downstream.cc
+++ b/src/shrpx_downstream.cc
@@ -193,7 +193,7 @@ Downstream::~Downstream() {
   if (dconn_) {
     const auto &group = dconn_->get_downstream_addr_group();
     if (group) {
-      const auto &mruby_ctx = group->mruby_ctx;
+      const auto &mruby_ctx = group->shared_addr->mruby_ctx;
       mruby_ctx->delete_downstream(this);
     }
   }
@@ -231,7 +231,7 @@ void Downstream::detach_downstream_connection() {
 #ifdef HAVE_MRUBY
   const auto &group = dconn_->get_downstream_addr_group();
   if (group) {
-    const auto &mruby_ctx = group->mruby_ctx;
+    const auto &mruby_ctx = group->shared_addr->mruby_ctx;
     mruby_ctx->delete_downstream(this);
   }
 #endif // HAVE_MRUBY
@@ -256,7 +256,7 @@ std::unique_ptr<DownstreamConnection> Downstream::pop_downstream_connection() {
 
   const auto &group = dconn_->get_downstream_addr_group();
   if (group) {
-    const auto &mruby_ctx = group->mruby_ctx;
+    const auto &mruby_ctx = group->shared_addr->mruby_ctx;
     mruby_ctx->delete_downstream(this);
   }
 #endif // HAVE_MRUBY

--- a/src/shrpx_http2_upstream.cc
+++ b/src/shrpx_http2_upstream.cc
@@ -492,7 +492,7 @@ void Http2Upstream::initiate_downstream(Downstream *downstream) {
 #ifdef HAVE_MRUBY
   const auto &group = dconn_ptr->get_downstream_addr_group();
   if (group) {
-    const auto &mruby_ctx = group->mruby_ctx;
+    const auto &mruby_ctx = group->shared_addr->mruby_ctx;
     if (mruby_ctx->run_on_request_proc(downstream) != 0) {
       if (error_reply(downstream, 500) != 0) {
         rst_stream(downstream, NGHTTP2_INTERNAL_ERROR);
@@ -1665,7 +1665,7 @@ int Http2Upstream::on_downstream_header_complete(Downstream *downstream) {
     auto dconn = downstream->get_downstream_connection();
     const auto &group = dconn->get_downstream_addr_group();
     if (group) {
-      const auto &dmruby_ctx = group->mruby_ctx;
+      const auto &dmruby_ctx = group->shared_addr->mruby_ctx;
 
       if (dmruby_ctx->run_on_response_proc(downstream) != 0) {
         if (error_reply(downstream, 500) != 0) {

--- a/src/shrpx_https_upstream.cc
+++ b/src/shrpx_https_upstream.cc
@@ -481,7 +481,7 @@ int htp_hdrs_completecb(llhttp_t *htp) {
 #ifdef HAVE_MRUBY
   const auto &group = dconn_ptr->get_downstream_addr_group();
   if (group) {
-    const auto &dmruby_ctx = group->mruby_ctx;
+    const auto &dmruby_ctx = group->shared_addr->mruby_ctx;
 
     if (dmruby_ctx->run_on_request_proc(downstream) != 0) {
       resp.http_status = 500;
@@ -1087,7 +1087,7 @@ int HttpsUpstream::on_downstream_header_complete(Downstream *downstream) {
     assert(dconn);
     const auto &group = dconn->get_downstream_addr_group();
     if (group) {
-      const auto &dmruby_ctx = group->mruby_ctx;
+      const auto &dmruby_ctx = group->shared_addr->mruby_ctx;
 
       if (dmruby_ctx->run_on_response_proc(downstream) != 0) {
         error_reply(500);

--- a/src/shrpx_worker.h
+++ b/src/shrpx_worker.h
@@ -206,6 +206,9 @@ struct SharedDownstreamAddr {
   // Bunch of session affinity hash.  Only used if affinity ==
   // SessionAffinity::IP.
   std::vector<AffinityHash> affinity_hash;
+#ifdef HAVE_MRUBY
+  std::shared_ptr<mruby::MRubyContext> mruby_ctx;
+#endif // HAVE_MRUBY
   // Configuration for session affinity
   AffinityConfig affinity;
   // Session affinity
@@ -230,9 +233,6 @@ struct DownstreamAddrGroup {
 
   ImmutableString pattern;
   std::shared_ptr<SharedDownstreamAddr> shared_addr;
-#ifdef HAVE_MRUBY
-  std::shared_ptr<mruby::MRubyContext> mruby_ctx;
-#endif // HAVE_MRUBY
   // true if this group is no longer used for new request.  If this is
   // true, the connection made using one of address in shared_addr
   // must not be pooled.


### PR DESCRIPTION
Previously, mruby context is wrongly shared by multiple patterns if
the underlying SharedDownstreamAddr is shared by multiple
DownstreamAddrGroups.  This commit fixes it.