### PR TITLE
Fix UBSan errors 

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,16 +2,20 @@
 Language:        Cpp
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlines: Right
 AlignOperands:   true
 AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: false
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
@@ -19,7 +23,8 @@ AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: MultiLine
 BinPackArguments: true
 BinPackParameters: true
-BraceWrapping:   
+BraceWrapping:
+  AfterCaseLabel:  false
   AfterClass:      false
   AfterControlStatement: false
   AfterEnum:       false
@@ -55,12 +60,12 @@ DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
-ForEachMacros:   
+ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
 IncludeBlocks:   Preserve
-IncludeCategories: 
+IncludeCategories:
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2
   - Regex:           '^(<|"(gtest|isl|json)/)'
@@ -96,6 +101,7 @@ ReflowComments:  true
 SortIncludes:    false
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCpp11BracedList: false
@@ -111,7 +117,7 @@ SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard:        Cpp11
-StatementMacros: 
+StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
 TabWidth:        8

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,23 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'nghttp2'
+        dry-run: false
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'nghttp2'
+        fuzz-seconds: 600
+        dry-run: false
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: artifacts
+        path: ./out/artifacts

--- a/doc/sources/contribute.rst
+++ b/doc/sources/contribute.rst
@@ -26,14 +26,14 @@ Coding style
 We use clang-format to format source code consistently.  The
 clang-format configuration file .clang-format is located at the root
 directory.  Since clang-format produces slightly different results
-between versions, we currently use clang-format-8.
+between versions, we currently use clang-format-9.
 
 To detect any violation to the coding style, we recommend to setup git
 pre-commit hook to check coding style of the changes you introduced.
 The pre-commit file is located at the root directory.  Copy it under
 .git/hooks and make sure that it is executable.  The pre-commit script
 uses clang-format-diff.py to detect any style errors.  If it is not in
-your PATH or it exists under different name (e.g., clang-format-diff-8
+your PATH or it exists under different name (e.g., clang-format-diff-9
 in debian), either add it to PATH variable or add git option
 ``clangformatdiff.binary`` to point to the script.
 

--- a/doc/sources/nghttpx-howto.rst
+++ b/doc/sources/nghttpx-howto.rst
@@ -401,6 +401,9 @@ like so:
 
    frontend=*,443;proxyproto
 
+nghttpx supports both PROXY protocol v1 and v2.  AF_UNIX in PROXY
+protocol version 2 is ignored.
+
 Session affinity
 ----------------
 

--- a/doc/sources/tutorial-client.rst
+++ b/doc/sources/tutorial-client.rst
@@ -422,7 +422,7 @@ the ``on_header_callback()`` is called for each name/value pair::
       return 0;
     }
 
-In this tutorial, we just print the name/value pairs on stdout.
+In this tutorial, we just print the name/value pairs on stderr.
 
 After the HEADERS frame has been fully received (and thus all response
 header name/value pairs have been received), the

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -62,7 +62,7 @@ if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
   set_target_properties(nghttp2_static PROPERTIES
     COMPILE_FLAGS "${WARNCFLAGS}"
     VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
-    ARCHIVE_OUTPUT_NAME nghttp2_static
+    ARCHIVE_OUTPUT_NAME nghttp2${STATIC_LIB_SUFFIX}
   )
   target_compile_definitions(nghttp2_static PUBLIC "-DNGHTTP2_STATICLIB")
   if(ENABLE_STATIC_LIB)

