### PR TITLE
priority_spec::valid(): remove const qualifier from return value

### DIFF
--- a/src/asio_client_session.cc
+++ b/src/asio_client_session.cc
@@ -154,7 +154,7 @@ const nghttp2_priority_spec *priority_spec::get() const {
   return &spec_;
 }
 
-const bool priority_spec::valid() const { return valid_; }
+bool priority_spec::valid() const { return valid_; }
 
 } // namespace client
 } // namespace asio_http2

--- a/src/includes/nghttp2/asio_http2_client.h
+++ b/src/includes/nghttp2/asio_http2_client.h
@@ -133,7 +133,7 @@ public:
 
   // Indicates whether or not this spec is valid (i.e. was constructed with
   // values).
-  const bool valid() const;
+  bool valid() const;
 
 private:
   nghttp2_priority_spec spec_;


### PR DESCRIPTION
gcc generates warning:
* type qualifiers ignored on function return type [-Wignored-qualifiers]