### PR TITLE
Fix examples/libevent-client.cc

### DIFF
--- a/examples/libevent-client.c
+++ b/examples/libevent-client.c
@@ -551,6 +551,7 @@ static void initiate_connection(struct event_base *evbase, SSL_CTX *ssl_ctx,
   SSL *ssl;
 
   ssl = create_ssl(ssl_ctx);
+  SSL_set_tlsext_host_name(ssl, host);
   bev = bufferevent_openssl_socket_new(
       evbase, -1, ssl, BUFFEREVENT_SSL_CONNECTING,
       BEV_OPT_DEFER_CALLBACKS | BEV_OPT_CLOSE_ON_FREE);


### PR DESCRIPTION
Fixes #1386.

According to [RFC 7540 HTTP/2 Section 9.2](https://tools.ietf.org/html/rfc7540#section-9.2), 

>   The TLS implementation MUST support the Server Name Indication (SNI)
>   [TLS-EXT] extension to TLS.  HTTP/2 clients MUST indicate the target
>   domain name when negotiating TLS.

Thus, I add the missing SNI in the Client Hello message.