### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -229,6 +229,20 @@ used:
     $ ./configure
     $ make
 
+Building nghttp2 - Using vcpkg
+------------------------------
+
+You can download and install nghttp2 using the `vcpkg <https://github.com/Microsoft/vcpkg>`_ dependency manager::
+
+    $ git clone https://github.com/Microsoft/vcpkg.git
+    $ cd vcpkg
+    $ ./bootstrap-vcpkg.sh
+    $ ./vcpkg integrate install
+    $ ./vcpkg install nghttp2
+
+The nghttp2 port in vcpkg is kept up to date by Microsoft team members and community contributors.
+If the version is out of date, please `create an issue or pull request <https://github.com/Microsoft/vcpkg>`_ on the vcpkg repository.
+
 Notes for building on Windows (MSVC)
 ------------------------------------
 


### PR DESCRIPTION
Nghttp2 is available as a port in vcpkg, a C++ library manager that simplifies installation for nghttp2 and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build nghttp2, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.