### PR TITLE
doc: clarify flow control behaviour for nghttp2_session_send()

### DIFF
--- a/lib/includes/nghttp2/nghttp2.h
+++ b/lib/includes/nghttp2/nghttp2.h
@@ -2853,7 +2853,8 @@ NGHTTP2_EXTERN void nghttp2_session_del(nghttp2_session *session);
  * outbound queue and sends it to the remote peer.  It does this as
  * many as possible until the user callback
  * :type:`nghttp2_send_callback` returns
- * :enum:`NGHTTP2_ERR_WOULDBLOCK` or the outbound queue becomes empty.
+ * :enum:`NGHTTP2_ERR_WOULDBLOCK`, the outbound queue becomes empty
+ * or remote window size becomes depleted due to flow control.
  * This function calls several callback functions which are passed
  * when initializing the |session|.  Here is the simple time chart
  * which tells when each callback is invoked:


### PR DESCRIPTION
The previous wording implied that if send_callback doesn't return
NGHTTP2_ERR_WOULDBLOCK, this function would always send all
submitted requests / data. This is not the case, since flow control can
cause some data to remain queued until WINDOW_UPDATE is received.