--- a/lib/nghttp2_buf.c
+++ b/lib/nghttp2_buf.c
@@ -82,8 +82,10 @@ void nghttp2_buf_reset(nghttp2_buf *buf) {
 }
 
 void nghttp2_buf_wrap_init(nghttp2_buf *buf, uint8_t *begin, size_t len) {
-  buf->begin = buf->pos = buf->last = buf->mark = begin;
-  buf->end = begin + len;
+  buf->begin = buf->pos = buf->last = buf->mark = = buf->end = begin;
+  if (buf->end != NULL) {
+    buf->end += len;
+  }
 }
 
 static int buf_chain_new(nghttp2_buf_chain **chain, size_t chunk_length,

--- a/lib/nghttp2_frame.c
+++ b/lib/nghttp2_frame.c
@@ -819,7 +819,9 @@ int nghttp2_frame_unpack_origin_payload(nghttp2_extension *frame,
 
   origin = frame->payload;
   p = payload;
-  end = p + payloadlen;
+  if (p != NULL) {
+    end = p + payloadlen;
+  }
 
   for (; p != end;) {
     if (end - p < 2) {

--- a/lib/nghttp2_frame.c
+++ b/lib/nghttp2_frame.c
@@ -818,9 +818,9 @@ int nghttp2_frame_unpack_origin_payload(nghttp2_extension *frame,
   size_t len = 0;
 
   origin = frame->payload;
-  p = payload;
-  if (p != NULL) {
-    end = p + payloadlen;
+  p = end = payload;
+  if (end != NULL) {
+    end += payloadlen;
   }
 
   for (; p != end;) {

--- a/lib/nghttp2_session.c
+++ b/lib/nghttp2_session.c
@@ -5349,7 +5349,10 @@ static ssize_t inbound_frame_effective_readlen(nghttp2_inbound_frame *iframe,
 
 ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
                                  size_t inlen) {
-  const uint8_t *first = in, *last = in + inlen;
+  const uint8_t *first = in, *last = in;
+  if (in != NULL) {
+    last += inlen;
+  }
   nghttp2_inbound_frame *iframe = &session->iframe;
   size_t readlen;
   ssize_t padlen;
@@ -6485,7 +6488,9 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
 
       readlen = inbound_frame_payload_readlen(iframe, in, last);
       iframe->payloadleft -= readlen;
-      in += readlen;
+      if (in != NULL) {
+        in += readlen;
+      }
 
       DEBUGF("recv: readlen=%zu, payloadleft=%zu\n", readlen,
              iframe->payloadleft);

--- a/lib/nghttp2_session.c
+++ b/lib/nghttp2_session.c
@@ -4698,12 +4698,7 @@ int nghttp2_session_on_ping_received(nghttp2_session *session,
     rv = nghttp2_session_add_ping(session, NGHTTP2_FLAG_ACK,
                                   frame->ping.opaque_data);
     if (rv != 0) {
-      if (nghttp2_is_fatal(rv)) {
-        return rv;
-      }
-
-      return session_handle_invalid_connection(session, frame,
-                                               NGHTTP2_ERR_INTERNAL, NULL);
+      return rv;
     }
   }
   return session_call_on_frame_received(session, frame);

--- a/lib/nghttp2_session.c
+++ b/lib/nghttp2_session.c
@@ -5350,9 +5350,6 @@ static ssize_t inbound_frame_effective_readlen(nghttp2_inbound_frame *iframe,
 ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
                                  size_t inlen) {
   const uint8_t *first = in, *last = in;
-  if (in != NULL) {
-    last += inlen;
-  }
   nghttp2_inbound_frame *iframe = &session->iframe;
   size_t readlen;
   ssize_t padlen;
@@ -5362,6 +5359,10 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
   nghttp2_stream *stream;
   size_t pri_fieldlen;
   nghttp2_mem *mem;
+  
+  if (in != NULL) {
+    last += inlen;
+  }
 
   DEBUGF("recv: connection recv_window_size=%d, local_window=%d\n",
          session->recv_window_size, session->local_window_size);

--- a/lib/nghttp2_session.c
+++ b/lib/nghttp2_session.c
@@ -4698,7 +4698,12 @@ int nghttp2_session_on_ping_received(nghttp2_session *session,
     rv = nghttp2_session_add_ping(session, NGHTTP2_FLAG_ACK,
                                   frame->ping.opaque_data);
     if (rv != 0) {
-      return rv;
+      if (nghttp2_is_fatal(rv)) {
+        return rv;
+      }
+
+      return session_handle_invalid_connection(session, frame,
+                                               NGHTTP2_ERR_INTERNAL, NULL);
     }
   }
   return session_call_on_frame_received(session, frame);

--- a/lib/nghttp2_session.h
+++ b/lib/nghttp2_session.h
@@ -898,4 +898,36 @@ int nghttp2_session_terminate_session_with_reason(nghttp2_session *session,
                                                   uint32_t error_code,
                                                   const char *reason);
 
+/*
+ * Accumulates received bytes |delta_size| for connection-level flow
+ * control and decides whether to send WINDOW_UPDATE to the
+ * connection.  If NGHTTP2_OPT_NO_AUTO_WINDOW_UPDATE is set,
+ * WINDOW_UPDATE will not be sent.
+ *
+ * This function returns 0 if it succeeds, or one of the following
+ * negative error codes:
+ *
+ * NGHTTP2_ERR_NOMEM
+ *     Out of memory.
+ */
+int nghttp2_session_update_recv_connection_window_size(nghttp2_session *session,
+                                                       size_t delta_size);
+
+/*
+ * Accumulates received bytes |delta_size| for stream-level flow
+ * control and decides whether to send WINDOW_UPDATE to that stream.
+ * If NGHTTP2_OPT_NO_AUTO_WINDOW_UPDATE is set, WINDOW_UPDATE will not
+ * be sent.
+ *
+ * This function returns 0 if it succeeds, or one of the following
+ * negative error codes:
+ *
+ * NGHTTP2_ERR_NOMEM
+ *     Out of memory.
+ */
+int nghttp2_session_update_recv_stream_window_size(nghttp2_session *session,
+                                                   nghttp2_stream *stream,
+                                                   size_t delta_size,
+                                                   int send_window_update);
+
 #endif /* NGHTTP2_SESSION_H */

--- a/lib/nghttp2_submit.c
+++ b/lib/nghttp2_submit.c
@@ -450,6 +450,13 @@ int nghttp2_session_set_local_window_size(nghttp2_session *session,
     if (rv != 0) {
       return rv;
     }
+
+    if (window_size_increment > 0) {
+      return nghttp2_session_add_window_update(session, 0, stream_id,
+                                               window_size_increment);
+    }
+
+    return nghttp2_session_update_recv_connection_window_size(session, 0);
   } else {
     stream = nghttp2_session_get_stream(session, stream_id);
 
@@ -476,11 +483,14 @@ int nghttp2_session_set_local_window_size(nghttp2_session *session,
     if (rv != 0) {
       return rv;
     }
-  }
 
-  if (window_size_increment > 0) {
-    return nghttp2_session_add_window_update(session, 0, stream_id,
-                                             window_size_increment);
+    if (window_size_increment > 0) {
+      return nghttp2_session_add_window_update(session, 0, stream_id,
+                                               window_size_increment);
+    }
+
+    return nghttp2_session_update_recv_stream_window_size(session, stream, 0,
+                                                          1);
   }
 
   return 0;

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -2517,7 +2517,7 @@ int main(int argc, char **argv) {
   shared_nva.emplace_back(":method", config.data_fd == -1 ? "GET" : "POST");
   shared_nva.emplace_back("user-agent", user_agent);
 
-  // list overridalbe headers
+  // list header fields that can be overridden.
   auto override_hdrs = make_array<std::string>(":authority", ":host", ":method",
                                                ":scheme", "user-agent");
 

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -1563,8 +1563,11 @@ void resolve_host() {
   hints.ai_protocol = 0;
   hints.ai_flags = AI_ADDRCONFIG;
 
-  rv = getaddrinfo(config.host.c_str(), util::utos(config.port).c_str(), &hints,
-                   &res);
+  const auto &resolve_host =
+      config.connect_to_host.empty() ? config.host : config.connect_to_host;
+
+  rv = getaddrinfo(resolve_host.c_str(), util::utos(config.port).c_str(),
+                   &hints, &res);
   if (rv != 0) {
     std::cerr << "getaddrinfo() failed: " << gai_strerror(rv) << std::endl;
     exit(EXIT_FAILURE);
@@ -1979,6 +1982,8 @@ Options:
               response  time when  using  one worker  thread, but  may
               appear slightly  out of order with  multiple threads due
               to buffering.  Status code is -1 for failed streams.
+  --connect-to=<HOST>
+              Host to connect instead of using the host in <URI>.
   -v, --verbose
               Output debug information.
   --version   Display version information and exit.
@@ -2037,6 +2042,7 @@ int main(int argc, char **argv) {
         {"encoder-header-table-size", required_argument, &flag, 8},
         {"warm-up-time", required_argument, &flag, 9},
         {"log-file", required_argument, &flag, 10},
+        {"connect-to", required_argument, &flag, 11},
         {nullptr, 0, nullptr, 0}};
     int option_index = 0;
     auto c = getopt_long(argc, argv,
@@ -2263,6 +2269,10 @@ int main(int argc, char **argv) {
       case 10:
         // --log-file
         logfile = optarg;
+        break;
+      case 11:
+        // --connect-to
+        config.connect_to_host = optarg;
         break;
       }
       break;

--- a/src/h2load.h
+++ b/src/h2load.h
@@ -69,6 +69,7 @@ struct Config {
   nghttp2::Headers custom_headers;
   std::string scheme;
   std::string host;
+  std::string connect_to_host;
   std::string ifile;
   std::string ciphers;
   // length of upload data

--- a/src/h2load.h
+++ b/src/h2load.h
@@ -102,6 +102,7 @@ struct Config {
   int log_fd;
   uint16_t port;
   uint16_t default_port;
+  uint16_t connect_to_port;
   bool verbose;
   bool timing_script;
   std::string base_uri;

--- a/src/shrpx-unittest.cc
+++ b/src/shrpx-unittest.cc
@@ -195,6 +195,8 @@ int main(int argc, char *argv[]) {
       !CU_add_test(pSuite, "util_decode_hex", shrpx::test_util_decode_hex) ||
       !CU_add_test(pSuite, "util_extract_host",
                    shrpx::test_util_extract_host) ||
+      !CU_add_test(pSuite, "util_split_hostport",
+                   shrpx::test_util_split_hostport) ||
       !CU_add_test(pSuite, "gzip_inflate", test_nghttp2_gzip_inflate) ||
       !CU_add_test(pSuite, "buffer_write", nghttp2::test_buffer_write) ||
       !CU_add_test(pSuite, "pool_recycle", nghttp2::test_pool_recycle) ||

--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -1914,7 +1914,7 @@ Connections:
               default.  Any  requests which come through  this address
               are replied with 200 HTTP status, without no body.
 
-              To  accept   PROXY  protocol   version  1   on  frontend
+              To accept  PROXY protocol  version 1  and 2  on frontend
               connection,  specify  "proxyproto" parameter.   This  is
               disabled by default.
 

--- a/src/shrpx_client_handler.h
+++ b/src/shrpx_client_handler.h
@@ -77,6 +77,7 @@ public:
   int upstream_write();
 
   int proxy_protocol_read();
+  int proxy_protocol_v2_read();
   int on_proxy_protocol_finish();
 
   // Performs I/O operation.  Internally calls on_read()/on_write().

--- a/src/shrpx_tls.cc
+++ b/src/shrpx_tls.cc
@@ -2030,17 +2030,6 @@ StringRef get_x509_issuer_name(BlockAllocator &balloc, X509 *x) {
 #endif /* !WORDS_BIGENDIAN */
 
 StringRef get_x509_serial(BlockAllocator &balloc, X509 *x) {
-#if OPENSSL_1_1_API && !defined(OPENSSL_IS_BORINGSSL)
-  auto sn = X509_get0_serialNumber(x);
-  uint64_t r;
-  if (ASN1_INTEGER_get_uint64(&r, sn) != 1) {
-    return StringRef{};
-  }
-
-  r = bswap64(r);
-  return util::format_hex(
-      balloc, StringRef{reinterpret_cast<uint8_t *>(&r), sizeof(r)});
-#else  // !OPENSSL_1_1_API || OPENSSL_IS_BORINGSSL
   auto sn = X509_get_serialNumber(x);
   auto bn = BN_new();
   auto bn_d = defer(BN_free, bn);
@@ -2052,8 +2041,7 @@ StringRef get_x509_serial(BlockAllocator &balloc, X509 *x) {
   auto n = BN_bn2bin(bn, b.data());
   assert(n <= 20);
 
-  return util::format_hex(balloc, StringRef{std::begin(b), std::end(b)});
-#endif // !OPENSSL_1_1_API
+  return util::format_hex(balloc, StringRef{b.data(), static_cast<size_t>(n)});
 }
 
 namespace {

--- a/src/util.cc
+++ b/src/util.cc
@@ -1537,6 +1537,41 @@ StringRef extract_host(const StringRef &hostport) {
   return StringRef{std::begin(hostport), p};
 }
 
+std::pair<StringRef, StringRef> split_hostport(const StringRef &hostport) {
+  if (hostport.empty()) {
+    return {};
+  }
+  if (hostport[0] == '[') {
+    // assume this is IPv6 numeric address
+    auto p = std::find(std::begin(hostport), std::end(hostport), ']');
+    if (p == std::end(hostport)) {
+      return {};
+    }
+    if (p + 1 == std::end(hostport)) {
+      return {StringRef{std::begin(hostport) + 1, p}, {}};
+    }
+    if (*(p + 1) != ':' || p + 2 == std::end(hostport)) {
+      return {};
+    }
+    return {StringRef{std::begin(hostport) + 1, p},
+            StringRef{p + 2, std::end(hostport)}};
+  }
+
+  auto p = std::find(std::begin(hostport), std::end(hostport), ':');
+  if (p == std::begin(hostport)) {
+    return {};
+  }
+  if (p == std::end(hostport)) {
+    return {StringRef{std::begin(hostport), p}, {}};
+  }
+  if (p + 1 == std::end(hostport)) {
+    return {};
+  }
+
+  return {StringRef{std::begin(hostport), p},
+          StringRef{p + 1, std::end(hostport)}};
+}
+
 std::mt19937 make_mt19937() {
   std::random_device rd;
   return std::mt19937(rd());

--- a/src/util.h
+++ b/src/util.h
@@ -769,6 +769,13 @@ int sha1(uint8_t *buf, const StringRef &s);
 // NULL-terminated.
 StringRef extract_host(const StringRef &hostport);
 
+// split_hostport splits host and port in |hostport|.  Unlike
+// extract_host, square brackets enclosing host name is stripped.  If
+// port is not available, it returns empty string in the second
+// string.  The returned string might not be NULL-terminated.  On any
+// error, it returns a pair which has empty strings.
+std::pair<StringRef, StringRef> split_hostport(const StringRef &hostport);
+
 // Returns new std::mt19937 object.
 std::mt19937 make_mt19937();
 

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -628,4 +628,28 @@ void test_util_extract_host(void) {
   CU_ASSERT(util::extract_host(StringRef{}).empty());
 }
 
+void test_util_split_hostport(void) {
+  CU_ASSERT(std::make_pair(StringRef::from_lit("foo"), StringRef{}) ==
+            util::split_hostport(StringRef::from_lit("foo")));
+  CU_ASSERT(
+      std::make_pair(StringRef::from_lit("foo"), StringRef::from_lit("80")) ==
+      util::split_hostport(StringRef::from_lit("foo:80")));
+  CU_ASSERT(
+      std::make_pair(StringRef::from_lit("::1"), StringRef::from_lit("80")) ==
+      util::split_hostport(StringRef::from_lit("[::1]:80")));
+  CU_ASSERT(std::make_pair(StringRef::from_lit("::1"), StringRef{}) ==
+            util::split_hostport(StringRef::from_lit("[::1]")));
+
+  CU_ASSERT(std::make_pair(StringRef{}, StringRef{}) ==
+            util::split_hostport(StringRef{}));
+  CU_ASSERT(std::make_pair(StringRef{}, StringRef{}) ==
+            util::split_hostport(StringRef::from_lit("[::1]:")));
+  CU_ASSERT(std::make_pair(StringRef{}, StringRef{}) ==
+            util::split_hostport(StringRef::from_lit("foo:")));
+  CU_ASSERT(std::make_pair(StringRef{}, StringRef{}) ==
+            util::split_hostport(StringRef::from_lit("[::1:")));
+  CU_ASSERT(std::make_pair(StringRef{}, StringRef{}) ==
+            util::split_hostport(StringRef::from_lit("[::1]80")));
+}
+
 } // namespace shrpx

--- a/src/util_test.h
+++ b/src/util_test.h
@@ -67,6 +67,7 @@ void test_util_format_hex(void);
 void test_util_is_hex_string(void);
 void test_util_decode_hex(void);
 void test_util_extract_host(void);
+void test_util_split_hostport(void);
 
 } // namespace shrpx
 

--- a/tests/main.c
+++ b/tests/main.c
@@ -307,6 +307,8 @@ int main() {
       !CU_add_test(pSuite, "session_flooding", test_nghttp2_session_flooding) ||
       !CU_add_test(pSuite, "session_change_stream_priority",
                    test_nghttp2_session_change_stream_priority) ||
+      !CU_add_test(pSuite, "session_create_idle_stream",
+                   test_nghttp2_session_create_idle_stream) ||
       !CU_add_test(pSuite, "session_repeated_priority_change",
                    test_nghttp2_session_repeated_priority_change) ||
       !CU_add_test(pSuite, "session_repeated_priority_submission",

--- a/tests/nghttp2_session_test.c
+++ b/tests/nghttp2_session_test.c
@@ -10141,7 +10141,7 @@ void test_nghttp2_session_create_idle_stream(void) {
 
   /* If pri_spec->stream_id does not exist, and it is idle stream, it
      is created too */
-  nghttp2_priority_spec_init(&pri_spec, 8, 109, 0);
+  nghttp2_priority_spec_init(&pri_spec, 10, 109, 0);
 
   rv = nghttp2_session_create_idle_stream(session, 8, &pri_spec);
 
@@ -10174,7 +10174,7 @@ void test_nghttp2_session_create_idle_stream(void) {
   CU_ASSERT(NGHTTP2_ERR_INVALID_ARGUMENT == rv);
 
   /* It is an error to create non-idle stream */
-  session->next_stream_id = 20;
+  session->last_sent_stream_id = 20;
   pri_spec.stream_id = 2;
 
   rv = nghttp2_session_create_idle_stream(session, 18, &pri_spec);

--- a/third-party/llhttp/README.md
+++ b/third-party/llhttp/README.md
@@ -14,6 +14,8 @@ This project aims to:
 * Verifiable
 * Improving benchmarks where possible
 
+More details in [Fedor Indutny's talk at JSConf EU 2019](https://youtu.be/x3k_5Mi66sY)
+
 ## How?
 
 Over time, different approaches for improving [http_parser][0]'s code base
@@ -30,11 +32,10 @@ So far llhttp outperforms http_parser:
 
 |                 | input size |  bandwidth   |  reqs/sec  |   time  |
 |:----------------|-----------:|-------------:|-----------:|--------:|
-| **llhttp** _(C)_ | 8192.00 mb | 1497.88 mb/s | 3020458.87 ops/sec | 5.47 s |
-| **llhttp** _(bitcode)_ | 8192.00 mb | 1131.75 mb/s | 2282171.24 ops/sec | 7.24 s |
+| **llhttp** _(C)_ | 8192.00 mb | 1777.24 mb/s | 3583799.39 ops/sec | 4.61 s |
 | **http_parser** | 8192.00 mb | 694.66 mb/s | 1406180.33 req/sec | 11.79 s |
 
-llhttp is faster by approximately **116%**.
+llhttp is faster by approximately **156%**.
 
 ## Maintenance
 
@@ -76,8 +77,6 @@ settings.on_message_complete = handle_on_message_complete;
  * input.
  */
 llhttp_init(&parser, HTTP_BOTH, &settings);
-
-/* Use `llhttp_set_type(&parser, HTTP_REQUEST);` to override the mode */
 
 /* Parse request! */
 const char* request = "GET / HTTP/1.1\r\n\r\n";

--- a/third-party/llhttp/include/llhttp.h
+++ b/third-party/llhttp/include/llhttp.h
@@ -1,9 +1,9 @@
 #ifndef INCLUDE_LLHTTP_H_
 #define INCLUDE_LLHTTP_H_
 
-#define LLHTTP_VERSION_MAJOR 1
-#define LLHTTP_VERSION_MINOR 1
-#define LLHTTP_VERSION_PATCH 3
+#define LLHTTP_VERSION_MAJOR 2
+#define LLHTTP_VERSION_MINOR 0
+#define LLHTTP_VERSION_PATCH 4
 
 #ifndef INCLUDE_LLHTTP_ITSELF_H_
 #define INCLUDE_LLHTTP_ITSELF_H_
@@ -29,7 +29,7 @@ struct llhttp__internal_s {
   uint8_t http_major;
   uint8_t http_minor;
   uint8_t header_state;
-  uint8_t flags;
+  uint16_t flags;
   uint8_t upgrade;
   uint16_t status_code;
   uint8_t finish;
@@ -66,14 +66,15 @@ enum llhttp_errno {
   HPE_INVALID_CHUNK_SIZE = 12,
   HPE_INVALID_STATUS = 13,
   HPE_INVALID_EOF_STATE = 14,
-  HPE_CB_MESSAGE_BEGIN = 15,
-  HPE_CB_HEADERS_COMPLETE = 16,
-  HPE_CB_MESSAGE_COMPLETE = 17,
-  HPE_CB_CHUNK_HEADER = 18,
-  HPE_CB_CHUNK_COMPLETE = 19,
-  HPE_PAUSED = 20,
-  HPE_PAUSED_UPGRADE = 21,
-  HPE_USER = 22
+  HPE_INVALID_TRANSFER_ENCODING = 15,
+  HPE_CB_MESSAGE_BEGIN = 16,
+  HPE_CB_HEADERS_COMPLETE = 17,
+  HPE_CB_MESSAGE_COMPLETE = 18,
+  HPE_CB_CHUNK_HEADER = 19,
+  HPE_CB_CHUNK_COMPLETE = 20,
+  HPE_PAUSED = 21,
+  HPE_PAUSED_UPGRADE = 22,
+  HPE_USER = 23
 };
 typedef enum llhttp_errno llhttp_errno_t;
 
@@ -85,7 +86,9 @@ enum llhttp_flags {
   F_UPGRADE = 0x10,
   F_CONTENT_LENGTH = 0x20,
   F_SKIPBODY = 0x40,
-  F_TRAILING = 0x80
+  F_TRAILING = 0x80,
+  F_LENIENT = 0x100,
+  F_TRANSFER_ENCODING = 0x200
 };
 typedef enum llhttp_flags llhttp_flags_t;
 
@@ -157,14 +160,15 @@ typedef enum llhttp_method llhttp_method_t;
   XX(12, INVALID_CHUNK_SIZE, INVALID_CHUNK_SIZE) \
   XX(13, INVALID_STATUS, INVALID_STATUS) \
   XX(14, INVALID_EOF_STATE, INVALID_EOF_STATE) \
-  XX(15, CB_MESSAGE_BEGIN, CB_MESSAGE_BEGIN) \
-  XX(16, CB_HEADERS_COMPLETE, CB_HEADERS_COMPLETE) \
-  XX(17, CB_MESSAGE_COMPLETE, CB_MESSAGE_COMPLETE) \
-  XX(18, CB_CHUNK_HEADER, CB_CHUNK_HEADER) \
-  XX(19, CB_CHUNK_COMPLETE, CB_CHUNK_COMPLETE) \
-  XX(20, PAUSED, PAUSED) \
-  XX(21, PAUSED_UPGRADE, PAUSED_UPGRADE) \
-  XX(22, USER, USER) \
+  XX(15, INVALID_TRANSFER_ENCODING, INVALID_TRANSFER_ENCODING) \
+  XX(16, CB_MESSAGE_BEGIN, CB_MESSAGE_BEGIN) \
+  XX(17, CB_HEADERS_COMPLETE, CB_HEADERS_COMPLETE) \
+  XX(18, CB_MESSAGE_COMPLETE, CB_MESSAGE_COMPLETE) \
+  XX(19, CB_CHUNK_HEADER, CB_CHUNK_HEADER) \
+  XX(20, CB_CHUNK_COMPLETE, CB_CHUNK_COMPLETE) \
+  XX(21, PAUSED, PAUSED) \
+  XX(22, PAUSED_UPGRADE, PAUSED_UPGRADE) \
+  XX(23, USER, USER) \
 
 
 #define HTTP_METHOD_MAP(XX) \
@@ -297,7 +301,7 @@ llhttp_errno_t llhttp_finish(llhttp_t* parser);
 int llhttp_message_needs_eof(const llhttp_t* parser);
 
 /* Returns `1` if there might be any other messages following the last that was
- * successfuly parsed.
+ * successfully parsed.
  */
 int llhttp_should_keep_alive(const llhttp_t* parser);
 
@@ -352,6 +356,18 @@ const char* llhttp_errno_name(llhttp_errno_t err);
 
 /* Returns textual name of HTTP method */
 const char* llhttp_method_name(llhttp_method_t method);
+
+
+/* Enables/disables lenient header value parsing (disabled by default).
+ *
+ * Lenient parsing disables header value token checks, extending llhttp's
+ * protocol support to highly non-compliant clients/server. No
+ * `HPE_INVALID_HEADER_TOKEN` will be raised for incorrect header values when
+ * lenient parsing is "on".
+ *
+ * **(USE AT YOUR OWN RISK)**
+ */
+void llhttp_set_lenient(llhttp_t* parser, int enabled);
 
 #ifdef __cplusplus
 }  /* extern "C" */

--- a/third-party/llhttp/src/api.c
+++ b/third-party/llhttp/src/api.c
@@ -127,6 +127,15 @@ const char* llhttp_method_name(llhttp_method_t method) {
 }
 
 
+void llhttp_set_lenient(llhttp_t* parser, int enabled) {
+  if (enabled) {
+    parser->flags |= F_LENIENT;
+  } else {
+    parser->flags &= ~F_LENIENT;
+  }
+}
+
+
 /* Callbacks */
 
 

--- a/third-party/llhttp/src/http.c
+++ b/third-party/llhttp/src/http.c
@@ -32,6 +32,7 @@ int llhttp__before_headers_complete(llhttp_t* parser, const char* p,
  * 2 - chunk_size_start
  * 3 - body_identity
  * 4 - body_identity_eof
+ * 5 - invalid transfer-encoding for request
  */
 int llhttp__after_headers_complete(llhttp_t* parser, const char* p,
                                    const char* endp) {
@@ -47,8 +48,29 @@ int llhttp__after_headers_complete(llhttp_t* parser, const char* p,
   if (parser->flags & F_SKIPBODY) {
     return 0;
   } else if (parser->flags & F_CHUNKED) {
-    /* chunked encoding - ignore Content-Length header */
+    /* chunked encoding - ignore Content-Length header, prepare for a chunk */
     return 2;
+  } else if (parser->flags & F_TRANSFER_ENCODING) {
+    if (parser->type == HTTP_REQUEST && (parser->flags & F_LENIENT) == 0) {
+      /* RFC 7230 3.3.3 */
+
+      /* If a Transfer-Encoding header field
+       * is present in a request and the chunked transfer coding is not
+       * the final encoding, the message body length cannot be determined
+       * reliably; the server MUST respond with the 400 (Bad Request)
+       * status code and then close the connection.
+       */
+      return 5;
+    } else {
+      /* RFC 7230 3.3.3 */
+
+      /* If a Transfer-Encoding header field is present in a response and
+       * the chunked transfer coding is not the final encoding, the
+       * message body length is determined by reading the connection until
+       * it is closed by the server.
+       */
+      return 4;
+    }
   } else {
     if (!(parser->flags & F_CONTENT_LENGTH)) {
       if (!llhttp_message_needs_eof(parser)) {
@@ -74,8 +96,10 @@ int llhttp__after_message_complete(llhttp_t* parser, const char* p,
   int should_keep_alive;
 
   should_keep_alive = llhttp_should_keep_alive(parser);
-  parser->flags = 0;
   parser->finish = HTTP_FINISH_SAFE;
+
+  /* Keep `F_LENIENT` flag between messages, but reset every other flag */
+  parser->flags &= F_LENIENT;
 
   /* NOTE: this is ignored in loose parsing mode */
   return should_keep_alive;
@@ -93,6 +117,12 @@ int llhttp_message_needs_eof(const llhttp_t* parser) {
       parser->status_code == 304 ||     /* Not Modified */
       (parser->flags & F_SKIPBODY)) {     /* response to a HEAD request */
     return 0;
+  }
+
+  /* RFC 7230 3.3.3, see `llhttp__after_headers_complete` */
+  if ((parser->flags & F_TRANSFER_ENCODING) &&
+      (parser->flags & F_CHUNKED) == 0) {
+    return 1;
   }
 
   if (parser->flags & (F_CHUNKED | F_CONTENT_LENGTH)) {

--- a/third-party/llhttp/src/llhttp.c
+++ b/third-party/llhttp/src/llhttp.c
@@ -2,6 +2,20 @@
 #include <stdint.h>
 #include <string.h>
 
+#ifdef __SSE4_2__
+ #ifdef _MSC_VER
+  #include <nmmintrin.h>
+ #else  /* !_MSC_VER */
+  #include <x86intrin.h>
+ #endif  /* _MSC_VER */
+#endif  /* __SSE4_2__ */
+
+#ifdef _MSC_VER
+ #define ALIGN(n) _declspec(align(n))
+#else  /* !_MSC_VER */
+ #define ALIGN(n) __attribute__((aligned(n)))
+#endif  /* _MSC_VER */
+
 #include "llhttp.h"
 
 typedef int (*llhttp__internal__span_cb)(
@@ -10,147 +24,171 @@ typedef int (*llhttp__internal__span_cb)(
 static const unsigned char llparse_blob0[] = {
   'C', 'L'
 };
-static const unsigned char llparse_blob1[] = {
+#ifdef __SSE4_2__
+static const unsigned char ALIGN(16) llparse_blob1[] = {
+  0x9, 0x9, 0xc, 0xc, '!', '"', '$', '>', '@', '~', 0x80,
+  0xff, 0x0, 0x0, 0x0, 0x0
+};
+#endif  /* __SSE4_2__ */
+static const unsigned char llparse_blob2[] = {
   'o', 'n'
 };
-static const unsigned char llparse_blob2[] = {
+static const unsigned char llparse_blob3[] = {
   'e', 'c', 't', 'i', 'o', 'n'
 };
-static const unsigned char llparse_blob3[] = {
+static const unsigned char llparse_blob4[] = {
   'l', 'o', 's', 'e'
 };
-static const unsigned char llparse_blob4[] = {
+static const unsigned char llparse_blob5[] = {
   'e', 'e', 'p', '-', 'a', 'l', 'i', 'v', 'e'
 };
-static const unsigned char llparse_blob5[] = {
+static const unsigned char llparse_blob6[] = {
   'p', 'g', 'r', 'a', 'd', 'e'
 };
-static const unsigned char llparse_blob6[] = {
-  'h', 'u', 'n', 'k', 'e', 'd'
+#ifdef __SSE4_2__
+static const unsigned char ALIGN(16) llparse_blob7[] = {
+  0x9, 0x9, ' ', '~', 0x80, 0xfe, 0x0, 0x0, 0x0, 0x0, 0x0,
+  0x0, 0x0, 0x0, 0x0, 0x0
 };
-static const unsigned char llparse_blob7[] = {
+#endif  /* __SSE4_2__ */
+static const unsigned char llparse_blob8[] = {
+  'c', 'h', 'u', 'n', 'k', 'e', 'd'
+};
+#ifdef __SSE4_2__
+static const unsigned char ALIGN(16) llparse_blob9[] = {
+  ' ', '!', '#', '\'', '*', '+', '-', '.', '0', '9', 'A',
+  'Z', '^', 'z', '|', '|'
+};
+#endif  /* __SSE4_2__ */
+#ifdef __SSE4_2__
+static const unsigned char ALIGN(16) llparse_blob10[] = {
+  '~', '~', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+  0x0, 0x0, 0x0, 0x0, 0x0
+};
+#endif  /* __SSE4_2__ */
+static const unsigned char llparse_blob11[] = {
   'e', 'n', 't', '-', 'l', 'e', 'n', 'g', 't', 'h'
 };
-static const unsigned char llparse_blob8[] = {
+static const unsigned char llparse_blob12[] = {
   'r', 'o', 'x', 'y', '-', 'c', 'o', 'n', 'n', 'e', 'c',
   't', 'i', 'o', 'n'
 };
-static const unsigned char llparse_blob9[] = {
+static const unsigned char llparse_blob13[] = {
   'r', 'a', 'n', 's', 'f', 'e', 'r', '-', 'e', 'n', 'c',
   'o', 'd', 'i', 'n', 'g'
 };
-static const unsigned char llparse_blob10[] = {
+static const unsigned char llparse_blob14[] = {
   'p', 'g', 'r', 'a', 'd', 'e'
 };
-static const unsigned char llparse_blob11[] = {
+static const unsigned char llparse_blob15[] = {
   0xd, 0xa
 };
-static const unsigned char llparse_blob12[] = {
+static const unsigned char llparse_blob16[] = {
   'T', 'T', 'P', '/'
 };
-static const unsigned char llparse_blob13[] = {
+static const unsigned char llparse_blob17[] = {
   'C', 'E', '/'
 };
-static const unsigned char llparse_blob14[] = {
-  'I', 'N', 'D'
-};
-static const unsigned char llparse_blob15[] = {
-  'E', 'C', 'K', 'O', 'U', 'T'
-};
-static const unsigned char llparse_blob16[] = {
-  'N', 'E', 'C', 'T'
-};
-static const unsigned char llparse_blob17[] = {
-  'E', 'L', 'E', 'T', 'E'
-};
 static const unsigned char llparse_blob18[] = {
-  'E', 'T'
+  'I', 'N', 'D'
 };
 static const unsigned char llparse_blob19[] = {
-  'E', 'A', 'D'
+  'E', 'C', 'K', 'O', 'U', 'T'
 };
 static const unsigned char llparse_blob20[] = {
-  'N', 'K'
+  'N', 'E', 'C', 'T'
 };
 static const unsigned char llparse_blob21[] = {
-  'C', 'K'
+  'E', 'L', 'E', 'T', 'E'
 };
 static const unsigned char llparse_blob22[] = {
-  'S', 'E', 'A', 'R', 'C', 'H'
+  'E', 'T'
 };
 static const unsigned char llparse_blob23[] = {
-  'R', 'G', 'E'
+  'E', 'A', 'D'
 };
 static const unsigned char llparse_blob24[] = {
-  'C', 'T', 'I', 'V', 'I', 'T', 'Y'
-};
-static const unsigned char llparse_blob25[] = {
-  'L', 'E', 'N', 'D', 'A', 'R'
-};
-static const unsigned char llparse_blob26[] = {
-  'V', 'E'
-};
-static const unsigned char llparse_blob27[] = {
-  'O', 'T', 'I', 'F', 'Y'
-};
-static const unsigned char llparse_blob28[] = {
-  'P', 'T', 'I', 'O', 'N', 'S'
-};
-static const unsigned char llparse_blob29[] = {
-  'T', 'C', 'H'
-};
-static const unsigned char llparse_blob30[] = {
-  'S', 'T'
-};
-static const unsigned char llparse_blob31[] = {
-  'O', 'P'
-};
-static const unsigned char llparse_blob32[] = {
-  'I', 'N', 'D'
-};
-static const unsigned char llparse_blob33[] = {
-  'A', 'T', 'C', 'H'
-};
-static const unsigned char llparse_blob34[] = {
-  'G', 'E'
-};
-static const unsigned char llparse_blob35[] = {
-  'I', 'N', 'D'
-};
-static const unsigned char llparse_blob36[] = {
-  'O', 'R', 'T'
-};
-static const unsigned char llparse_blob37[] = {
-  'A', 'R', 'C', 'H'
-};
-static const unsigned char llparse_blob38[] = {
-  'U', 'R', 'C', 'E'
-};
-static const unsigned char llparse_blob39[] = {
-  'B', 'S', 'C', 'R', 'I', 'B', 'E'
-};
-static const unsigned char llparse_blob40[] = {
-  'R', 'A', 'C', 'E'
-};
-static const unsigned char llparse_blob41[] = {
-  'I', 'N', 'D'
-};
-static const unsigned char llparse_blob42[] = {
   'N', 'K'
 };
-static const unsigned char llparse_blob43[] = {
+static const unsigned char llparse_blob25[] = {
   'C', 'K'
 };
+static const unsigned char llparse_blob26[] = {
+  'S', 'E', 'A', 'R', 'C', 'H'
+};
+static const unsigned char llparse_blob27[] = {
+  'R', 'G', 'E'
+};
+static const unsigned char llparse_blob28[] = {
+  'C', 'T', 'I', 'V', 'I', 'T', 'Y'
+};
+static const unsigned char llparse_blob29[] = {
+  'L', 'E', 'N', 'D', 'A', 'R'
+};
+static const unsigned char llparse_blob30[] = {
+  'V', 'E'
+};
+static const unsigned char llparse_blob31[] = {
+  'O', 'T', 'I', 'F', 'Y'
+};
+static const unsigned char llparse_blob32[] = {
+  'P', 'T', 'I', 'O', 'N', 'S'
+};
+static const unsigned char llparse_blob33[] = {
+  'T', 'C', 'H'
+};
+static const unsigned char llparse_blob34[] = {
+  'S', 'T'
+};
+static const unsigned char llparse_blob35[] = {
+  'O', 'P'
+};
+static const unsigned char llparse_blob36[] = {
+  'I', 'N', 'D'
+};
+static const unsigned char llparse_blob37[] = {
+  'A', 'T', 'C', 'H'
+};
+static const unsigned char llparse_blob38[] = {
+  'G', 'E'
+};
+static const unsigned char llparse_blob39[] = {
+  'I', 'N', 'D'
+};
+static const unsigned char llparse_blob40[] = {
+  'O', 'R', 'T'
+};
+static const unsigned char llparse_blob41[] = {
+  'A', 'R', 'C', 'H'
+};
+static const unsigned char llparse_blob42[] = {
+  'U', 'R', 'C', 'E'
+};
+static const unsigned char llparse_blob43[] = {
+  'B', 'S', 'C', 'R', 'I', 'B', 'E'
+};
 static const unsigned char llparse_blob44[] = {
-  'U', 'B', 'S', 'C', 'R', 'I', 'B', 'E'
+  'R', 'A', 'C', 'E'
 };
 static const unsigned char llparse_blob45[] = {
-  'H', 'T', 'T', 'P', '/'
+  'I', 'N', 'D'
 };
 static const unsigned char llparse_blob46[] = {
-  'A', 'D'
+  'N', 'K'
 };
 static const unsigned char llparse_blob47[] = {
+  'C', 'K'
+};
+static const unsigned char llparse_blob48[] = {
+  'U', 'B', 'S', 'C', 'R', 'I', 'B', 'E'
+};
+static const unsigned char llparse_blob49[] = {
+  'H', 'T', 'T', 'P', '/'
+};
+static const unsigned char llparse_blob50[] = {
+  'A', 'D'
+};
+static const unsigned char llparse_blob51[] = {
   'T', 'P', '/'
 };
 
@@ -259,6 +297,7 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_header_value_discard_ws_almost_done,
   s_n_llhttp__internal__n_header_value_lws,
   s_n_llhttp__internal__n_header_value_almost_done,
+  s_n_llhttp__internal__n_header_value_lenient,
   s_n_llhttp__internal__n_header_value_otherwise,
   s_n_llhttp__internal__n_header_value_connection_token,
   s_n_llhttp__internal__n_header_value_connection_ws,
@@ -266,13 +305,15 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_header_value_connection_2,
   s_n_llhttp__internal__n_header_value_connection_3,
   s_n_llhttp__internal__n_header_value_connection,
-  s_n_llhttp__internal__n_error_15,
+  s_n_llhttp__internal__n_error_18,
   s_n_llhttp__internal__n_header_value,
   s_n_llhttp__internal__n_header_value_discard_rws,
-  s_n_llhttp__internal__n_error_16,
+  s_n_llhttp__internal__n_error_19,
   s_n_llhttp__internal__n_header_value_content_length_ws,
   s_n_llhttp__internal__n_header_value_content_length,
-  s_n_llhttp__internal__n_header_value_te_chunked_1,
+  s_n_llhttp__internal__n_header_value_te_chunked_last,
+  s_n_llhttp__internal__n_header_value_te_token_ows,
+  s_n_llhttp__internal__n_header_value_te_token,
   s_n_llhttp__internal__n_header_value_te_chunked,
   s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1,
   s_n_llhttp__internal__n_header_value_discard_ws,
@@ -487,7 +528,29 @@ int llhttp__after_message_complete(
     llhttp__internal_t* s, const unsigned char* p,
     const unsigned char* endp);
 
+int llhttp__internal__c_update_finish_1(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->finish = 0;
+  return 0;
+}
+
 int llhttp__internal__c_test_flags_1(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->flags & 544) == 544;
+}
+
+int llhttp__internal__c_test_flags_2(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->flags & 256) == 256;
+}
+
+int llhttp__internal__c_test_flags_3(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
@@ -559,7 +622,7 @@ int llhttp__internal__c_or_flags(
   return 0;
 }
 
-int llhttp__internal__c_update_finish_1(
+int llhttp__internal__c_update_finish_2(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
@@ -671,7 +734,7 @@ int llhttp__internal__c_update_header_state_6(
   return 0;
 }
 
-int llhttp__internal__c_test_flags_2(
+int llhttp__internal__c_test_flags_5(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
@@ -712,6 +775,14 @@ int llhttp__internal__c_or_flags_15(
   return 0;
 }
 
+int llhttp__internal__c_or_flags_16(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  state->flags |= 512;
+  return 0;
+}
+
 int llhttp__internal__c_update_header_state_8(
     llhttp__internal_t* state,
     const unsigned char* p,
@@ -720,7 +791,7 @@ int llhttp__internal__c_update_header_state_8(
   return 0;
 }
 
-int llhttp__internal__c_or_flags_16(
+int llhttp__internal__c_or_flags_17(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
@@ -824,14 +895,14 @@ static llparse_state_t llhttp__internal__run(
     s_n_llhttp__internal__n_invoke_llhttp__after_message_complete: {
       switch (llhttp__after_message_complete(state, p, endp)) {
         default:
-          goto s_n_llhttp__internal__n_start;
+          goto s_n_llhttp__internal__n_invoke_update_finish_1;
       }
       /* UNREACHABLE */;
       abort();
     }
     case s_n_llhttp__internal__n_pause_1:
     s_n_llhttp__internal__n_pause_1: {
-      state->error = 0x15;
+      state->error = 0x16;
       state->reason = "Pause on CONNECT/Upgrade";
       state->error_pos = (const char*) p;
       state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__after_message_complete;
@@ -855,7 +926,7 @@ static llparse_state_t llhttp__internal__run(
       switch (llhttp__on_message_complete(state, p, endp)) {
         case 0:
           goto s_n_llhttp__internal__n_invoke_is_equal_upgrade;
-        case 20:
+        case 21:
           goto s_n_llhttp__internal__n_pause_5;
         default:
           goto s_n_llhttp__internal__n_error_9;
@@ -1277,7 +1348,7 @@ static llparse_state_t llhttp__internal__run(
       }
       state->_span_pos0 = (void*) p;
       state->_span_cb0 = llhttp__on_body;
-      goto s_n_llhttp__internal__n_invoke_update_finish_1;
+      goto s_n_llhttp__internal__n_eof;
       /* UNREACHABLE */;
       abort();
     }
@@ -1291,7 +1362,9 @@ static llparse_state_t llhttp__internal__run(
         case 3:
           goto s_n_llhttp__internal__n_span_start_llhttp__on_body_1;
         case 4:
-          goto s_n_llhttp__internal__n_span_start_llhttp__on_body_2;
+          goto s_n_llhttp__internal__n_invoke_update_finish_2;
+        case 5:
+          goto s_n_llhttp__internal__n_error_10;
         default:
           goto s_n_llhttp__internal__n_invoke_llhttp__on_message_complete;
       }
@@ -1363,7 +1436,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_invoke_load_header_state_2;
+          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
         }
       }
       /* UNREACHABLE */;
@@ -1380,7 +1453,27 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_header_value_lws;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_12;
+          goto s_n_llhttp__internal__n_error_15;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_value_lenient:
+    s_n_llhttp__internal__n_header_value_lenient: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_value_lenient;
+      }
+      switch (*p) {
+        case 10: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1;
+        }
+        case 13: {
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3;
+        }
+        default: {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_lenient;
         }
       }
       /* UNREACHABLE */;
@@ -1399,7 +1492,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_13;
+          goto s_n_llhttp__internal__n_invoke_test_flags_4;
         }
       }
       /* UNREACHABLE */;
@@ -1462,7 +1555,7 @@ static llparse_state_t llhttp__internal__run(
         }
         case ',': {
           p++;
-          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
+          goto s_n_llhttp__internal__n_invoke_load_header_state_4;
         }
         default: {
           goto s_n_llhttp__internal__n_invoke_update_header_state_4;
@@ -1478,7 +1571,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_value_connection_1;
       }
-      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob3, 4);
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob4, 4);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -1502,7 +1595,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_value_connection_2;
       }
-      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob4, 9);
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob5, 9);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -1526,7 +1619,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_value_connection_3;
       }
-      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob5, 6);
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob6, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -1576,8 +1669,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_15:
-    s_n_llhttp__internal__n_error_15: {
+    case s_n_llhttp__internal__n_error_18:
+    s_n_llhttp__internal__n_error_18: {
       state->error = 0xb;
       state->reason = "Content-Length overflow";
       state->error_pos = (const char*) p;
@@ -1609,6 +1702,30 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_value;
       }
+      #ifdef __SSE4_2__
+      if (endp - p >= 16) {
+        __m128i ranges;
+        __m128i input;
+        int avail;
+        int match_len;
+      
+        /* Load input */
+        input = _mm_loadu_si128((__m128i const*) p);
+        ranges = _mm_loadu_si128((__m128i const*) llparse_blob7);
+      
+        /* Find first character that does not match `ranges` */
+        match_len = _mm_cmpestri(ranges, 6,
+            input, 16,
+            _SIDD_UBYTE_OPS | _SIDD_CMP_RANGES |
+              _SIDD_NEGATIVE_POLARITY);
+      
+        if (match_len != 0) {
+          p += match_len;
+          goto s_n_llhttp__internal__n_header_value;
+        }
+        goto s_n_llhttp__internal__n_header_value_otherwise;
+      }
+      #endif  /* __SSE4_2__ */
       switch (lookup_table[(uint8_t) *p]) {
         case 1: {
           p++;
@@ -1644,8 +1761,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_16:
-    s_n_llhttp__internal__n_error_16: {
+    case s_n_llhttp__internal__n_error_19:
+    s_n_llhttp__internal__n_error_19: {
       state->error = 0xb;
       state->reason = "Invalid character in Content-Length";
       state->error_pos = (const char*) p;
@@ -1671,7 +1788,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_header_value_content_length_ws;
         }
         default: {
-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4;
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5;
         }
       }
       /* UNREACHABLE */;
@@ -1740,24 +1857,83 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_header_value_te_chunked_1:
-    s_n_llhttp__internal__n_header_value_te_chunked_1: {
-      llparse_match_t match_seq;
-      
+    case s_n_llhttp__internal__n_header_value_te_chunked_last:
+    s_n_llhttp__internal__n_header_value_te_chunked_last: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_header_value_te_chunked_1;
+        return s_n_llhttp__internal__n_header_value_te_chunked_last;
       }
-      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob6, 6);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
+      switch (*p) {
+        case 10: {
           goto s_n_llhttp__internal__n_invoke_update_header_state_8;
         }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_header_value_te_chunked_1;
+        case 13: {
+          goto s_n_llhttp__internal__n_invoke_update_header_state_8;
         }
-        case kMatchMismatch: {
+        case ' ': {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_te_chunked_last;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_header_value_te_chunked;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_value_te_token_ows:
+    s_n_llhttp__internal__n_header_value_te_token_ows: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_value_te_token_ows;
+      }
+      switch (*p) {
+        case 9: {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_te_token_ows;
+        }
+        case ' ': {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_te_token_ows;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_header_value_te_chunked;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_header_value_te_token:
+    s_n_llhttp__internal__n_header_value_te_token: {
+      static uint8_t lookup_table[] = {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0
+      };
+      if (p == endp) {
+        return s_n_llhttp__internal__n_header_value_te_token;
+      }
+      switch (lookup_table[(uint8_t) *p]) {
+        case 1: {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_te_token;
+        }
+        case 2: {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_te_token_ows;
+        }
+        default: {
           goto s_n_llhttp__internal__n_invoke_update_header_state_7;
         }
       }
@@ -1766,25 +1942,23 @@ static llparse_state_t llhttp__internal__run(
     }
     case s_n_llhttp__internal__n_header_value_te_chunked:
     s_n_llhttp__internal__n_header_value_te_chunked: {
+      llparse_match_t match_seq;
+      
       if (p == endp) {
         return s_n_llhttp__internal__n_header_value_te_chunked;
       }
-      switch (((*p) | 0x20)) {
-        case 10: {
-          goto s_n_llhttp__internal__n_header_value_discard_rws;
-        }
-        case 13: {
-          goto s_n_llhttp__internal__n_header_value_discard_rws;
-        }
-        case ' ': {
-          goto s_n_llhttp__internal__n_header_value_discard_rws;
-        }
-        case 'c': {
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob8, 7);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
           p++;
-          goto s_n_llhttp__internal__n_header_value_te_chunked_1;
+          goto s_n_llhttp__internal__n_header_value_te_chunked_last;
         }
-        default: {
-          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_header_value_te_chunked;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_header_value_te_token;
         }
       }
       /* UNREACHABLE */;
@@ -1797,7 +1971,7 @@ static llparse_state_t llhttp__internal__run(
       }
       state->_span_pos0 = (void*) p;
       state->_span_cb0 = llhttp__on_header_value;
-      goto s_n_llhttp__internal__n_invoke_load_header_state_1;
+      goto s_n_llhttp__internal__n_invoke_load_header_state_2;
       /* UNREACHABLE */;
       abort();
     }
@@ -1840,7 +2014,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_17;
+          goto s_n_llhttp__internal__n_error_20;
         }
       }
       /* UNREACHABLE */;
@@ -1869,6 +2043,42 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_general;
       }
+      #ifdef __SSE4_2__
+      if (endp - p >= 16) {
+        __m128i ranges;
+        __m128i input;
+        int avail;
+        int match_len;
+      
+        /* Load input */
+        input = _mm_loadu_si128((__m128i const*) p);
+        ranges = _mm_loadu_si128((__m128i const*) llparse_blob9);
+      
+        /* Find first character that does not match `ranges` */
+        match_len = _mm_cmpestri(ranges, 16,
+            input, 16,
+            _SIDD_UBYTE_OPS | _SIDD_CMP_RANGES |
+              _SIDD_NEGATIVE_POLARITY);
+      
+        if (match_len != 0) {
+          p += match_len;
+          goto s_n_llhttp__internal__n_header_field_general;
+        }
+        ranges = _mm_loadu_si128((__m128i const*) llparse_blob10);
+      
+        /* Find first character that does not match `ranges` */
+        match_len = _mm_cmpestri(ranges, 2,
+            input, 16,
+            _SIDD_UBYTE_OPS | _SIDD_CMP_RANGES |
+              _SIDD_NEGATIVE_POLARITY);
+      
+        if (match_len != 0) {
+          p += match_len;
+          goto s_n_llhttp__internal__n_header_field_general;
+        }
+        goto s_n_llhttp__internal__n_header_field_general_otherwise;
+      }
+      #endif  /* __SSE4_2__ */
       switch (lookup_table[(uint8_t) *p]) {
         case 1: {
           p++;
@@ -1908,7 +2118,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_3;
       }
-      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob2, 6);
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob3, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -1933,7 +2143,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_4;
       }
-      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob7, 10);
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob11, 10);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -1979,7 +2189,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_1;
       }
-      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob1, 2);
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob2, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2003,7 +2213,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_5;
       }
-      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob8, 15);
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob12, 15);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2028,7 +2238,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_6;
       }
-      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob9, 16);
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob13, 16);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2053,7 +2263,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_7;
       }
-      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob10, 6);
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob14, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2148,7 +2358,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_url_skip_lf_to_http09;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob11, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob15, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2159,7 +2369,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_url_skip_lf_to_http09;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_18;
+          goto s_n_llhttp__internal__n_error_21;
         }
       }
       /* UNREACHABLE */;
@@ -2176,7 +2386,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_header_field_start;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_19;
+          goto s_n_llhttp__internal__n_error_22;
         }
       }
       /* UNREACHABLE */;
@@ -2197,7 +2407,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_http_end_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_19;
+          goto s_n_llhttp__internal__n_error_22;
         }
       }
       /* UNREACHABLE */;
@@ -2260,7 +2470,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_http_minor;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_20;
+          goto s_n_llhttp__internal__n_error_23;
         }
       }
       /* UNREACHABLE */;
@@ -2277,7 +2487,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_http_minor;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_21;
+          goto s_n_llhttp__internal__n_error_24;
         }
       }
       /* UNREACHABLE */;
@@ -2340,7 +2550,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_http_major;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_22;
+          goto s_n_llhttp__internal__n_error_25;
         }
       }
       /* UNREACHABLE */;
@@ -2353,7 +2563,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_req_http_start_1;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob12, 4);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob16, 4);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2364,7 +2574,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_req_http_start_1;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_24;
+          goto s_n_llhttp__internal__n_error_27;
         }
       }
       /* UNREACHABLE */;
@@ -2377,7 +2587,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_req_http_start_2;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob13, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob17, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2388,7 +2598,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_req_http_start_2;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_24;
+          goto s_n_llhttp__internal__n_error_27;
         }
       }
       /* UNREACHABLE */;
@@ -2413,7 +2623,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_http_start_2;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_24;
+          goto s_n_llhttp__internal__n_error_27;
         }
       }
       /* UNREACHABLE */;
@@ -2467,7 +2677,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_span_end_llhttp__on_url_8;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_25;
+          goto s_n_llhttp__internal__n_error_28;
         }
       }
       /* UNREACHABLE */;
@@ -2524,7 +2734,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_span_end_stub_query_3;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_26;
+          goto s_n_llhttp__internal__n_error_29;
         }
       }
       /* UNREACHABLE */;
@@ -2554,7 +2764,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_query;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_27;
+          goto s_n_llhttp__internal__n_error_30;
         }
       }
       /* UNREACHABLE */;
@@ -2583,6 +2793,30 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_url_path;
       }
+      #ifdef __SSE4_2__
+      if (endp - p >= 16) {
+        __m128i ranges;
+        __m128i input;
+        int avail;
+        int match_len;
+      
+        /* Load input */
+        input = _mm_loadu_si128((__m128i const*) p);
+        ranges = _mm_loadu_si128((__m128i const*) llparse_blob1);
+      
+        /* Find first character that does not match `ranges` */
+        match_len = _mm_cmpestri(ranges, 12,
+            input, 16,
+            _SIDD_UBYTE_OPS | _SIDD_CMP_RANGES |
+              _SIDD_NEGATIVE_POLARITY);
+      
+        if (match_len != 0) {
+          p += match_len;
+          goto s_n_llhttp__internal__n_url_path;
+        }
+        goto s_n_llhttp__internal__n_url_query_or_fragment;
+      }
+      #endif  /* __SSE4_2__ */
       switch (lookup_table[(uint8_t) *p]) {
         case 1: {
           p++;
@@ -2671,10 +2905,10 @@ static llparse_state_t llhttp__internal__run(
         }
         case 7: {
           p++;
-          goto s_n_llhttp__internal__n_error_28;
+          goto s_n_llhttp__internal__n_error_31;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_29;
+          goto s_n_llhttp__internal__n_error_32;
         }
       }
       /* UNREACHABLE */;
@@ -2729,7 +2963,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_server_with_at;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_30;
+          goto s_n_llhttp__internal__n_error_33;
         }
       }
       /* UNREACHABLE */;
@@ -2746,7 +2980,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_server;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_32;
+          goto s_n_llhttp__internal__n_error_35;
         }
       }
       /* UNREACHABLE */;
@@ -2760,22 +2994,22 @@ static llparse_state_t llhttp__internal__run(
       switch (*p) {
         case 10: {
           p++;
-          goto s_n_llhttp__internal__n_error_31;
+          goto s_n_llhttp__internal__n_error_34;
         }
         case 13: {
           p++;
-          goto s_n_llhttp__internal__n_error_31;
+          goto s_n_llhttp__internal__n_error_34;
         }
         case ' ': {
           p++;
-          goto s_n_llhttp__internal__n_error_31;
+          goto s_n_llhttp__internal__n_error_34;
         }
         case '/': {
           p++;
           goto s_n_llhttp__internal__n_url_schema_delim_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_32;
+          goto s_n_llhttp__internal__n_error_35;
         }
       }
       /* UNREACHABLE */;
@@ -2817,7 +3051,7 @@ static llparse_state_t llhttp__internal__run(
       switch (lookup_table[(uint8_t) *p]) {
         case 1: {
           p++;
-          goto s_n_llhttp__internal__n_error_31;
+          goto s_n_llhttp__internal__n_error_34;
         }
         case 2: {
           goto s_n_llhttp__internal__n_span_end_stub_schema;
@@ -2827,7 +3061,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_schema;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_33;
+          goto s_n_llhttp__internal__n_error_36;
         }
       }
       /* UNREACHABLE */;
@@ -2859,7 +3093,7 @@ static llparse_state_t llhttp__internal__run(
       switch (lookup_table[(uint8_t) *p]) {
         case 1: {
           p++;
-          goto s_n_llhttp__internal__n_error_31;
+          goto s_n_llhttp__internal__n_error_34;
         }
         case 2: {
           goto s_n_llhttp__internal__n_span_start_stub_path_2;
@@ -2868,7 +3102,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_schema;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_34;
+          goto s_n_llhttp__internal__n_error_37;
         }
       }
       /* UNREACHABLE */;
@@ -2924,7 +3158,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_spaces_before_url;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_35;
+          goto s_n_llhttp__internal__n_error_38;
         }
       }
       /* UNREACHABLE */;
@@ -2949,7 +3183,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_1;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -2962,7 +3196,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_2;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob14, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob18, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2974,7 +3208,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_2;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -2987,7 +3221,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_4;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob15, 6);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob19, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2999,7 +3233,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_4;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3012,7 +3246,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_6;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob16, 4);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob20, 4);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3024,7 +3258,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_6;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3042,7 +3276,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3063,7 +3297,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_start_req_7;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3084,7 +3318,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_start_req_5;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3097,7 +3331,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_8;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob17, 5);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob21, 5);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3109,7 +3343,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_8;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3122,7 +3356,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_9;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob18, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob22, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3134,7 +3368,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_9;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3147,7 +3381,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_10;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob19, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob23, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3159,7 +3393,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_10;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3172,7 +3406,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_12;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob20, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob24, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3184,7 +3418,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_12;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3197,7 +3431,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_13;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob21, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob25, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3209,7 +3443,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_13;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3230,7 +3464,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_start_req_13;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3243,7 +3477,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_15;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob22, 6);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob26, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3255,7 +3489,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_15;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3268,7 +3502,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_16;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob23, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob27, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3280,7 +3514,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_16;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3293,7 +3527,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_18;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob24, 7);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob28, 7);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3305,7 +3539,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_18;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3318,7 +3552,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_20;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob25, 6);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob29, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3330,7 +3564,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_20;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3348,7 +3582,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3369,7 +3603,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_start_req_21;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3390,7 +3624,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_start_req_19;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3403,7 +3637,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_22;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob26, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob30, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3415,7 +3649,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_22;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3444,7 +3678,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_start_req_22;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3457,7 +3691,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_23;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob27, 5);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob31, 5);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3469,7 +3703,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_23;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3482,7 +3716,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_24;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob28, 6);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob32, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3494,7 +3728,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_24;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3507,7 +3741,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_26;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob29, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob33, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3519,7 +3753,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_26;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3532,7 +3766,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_27;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob30, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob34, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3544,7 +3778,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_27;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3557,7 +3791,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_30;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob32, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob36, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3569,7 +3803,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_30;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3582,7 +3816,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_31;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob33, 4);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob37, 4);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3594,7 +3828,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_31;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3615,7 +3849,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_start_req_31;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3628,7 +3862,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_28;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob31, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob35, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3639,7 +3873,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_28;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3652,7 +3886,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_33;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob34, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob38, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3664,7 +3898,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_33;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3686,7 +3920,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3715,7 +3949,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_start_req_32;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3728,7 +3962,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_36;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob35, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob39, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3740,7 +3974,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_36;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3753,7 +3987,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_37;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob36, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob40, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3765,7 +3999,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_37;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3786,7 +4020,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_start_req_37;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3803,7 +4037,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_start_req_35;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3816,7 +4050,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_39;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob37, 4);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob41, 4);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3828,7 +4062,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_39;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3841,7 +4075,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_40;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob38, 4);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob42, 4);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3853,7 +4087,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_40;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3866,7 +4100,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_41;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob39, 7);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob43, 7);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3878,7 +4112,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_41;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3903,7 +4137,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_start_req_41;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3916,7 +4150,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_42;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob40, 4);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob44, 4);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3928,7 +4162,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_42;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3941,7 +4175,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_45;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob41, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob45, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3953,7 +4187,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_45;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3966,7 +4200,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_47;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob42, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob46, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -3978,7 +4212,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_47;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -3991,7 +4225,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_48;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob43, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob47, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4003,7 +4237,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_48;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -4024,7 +4258,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_start_req_48;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -4037,7 +4271,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_49;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob44, 8);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob48, 8);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4049,7 +4283,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_req_49;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -4074,7 +4308,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_start_req_49;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -4091,7 +4325,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_start_req_44;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -4164,7 +4398,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_start_req_43;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -4249,7 +4483,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_res_status_start;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_37;
+          goto s_n_llhttp__internal__n_error_40;
         }
       }
       /* UNREACHABLE */;
