### PR TITLE
Add GOAWAY handling on asio client

### DIFF
--- a/src/asio_client_session_impl.cc
+++ b/src/asio_client_session_impl.cc
@@ -329,6 +329,15 @@ int on_frame_recv_callback(nghttp2_session *session, const nghttp2_frame *frame,
 
     break;
   }
+  case NGHTTP2_GOAWAY: {
+    if (!sess->stopped()) {
+      auto& cb = sess->on_error();
+      auto ec = make_error_code(
+        static_cast<nghttp2_error>(NGHTTP2_ERR_START_STREAM_NOT_ALLOWED));
+      cb(ec);
+    }
+    break;
+  }
   }
   return 0;
 }


### PR DESCRIPTION
Upon receiving GOAWAY frames the asio client does not do any signalling towards the user, leaving a stale session object. This has two downsides:
- If there were active streams, session is not stopped but any new messages should not be sent, as they will be rejected by the other endpoint.
- If there were no active streams, session is shutdown silently, leaving the object stale and unusable. The next request will try to create a new stream and will fail with a generic NGHTTP2_INTERNAL_ERROR, which is confusing.

This change attempts to fix that situation by properly calling the error callback with a clear intentional error, signalling that a GOAWAY was received.