### PR TITLE
Correct ssize_t on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,7 +275,11 @@ check_type_size("ssize_t" SIZEOF_SSIZE_T)
 if(SIZEOF_SSIZE_T STREQUAL "")
   # ssize_t is a signed type in POSIX storing at least -1.
   # Set it to "int" to match the behavior of AC_TYPE_SSIZE_T (autotools).
-  set(ssize_t int)
+  if(WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(ssize_t int64_t)
+  else()
+    set(ssize_t int)
+  endif()
 endif()
 # AC_TYPE_UINT8_T
 # AC_TYPE_UINT16_T


### PR DESCRIPTION
There is no standard C type ssize_t. The modern C99 introduces ptrdiff_t
which has an effectively equivilant (but subtly different) definition.

This patch makes ssize_t the equivilant byte-width of size_t on Windows,
using the stdint.h definition.

The remaining issue is that every consumer on Windows must continue to
define (either -Dssize_t=int64_t or -Dssize_t=ptrdiff_t) an override
because ssize_t was resolved in the nghttp2-private config.h. These uses
of ssize_t bleed out to the public API in nghttp2.h, leaving non-POSIX
environments like Windows with an undefined ssize_t type.

The cleanest solution in any later refactoring will be to switch all
external declarations using ssize_t to use the C99-standard ptrdiff_t.

This change requires a release notes notice as it causes an ABI change,
only for those on a 64-bit win32 build environment.

Signed-off-by: William A Rowe Jr wrowe@pivotal.io
Signed-off-by: Yechiel Kalmenson ykalmenson@pivotal.io