@@ -4329,7 +4563,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_update_status_code;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_38;
+          goto s_n_llhttp__internal__n_error_41;
         }
       }
       /* UNREACHABLE */;
@@ -4392,7 +4626,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_39;
+          goto s_n_llhttp__internal__n_error_42;
         }
       }
       /* UNREACHABLE */;
@@ -4409,7 +4643,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_res_http_minor;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_40;
+          goto s_n_llhttp__internal__n_error_43;
         }
       }
       /* UNREACHABLE */;
@@ -4472,7 +4706,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_http_major_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_41;
+          goto s_n_llhttp__internal__n_error_44;
         }
       }
       /* UNREACHABLE */;
@@ -4485,7 +4719,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_res;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob45, 5);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob49, 5);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4496,7 +4730,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_res;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_44;
+          goto s_n_llhttp__internal__n_error_47;
         }
       }
       /* UNREACHABLE */;
@@ -4509,7 +4743,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_req_or_res_method_2;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob46, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob50, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4521,7 +4755,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_req_or_res_method_2;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_42;
+          goto s_n_llhttp__internal__n_error_45;
         }
       }
       /* UNREACHABLE */;
@@ -4534,7 +4768,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_req_or_res_method_3;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob47, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob51, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4545,7 +4779,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_req_or_res_method_3;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_42;
+          goto s_n_llhttp__internal__n_error_45;
         }
       }
       /* UNREACHABLE */;
