### PR TITLE
h2load: Allow client to connect to a different target name or IP

### DIFF
--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -1656,7 +1656,9 @@ void resolve_host() {
   hints.ai_protocol = 0;
   hints.ai_flags = AI_ADDRCONFIG;
 
-  rv = getaddrinfo(config.host.c_str(), util::utos(config.port).c_str(), &hints,
+  auto resolve_host = config.connect_to_host.empty() ? config.host : config.connect_to_host;
+
+  rv = getaddrinfo(resolve_host.c_str(), util::utos(config.port).c_str(), &hints,
                    &res);
   if (rv != 0) {
     std::cerr << "getaddrinfo() failed: " << gai_strerror(rv) << std::endl;
@@ -2141,6 +2143,7 @@ int main(int argc, char **argv) {
         {"log-file", required_argument, &flag, 10},
         {"groups", required_argument, &flag, 11},
         {"tls13-ciphers", required_argument, &flag, 12},
+        {"connect-to", required_argument, &flag, 13},
         {nullptr, 0, nullptr, 0}};
     int option_index = 0;
     auto c = getopt_long(argc, argv,
@@ -2375,6 +2378,10 @@ int main(int argc, char **argv) {
       case 12:
         // --tls13-ciphers
         config.tls13_ciphers = optarg;
+        break;
+      case 13:
+        // --connect-to
+        config.connect_to_host = optarg;
         break;
       }
       break;

--- a/src/h2load.h
+++ b/src/h2load.h
@@ -73,6 +73,7 @@ struct Config {
   nghttp2::Headers custom_headers;
   std::string scheme;
   std::string host;
+  std::string connect_to_host;
   std::string ifile;
   std::string ciphers;
   std::string tls13_ciphers;


### PR DESCRIPTION
This change allows people to use h2load with valid SNI and host/authority but point the client at a designated IP or hostname e.g

```
h2load https://example.com/
h2load --connect-to 127.0.01 https://example.com
h2load --connect-to example.home.arpa https://example.com
```