### PR TITLE
lib/CMakeLists.txt: Make hard-coded static lib suffix optional

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -62,7 +62,7 @@ if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
   set_target_properties(nghttp2_static PROPERTIES
     COMPILE_FLAGS "${WARNCFLAGS}"
     VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
-    ARCHIVE_OUTPUT_NAME nghttp2_static
+    ARCHIVE_OUTPUT_NAME nghttp2${STATIC_LIB_SUFFIX}
   )
   target_compile_definitions(nghttp2_static PUBLIC "-DNGHTTP2_STATICLIB")
   if(ENABLE_STATIC_LIB)


### PR DESCRIPTION
It can be set via the `STATIC_LIB_SUFFIX` variable.

This fixes every existing dependent project that relied on the name
having no suffix and thus capable of using either a static or shared
flavour depending on which one is present on this or how the linker
is configured.

Ref: https://github.com/nghttp2/nghttp2/pull/1394
