### PR TITLE
doc: nghttp2_session_send is also affected by max concurrent streams

### DIFF
--- a/lib/includes/nghttp2/nghttp2.h
+++ b/lib/includes/nghttp2/nghttp2.h
@@ -2851,10 +2851,11 @@ NGHTTP2_EXTERN void nghttp2_session_del(nghttp2_session *session);
  *
  * This function retrieves the highest prioritized frame from the
  * outbound queue and sends it to the remote peer.  It does this as
- * many as possible until the user callback
+ * many times as possible until the user callback
  * :type:`nghttp2_send_callback` returns
  * :enum:`NGHTTP2_ERR_WOULDBLOCK`, the outbound queue becomes empty
- * or remote window size becomes depleted due to flow control.
+ * or flow control is triggered (remote window size becomes depleted
+ * or maximum number of concurrent streams is reached).
  * This function calls several callback functions which are passed
  * when initializing the |session|.  Here is the simple time chart
  * which tells when each callback is invoked:


### PR DESCRIPTION
Further clarify the function also takes into account maximum concurrent
streams.

Closes #691
Closes #817