### PR TITLE
Fix to help automated license validation within the community.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,23 @@
-See COPYING
+The MIT License
+
+Copyright (c) 2012, 2014, 2015, 2016 Tatsuhiro Tsujikawa
+Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
**Problem Statement**
* Many companies to ensure they are honoring the intent of open source authors automate repository scans.  The deep scans (by products like JFROG Artifactory) look at source repos to verify license information from the LICENSE file.  If the LICENSE file contains a recognized license, the validation process is automatic.  But if the process cannot automatically verify the license, compliance teams ping engineers and ask them to attest to the validity.

**Solution**
* To honor the intent of the authors and save engineers from compliance departments asking questions, I've submitted this pull request to copy the license information in COPYING to LICENSE.