### PR TITLE
Enable session_create_idle_stream test, fix errors

### DIFF
--- a/tests/main.c
+++ b/tests/main.c
@@ -307,6 +307,8 @@ int main() {
       !CU_add_test(pSuite, "session_flooding", test_nghttp2_session_flooding) ||
       !CU_add_test(pSuite, "session_change_stream_priority",
                    test_nghttp2_session_change_stream_priority) ||
+      !CU_add_test(pSuite, "session_create_idle_stream",
+                   test_nghttp2_session_create_idle_stream) ||
       !CU_add_test(pSuite, "session_repeated_priority_change",
                    test_nghttp2_session_repeated_priority_change) ||
       !CU_add_test(pSuite, "session_repeated_priority_submission",

--- a/tests/nghttp2_session_test.c
+++ b/tests/nghttp2_session_test.c
@@ -10141,7 +10141,7 @@ void test_nghttp2_session_create_idle_stream(void) {
 
   /* If pri_spec->stream_id does not exist, and it is idle stream, it
      is created too */
-  nghttp2_priority_spec_init(&pri_spec, 8, 109, 0);
+  nghttp2_priority_spec_init(&pri_spec, 10, 109, 0);
 
   rv = nghttp2_session_create_idle_stream(session, 8, &pri_spec);
 
@@ -10174,7 +10174,7 @@ void test_nghttp2_session_create_idle_stream(void) {
   CU_ASSERT(NGHTTP2_ERR_INVALID_ARGUMENT == rv);
 
   /* It is an error to create non-idle stream */
-  session->next_stream_id = 20;
+  session->last_sent_stream_id = 20;
   pri_spec.stream_id = 2;
 
   rv = nghttp2_session_create_idle_stream(session, 18, &pri_spec);


### PR DESCRIPTION
Add the currently-unused `test_nghttp2_session_create_idle_stream()`
function to the test suite definition.

Modify the test in two places to make it pass:

  * Use stream ID=10 as the priority stream ID to test automatic creation
    of streams for priority specs. The code below checks against stream
    ID=10 so I assume this was a typo in the test.

  * Set the `last_sent_stream_id` instead of the `next_stream_id` to test
    that idle streams cannot be created with smaller numbers than the
    most-recently-seen stream ID. Looking at the validation path in
    `session_detect_idle_stream()`, I think this was another test typo.