### PR TITLE
Expose TLS handle

### DIFF
--- a/src/asio_client_session.cc
+++ b/src/asio_client_session.cc
@@ -140,6 +140,13 @@ void session::read_timeout(const boost::posix_time::time_duration &t) {
   impl_->read_timeout(t);
 }
 
+SSL *session::tls_native_handle() {
+  if(session_tls_impl* i=dynamic_cast<session_tls_impl*>(impl_.get())) {
+    return i->native_handle();
+  }
+  return nullptr;
+}
+
 priority_spec::priority_spec(const int32_t stream_id, const int32_t weight,
                              const bool exclusive)
     : valid_(true) {

--- a/src/asio_client_session_tls_impl.cc
+++ b/src/asio_client_session_tls_impl.cc
@@ -86,6 +86,8 @@ void session_tls_impl::start_connect(tcp::resolver::iterator endpoint_it) {
 
 tcp::socket &session_tls_impl::socket() { return socket_.next_layer(); }
 
+SSL *session_tls_impl::native_handle() { return socket_.native_handle(); }
+
 void session_tls_impl::read_socket(
     std::function<void(const boost::system::error_code &ec, std::size_t n)> h) {
   socket_.async_read_some(boost::asio::buffer(rb_), h);

--- a/src/asio_client_session_tls_impl.h
+++ b/src/asio_client_session_tls_impl.h
@@ -47,6 +47,7 @@ public:
 
   virtual void start_connect(tcp::resolver::iterator endpoint_it);
   virtual tcp::socket &socket();
+  virtual SSL* native_handle();
   virtual void read_socket(
       std::function<void(const boost::system::error_code &ec, std::size_t n)>
           h);

--- a/src/includes/nghttp2/asio_http2_client.h
+++ b/src/includes/nghttp2/asio_http2_client.h
@@ -233,6 +233,7 @@ public:
                         generator_cb cb, header_map h = header_map{},
                         priority_spec prio = priority_spec()) const;
 
+  SSL *tls_native_handle();
 private:
   std::shared_ptr<session_impl> impl_;
 };


### PR DESCRIPTION
Cf https://github.com/nghttp2/nghttp2/issues/1406

I created a merge request to add a method to expose the TLS handle. Usecase is to let the application using the nghttp2 library (or rather, its C++ asio bindings) print some TLS info (protocol name, cipher, tmp key info).