### PR TITLE
Avoid filename collision of static and dynamic lib

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -62,7 +62,7 @@ if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
   set_target_properties(nghttp2_static PROPERTIES
     COMPILE_FLAGS "${WARNCFLAGS}"
     VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
-    ARCHIVE_OUTPUT_NAME nghttp2
+    ARCHIVE_OUTPUT_NAME nghttp2_static
   )
   target_compile_definitions(nghttp2_static PUBLIC "-DNGHTTP2_STATICLIB")
   if(ENABLE_STATIC_LIB)


### PR DESCRIPTION
Renames the output of the ENABLE_STATIC_LIB library/archive output
to nghttp2_static.lib/.a to avoid filenames colliding with the output
name for ENABLE_SHARED_LIB library/archive, when both are enabled.

This change requires a release notes notice.

Signed-off-by: William A Rowe Jr <wrowe@pivotal.io>
Signed-off-by: Yechiel Kalmenson <ykalmenson@pivotal.io>