### PR TITLE
Fix for client response with content-length & code 0 RST_STREAM

### DIFF
--- a/lib/nghttp2_session.c
+++ b/lib/nghttp2_session.c
@@ -1196,6 +1196,11 @@ int nghttp2_session_close_stream(nghttp2_session *session, int32_t stream_id,
     }
   }
 
+  if (error_code == NGHTTP2_NO_ERROR &&
+      nghttp2_http_on_remote_end_stream(stream) == -1) {
+    error_code = NGHTTP2_PROTOCOL_ERROR;
+  }
+
   /* We call on_stream_close_callback even if stream->state is
      NGHTTP2_STREAM_INITIAL. This will happen while sending request
      HEADERS, a local endpoint receives RST_STREAM for that stream. It

--- a/tests/main.c
+++ b/tests/main.c
@@ -333,6 +333,8 @@ int main() {
                    test_nghttp2_http_mandatory_headers) ||
       !CU_add_test(pSuite, "http_content_length",
                    test_nghttp2_http_content_length) ||
+      !CU_add_test(pSuite, "http_content_length_close",
+                   test_nghttp2_http_content_length_close) ||
       !CU_add_test(pSuite, "http_content_length_mismatch",
                    test_nghttp2_http_content_length_mismatch) ||
       !CU_add_test(pSuite, "http_non_final_response",

--- a/tests/nghttp2_session_test.c
+++ b/tests/nghttp2_session_test.c
@@ -11495,6 +11495,59 @@ void test_nghttp2_http_content_length(void) {
   nghttp2_bufs_free(&bufs);
 }
 
+void test_nghttp2_http_content_length_close(void) {
+  nghttp2_session *session;
+  nghttp2_session_callbacks callbacks;
+  nghttp2_hd_deflater deflater;
+  nghttp2_mem *mem;
+  nghttp2_bufs bufs;
+  ssize_t rv;
+  nghttp2_stream *stream;
+  my_user_data ud;
+  const nghttp2_nv cl_resnv[] = {MAKE_NV(":status", "200"),
+                                 MAKE_NV("content-length", "9000000000")};
+
+  mem = nghttp2_mem_default();
+  frame_pack_bufs_init(&bufs);
+
+  memset(&callbacks, 0, sizeof(nghttp2_session_callbacks));
+  callbacks.send_callback = null_send_callback;
+  callbacks.on_stream_close_callback = on_stream_close_callback;
+
+  ud.stream_close_cb_called = 0;
+
+  nghttp2_session_client_new(&session, &callbacks, &ud);
+
+  nghttp2_hd_deflate_init(&deflater, mem);
+
+  stream = open_sent_stream2(session, 1, NGHTTP2_STREAM_OPENING);
+
+  rv = pack_headers(&bufs, &deflater, 1, NGHTTP2_FLAG_END_HEADERS, cl_resnv,
+                    ARRLEN(cl_resnv), mem);
+  CU_ASSERT(0 == rv);
+
+  rv = nghttp2_session_mem_recv(session, bufs.head->buf.pos,
+                                nghttp2_buf_len(&bufs.head->buf));
+
+  CU_ASSERT((ssize_t)nghttp2_buf_len(&bufs.head->buf) == rv);
+  CU_ASSERT(NULL == nghttp2_session_get_next_ob_item(session));
+  CU_ASSERT(9000000000LL == stream->content_length);
+  CU_ASSERT(200 == stream->status_code);
+  CU_ASSERT(0 == ud.stream_close_cb_called);
+
+  CU_ASSERT(nghttp2_session_close_stream(session, 1, NGHTTP2_NO_ERROR) == 0);
+  CU_ASSERT(ud.stream_close_cb_called == 1);
+  CU_ASSERT(ud.stream_close_error_code != NGHTTP2_NO_ERROR);
+
+  nghttp2_hd_deflate_free(&deflater);
+
+  nghttp2_session_del(session);
+
+  nghttp2_bufs_reset(&bufs);
+
+  nghttp2_bufs_free(&bufs);
+}
+
 void test_nghttp2_http_content_length_mismatch(void) {
   nghttp2_session *session;
   nghttp2_session_callbacks callbacks;

--- a/tests/nghttp2_session_test.h
+++ b/tests/nghttp2_session_test.h
@@ -164,6 +164,7 @@ void test_nghttp2_session_no_closed_streams(void);
 void test_nghttp2_session_set_stream_user_data(void);
 void test_nghttp2_http_mandatory_headers(void);
 void test_nghttp2_http_content_length(void);
+void test_nghttp2_http_content_length_close(void);
 void test_nghttp2_http_content_length_mismatch(void);
 void test_nghttp2_http_non_final_response(void);
 void test_nghttp2_http_trailer_headers(void);


### PR DESCRIPTION
After an intense debugging session, I found that [node can complete http2 client requests with partial responses](https://github.com/sindresorhus/got/issues/1462#issuecomment-692349508). Since it uses nghttp2 to handle the transfer, it should not be possible according to the [nghttp2 programmers guide](https://github.com/nghttp2/nghttp2/blob/master/doc/programmers-guide.rst), but alas it does occur!

I managed to come up with this PR to fix the issue by simply calling the validation logic on any close with `error_code == 0`. Feel free to adapt this to better fit your code style.