@@ -4566,7 +4800,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_or_res_method_3;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_42;
+          goto s_n_llhttp__internal__n_error_45;
         }
       }
       /* UNREACHABLE */;
@@ -4583,7 +4817,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_or_res_method_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_42;
+          goto s_n_llhttp__internal__n_error_45;
         }
       }
       /* UNREACHABLE */;
@@ -4643,7 +4877,7 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */
       abort();
   }
-  s_n_llhttp__internal__n_error_31: {
+  s_n_llhttp__internal__n_error_34: {
     state->error = 0x7;
     state->reason = "Invalid characters in url";
     state->error_pos = (const char*) p;
@@ -4652,8 +4886,16 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
+  s_n_llhttp__internal__n_invoke_update_finish_1: {
+    switch (llhttp__internal__c_update_finish_1(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_start;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
   s_n_llhttp__internal__n_pause_5: {
-    state->error = 0x14;
+    state->error = 0x15;
     state->reason = "on_message_complete pause";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_is_equal_upgrade;
@@ -4662,7 +4904,7 @@ static llparse_state_t llhttp__internal__run(
     abort();
   }
   s_n_llhttp__internal__n_error_9: {
-    state->error = 0x11;
+    state->error = 0x12;
     state->reason = "`on_message_complete` callback error";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
@@ -4671,7 +4913,7 @@ static llparse_state_t llhttp__internal__run(
     abort();
   }
   s_n_llhttp__internal__n_pause_7: {
-    state->error = 0x14;
+    state->error = 0x15;
     state->reason = "on_chunk_complete pause";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2;
@@ -4679,8 +4921,8 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_11: {
-    state->error = 0x13;
+  s_n_llhttp__internal__n_error_13: {
+    state->error = 0x14;
     state->reason = "`on_chunk_complete` callback error";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
@@ -4692,15 +4934,24 @@ static llparse_state_t llhttp__internal__run(
     switch (llhttp__on_chunk_complete(state, p, endp)) {
       case 0:
         goto s_n_llhttp__internal__n_invoke_llhttp__on_message_complete_2;
-      case 20:
+      case 21:
         goto s_n_llhttp__internal__n_pause_7;
       default:
-        goto s_n_llhttp__internal__n_error_11;
+        goto s_n_llhttp__internal__n_error_13;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_10: {
+  s_n_llhttp__internal__n_error_11: {
+    state->error = 0x4;
+    state->reason = "Content-Length can't be present with Transfer-Encoding";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_12: {
     state->error = 0x4;
     state->reason = "Content-Length can't be present with chunked encoding";
     state->error_pos = (const char*) p;
@@ -4710,7 +4961,7 @@ static llparse_state_t llhttp__internal__run(
     abort();
   }
   s_n_llhttp__internal__n_pause_2: {
-    state->error = 0x14;
+    state->error = 0x15;
     state->reason = "on_message_complete pause";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_pause_1;
@@ -4719,7 +4970,7 @@ static llparse_state_t llhttp__internal__run(
     abort();
   }
   s_n_llhttp__internal__n_error_3: {
-    state->error = 0x11;
+    state->error = 0x12;
     state->reason = "`on_message_complete` callback error";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
@@ -4731,7 +4982,7 @@ static llparse_state_t llhttp__internal__run(
     switch (llhttp__on_message_complete(state, p, endp)) {
       case 0:
         goto s_n_llhttp__internal__n_pause_1;
-      case 20:
+      case 21:
         goto s_n_llhttp__internal__n_pause_2;
       default:
         goto s_n_llhttp__internal__n_error_3;
@@ -4749,7 +5000,7 @@ static llparse_state_t llhttp__internal__run(
     abort();
   }
   s_n_llhttp__internal__n_pause_3: {
-    state->error = 0x14;
+    state->error = 0x15;
     state->reason = "on_chunk_complete pause";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_update_content_length;
@@ -4758,7 +5009,7 @@ static llparse_state_t llhttp__internal__run(
     abort();
   }
   s_n_llhttp__internal__n_error_5: {
-    state->error = 0x13;
+    state->error = 0x14;
     state->reason = "`on_chunk_complete` callback error";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
@@ -4770,7 +5021,7 @@ static llparse_state_t llhttp__internal__run(
     switch (llhttp__on_chunk_complete(state, p, endp)) {
       case 0:
         goto s_n_llhttp__internal__n_invoke_update_content_length;
-      case 20:
+      case 21:
         goto s_n_llhttp__internal__n_pause_3;
       default:
         goto s_n_llhttp__internal__n_error_5;
@@ -4804,7 +5055,7 @@ static llparse_state_t llhttp__internal__run(
     abort();
   }
   s_n_llhttp__internal__n_pause_4: {
-    state->error = 0x14;
+    state->error = 0x15;
     state->reason = "on_chunk_header pause";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_is_equal_content_length;
@@ -4813,7 +5064,7 @@ static llparse_state_t llhttp__internal__run(
     abort();
   }
   s_n_llhttp__internal__n_error_4: {
-    state->error = 0x12;
+    state->error = 0x13;
     state->reason = "`on_chunk_header` callback error";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
@@ -4825,7 +5076,7 @@ static llparse_state_t llhttp__internal__run(
     switch (llhttp__on_chunk_header(state, p, endp)) {
       case 0:
         goto s_n_llhttp__internal__n_invoke_is_equal_content_length;
-      case 20:
+      case 21:
         goto s_n_llhttp__internal__n_pause_4;
       default:
         goto s_n_llhttp__internal__n_error_4;
@@ -4878,16 +5129,25 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_update_finish_1: {
-    switch (llhttp__internal__c_update_finish_1(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_update_finish_2: {
+    switch (llhttp__internal__c_update_finish_2(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_eof;
+        goto s_n_llhttp__internal__n_span_start_llhttp__on_body_2;
     }
     /* UNREACHABLE */;
     abort();
   }
+  s_n_llhttp__internal__n_error_10: {
+    state->error = 0xf;
+    state->reason = "Request has invalid `Transfer-Encoding`";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
   s_n_llhttp__internal__n_pause: {
-    state->error = 0x14;
+    state->error = 0x15;
     state->reason = "on_message_complete pause";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__after_message_complete;
@@ -4896,7 +5156,7 @@ static llparse_state_t llhttp__internal__run(
     abort();
   }
   s_n_llhttp__internal__n_error_2: {
-    state->error = 0x11;
+    state->error = 0x12;
     state->reason = "`on_message_complete` callback error";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
@@ -4908,7 +5168,7 @@ static llparse_state_t llhttp__internal__run(
     switch (llhttp__on_message_complete(state, p, endp)) {
       case 0:
         goto s_n_llhttp__internal__n_invoke_llhttp__after_message_complete;
-      case 20:
+      case 21:
         goto s_n_llhttp__internal__n_pause;
       default:
         goto s_n_llhttp__internal__n_error_2;
@@ -4941,7 +5201,7 @@ static llparse_state_t llhttp__internal__run(
     abort();
   }
   s_n_llhttp__internal__n_pause_6: {
-    state->error = 0x14;
+    state->error = 0x15;
     state->reason = "Paused by on_headers_complete";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete;
@@ -4950,7 +5210,7 @@ static llparse_state_t llhttp__internal__run(
     abort();
   }
   s_n_llhttp__internal__n_error_1: {
-    state->error = 0x10;
+    state->error = 0x11;
     state->reason = "User callback error";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
@@ -4966,7 +5226,7 @@ static llparse_state_t llhttp__internal__run(
         goto s_n_llhttp__internal__n_invoke_or_flags_1;
       case 2:
         goto s_n_llhttp__internal__n_invoke_update_upgrade;
-      case 20:
+      case 21:
         goto s_n_llhttp__internal__n_pause_6;
       default:
         goto s_n_llhttp__internal__n_error_1;
@@ -4982,10 +5242,32 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
+  s_n_llhttp__internal__n_invoke_test_flags_3: {
+    switch (llhttp__internal__c_test_flags_3(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_error_12;
+      default:
+        goto s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_flags_2: {
+    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_error_11;
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_test_flags_3;
+      default:
+        goto s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
   s_n_llhttp__internal__n_invoke_test_flags_1: {
     switch (llhttp__internal__c_test_flags_1(state, p, endp)) {
       case 1:
-        goto s_n_llhttp__internal__n_error_10;
+        goto s_n_llhttp__internal__n_invoke_test_flags_2;
       default:
         goto s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete;
     }
@@ -4999,6 +5281,15 @@ static llparse_state_t llhttp__internal__run(
       default:
         goto s_n_llhttp__internal__n_invoke_test_flags_1;
     }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_14: {
+    state->error = 0xb;
+    state->reason = "Empty Content-Length";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
     /* UNREACHABLE */;
     abort();
   }
@@ -5059,7 +5350,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_load_header_state: {
+  s_n_llhttp__internal__n_invoke_load_header_state_1: {
     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
       case 5:
         goto s_n_llhttp__internal__n_invoke_or_flags_3;
@@ -5071,6 +5362,16 @@ static llparse_state_t llhttp__internal__run(
         goto s_n_llhttp__internal__n_invoke_or_flags_6;
       default:
         goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_header_state: {
+    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
+      case 2:
+        goto s_n_llhttp__internal__n_error_14;
+      default:
+        goto s_n_llhttp__internal__n_invoke_load_header_state_1;
     }
     /* UNREACHABLE */;
     abort();
@@ -5115,7 +5416,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_load_header_state_2: {
+  s_n_llhttp__internal__n_invoke_load_header_state_3: {
     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
       case 5:
         goto s_n_llhttp__internal__n_invoke_or_flags_7;
@@ -5131,7 +5432,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_12: {
+  s_n_llhttp__internal__n_error_15: {
     state->error = 0x3;
     state->reason = "Missing expected LF after header value";
     state->error_pos = (const char*) p;
@@ -5175,12 +5476,40 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_13: {
+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_header_value(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) (p + 1);
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
+      return s_error;
+    }
+    p++;
+    goto s_n_llhttp__internal__n_header_value_almost_done;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_16: {
     state->error = 0xa;
     state->reason = "Invalid header value char";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_flags_4: {
+    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_header_value_lenient;
+      default:
+        goto s_n_llhttp__internal__n_error_16;
+    }
     /* UNREACHABLE */;
     abort();
   }
@@ -5224,7 +5553,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_load_header_state_3: {
+  s_n_llhttp__internal__n_invoke_load_header_state_4: {
     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
       case 5:
         goto s_n_llhttp__internal__n_invoke_or_flags_11;
@@ -5272,7 +5601,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3: {
+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4: {
     const unsigned char* start;
     int err;
     
@@ -5282,17 +5611,17 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_15;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_18;
       return s_error;
     }
-    goto s_n_llhttp__internal__n_error_15;
+    goto s_n_llhttp__internal__n_error_18;
     /* UNREACHABLE */;
     abort();
   }
   s_n_llhttp__internal__n_invoke_mul_add_content_length_1: {
     switch (llhttp__internal__c_mul_add_content_length_1(state, p, endp, match)) {
       case 1:
-        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3;
+        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4;
       default:
         goto s_n_llhttp__internal__n_header_value_content_length;
     }
@@ -5315,7 +5644,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4: {
+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5: {
     const unsigned char* start;
     int err;
     
@@ -5325,14 +5654,14 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_16;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_19;
       return s_error;
     }
-    goto s_n_llhttp__internal__n_error_16;
+    goto s_n_llhttp__internal__n_error_19;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_14: {
+  s_n_llhttp__internal__n_error_17: {
     state->error = 0x4;
     state->reason = "Duplicate Content-Length";
     state->error_pos = (const char*) p;
@@ -5341,12 +5670,12 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_flags_2: {
-    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_flags_5: {
+    switch (llhttp__internal__c_test_flags_5(state, p, endp)) {
       case 0:
         goto s_n_llhttp__internal__n_header_value_content_length;
       default:
-        goto s_n_llhttp__internal__n_error_14;
+        goto s_n_llhttp__internal__n_error_17;
     }
     /* UNREACHABLE */;
     abort();
@@ -5354,7 +5683,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_update_header_state_8: {
     switch (llhttp__internal__c_update_header_state_8(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_header_value_discard_rws;
+        goto s_n_llhttp__internal__n_header_value_otherwise;
     }
     /* UNREACHABLE */;
     abort();
@@ -5362,21 +5691,29 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_or_flags_16: {
     switch (llhttp__internal__c_or_flags_16(state, p, endp)) {
       default:
+        goto s_n_llhttp__internal__n_header_value_te_chunked;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_or_flags_17: {
+    switch (llhttp__internal__c_or_flags_17(state, p, endp)) {
+      default:
         goto s_n_llhttp__internal__n_invoke_update_header_state_7;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_load_header_state_1: {
+  s_n_llhttp__internal__n_invoke_load_header_state_2: {
     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
       case 1:
         goto s_n_llhttp__internal__n_header_value_connection;
       case 2:
-        goto s_n_llhttp__internal__n_invoke_test_flags_2;
+        goto s_n_llhttp__internal__n_invoke_test_flags_5;
       case 3:
-        goto s_n_llhttp__internal__n_header_value_te_chunked;
-      case 4:
         goto s_n_llhttp__internal__n_invoke_or_flags_16;
+      case 4:
+        goto s_n_llhttp__internal__n_invoke_or_flags_17;
       default:
         goto s_n_llhttp__internal__n_header_value;
     }
@@ -5419,7 +5756,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_17: {
+  s_n_llhttp__internal__n_error_20: {
     state->error = 0xa;
     state->reason = "Invalid header token";
     state->error_pos = (const char*) p;
@@ -5485,7 +5822,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_18: {
+  s_n_llhttp__internal__n_error_21: {
     state->error = 0x7;
     state->reason = "Expected CRLF";
     state->error_pos = (const char*) p;
@@ -5511,7 +5848,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_19: {
+  s_n_llhttp__internal__n_error_22: {
     state->error = 0x9;
     state->reason = "Expected CRLF after version";
     state->error_pos = (const char*) p;
@@ -5528,7 +5865,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_20: {
+  s_n_llhttp__internal__n_error_23: {
     state->error = 0x9;
     state->reason = "Invalid minor version";
     state->error_pos = (const char*) p;
@@ -5537,7 +5874,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_21: {
+  s_n_llhttp__internal__n_error_24: {
     state->error = 0x9;
     state->reason = "Expected dot";
     state->error_pos = (const char*) p;
@@ -5554,7 +5891,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_22: {
+  s_n_llhttp__internal__n_error_25: {
     state->error = 0x9;
     state->reason = "Invalid major version";
     state->error_pos = (const char*) p;
@@ -5563,7 +5900,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_24: {
+  s_n_llhttp__internal__n_error_27: {
     state->error = 0x8;
     state->reason = "Expected HTTP/";
     state->error_pos = (const char*) p;
@@ -5572,7 +5909,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_23: {
+  s_n_llhttp__internal__n_error_26: {
     state->error = 0x8;
     state->reason = "Expected SOURCE method for ICE/x.x request";
     state->error_pos = (const char*) p;
@@ -5584,7 +5921,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_is_equal_method_1: {
     switch (llhttp__internal__c_is_equal_method_1(state, p, endp)) {
       case 0:
-        goto s_n_llhttp__internal__n_error_23;
+        goto s_n_llhttp__internal__n_error_26;
       default:
         goto s_n_llhttp__internal__n_req_http_major;
     }
@@ -5659,7 +5996,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_25: {
+  s_n_llhttp__internal__n_error_28: {
     state->error = 0x7;
     state->reason = "Invalid char in url fragment start";
     state->error_pos = (const char*) p;
@@ -5719,7 +6056,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_26: {
+  s_n_llhttp__internal__n_error_29: {
     state->error = 0x7;
     state->reason = "Invalid char in url query";
     state->error_pos = (const char*) p;
@@ -5728,7 +6065,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_27: {
+  s_n_llhttp__internal__n_error_30: {
     state->error = 0x7;
     state->reason = "Invalid char in url path";
     state->error_pos = (const char*) p;
@@ -5839,7 +6176,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_28: {
+  s_n_llhttp__internal__n_error_31: {
     state->error = 0x7;
     state->reason = "Double @ in url";
     state->error_pos = (const char*) p;
@@ -5848,27 +6185,9 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_29: {
-    state->error = 0x7;
-    state->reason = "Unexpected char in url server";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_30: {
-    state->error = 0x7;
-    state->reason = "Unexpected char in url server";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
   s_n_llhttp__internal__n_error_32: {
     state->error = 0x7;
-    state->reason = "Unexpected char in url schema";
+    state->reason = "Unexpected char in url server";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
@@ -5877,6 +6196,15 @@ static llparse_state_t llhttp__internal__run(
   }
   s_n_llhttp__internal__n_error_33: {
     state->error = 0x7;
+    state->reason = "Unexpected char in url server";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_35: {
+    state->error = 0x7;
     state->reason = "Unexpected char in url schema";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
@@ -5884,7 +6212,16 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_34: {
+  s_n_llhttp__internal__n_error_36: {
+    state->error = 0x7;
+    state->reason = "Unexpected char in url schema";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_37: {
     state->error = 0x7;
     state->reason = "Unexpected start char in url";
     state->error_pos = (const char*) p;
@@ -5903,7 +6240,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_35: {
+  s_n_llhttp__internal__n_error_38: {
     state->error = 0x6;
     state->reason = "Expected space after method";
     state->error_pos = (const char*) p;
@@ -5920,7 +6257,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_43: {
+  s_n_llhttp__internal__n_error_46: {
     state->error = 0x6;
     state->reason = "Invalid method encountered";
     state->error_pos = (const char*) p;
@@ -5929,7 +6266,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_36: {
+  s_n_llhttp__internal__n_error_39: {
     state->error = 0xd;
     state->reason = "Response overflow";
     state->error_pos = (const char*) p;
@@ -5941,7 +6278,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_mul_add_status_code: {
     switch (llhttp__internal__c_mul_add_status_code(state, p, endp, match)) {
       case 1:
-        goto s_n_llhttp__internal__n_error_36;
+        goto s_n_llhttp__internal__n_error_39;
       default:
         goto s_n_llhttp__internal__n_res_status_code;
     }
@@ -5984,7 +6321,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_37: {
+  s_n_llhttp__internal__n_error_40: {
     state->error = 0xd;
     state->reason = "Invalid response status";
     state->error_pos = (const char*) p;
@@ -6001,7 +6338,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_38: {
+  s_n_llhttp__internal__n_error_41: {
     state->error = 0x9;
     state->reason = "Expected space after version";
     state->error_pos = (const char*) p;
@@ -6018,7 +6355,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_39: {
+  s_n_llhttp__internal__n_error_42: {
     state->error = 0x9;
     state->reason = "Invalid minor version";
     state->error_pos = (const char*) p;
@@ -6027,7 +6364,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_40: {
+  s_n_llhttp__internal__n_error_43: {
     state->error = 0x9;
     state->reason = "Expected dot";
     state->error_pos = (const char*) p;
@@ -6044,7 +6381,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_41: {
+  s_n_llhttp__internal__n_error_44: {
     state->error = 0x9;
     state->reason = "Invalid major version";
     state->error_pos = (const char*) p;
@@ -6053,7 +6390,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_44: {
+  s_n_llhttp__internal__n_error_47: {
     state->error = 0x8;
     state->reason = "Expected HTTP/";
     state->error_pos = (const char*) p;
@@ -6078,7 +6415,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_42: {
+  s_n_llhttp__internal__n_error_45: {
     state->error = 0x8;
     state->reason = "Invalid word encountered";
     state->error_pos = (const char*) p;
@@ -6104,7 +6441,7 @@ static llparse_state_t llhttp__internal__run(
     abort();
   }
   s_n_llhttp__internal__n_pause_8: {
-    state->error = 0x14;
+    state->error = 0x15;
     state->reason = "on_message_begin pause";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_load_type;
@@ -6113,7 +6450,7 @@ static llparse_state_t llhttp__internal__run(
     abort();
   }
   s_n_llhttp__internal__n_error: {
-    state->error = 0xf;
+    state->error = 0x10;
     state->reason = "`on_message_begin` callback error";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
@@ -6125,7 +6462,7 @@ static llparse_state_t llhttp__internal__run(
     switch (llhttp__on_message_begin(state, p, endp)) {
       case 0:
         goto s_n_llhttp__internal__n_invoke_load_type;
-      case 20:
+      case 21:
         goto s_n_llhttp__internal__n_pause_8;
       default:
         goto s_n_llhttp__internal__n_error;


### PR DESCRIPTION
Running main testsuite with UBSan found some instances of applying zero offsets to null pointers when testing for null frames with zero payloadlen. 

runtime error: applying zero offset to null pointer