### PR TITLE
Add custom memory allocator for session callbacks

### DIFF
--- a/lib/includes/nghttp2/nghttp2.h
+++ b/lib/includes/nghttp2/nghttp2.h
@@ -2230,6 +2230,31 @@ nghttp2_session_callbacks_new(nghttp2_session_callbacks **callbacks_ptr);
 /**
  * @function
  *
+ * Like `nghttp2_session_callbacks_new()`, but with additional custom
+ * memory allocator specified in the |mem|.
+ *
+ * The |mem| can be ``NULL`` and the call is equivalent to
+ * `nghttp2_session_callbacks_new()`.
+ *
+ * This function does not take ownership |mem|.  The application is
+ * responsible for freeing |mem|.
+ *
+ * The library code does not refer to |mem| pointer after this
+ * function returns, so the application can safely free it.
+ *
+ * This function returns 0 if it succeeds, or one of the following
+ * negative error codes:
+ *
+ * :enum:`nghttp2_error.NGHTTP2_ERR_NOMEM`
+ *     Out of memory.
+ */
+NGHTTP2_EXTERN int
+nghttp2_session_callbacks_new2(nghttp2_session_callbacks **callbacks_ptr,
+                               nghttp2_mem *mem);
+
+/**
+ * @function
+ *
  * Frees any resources allocated for |callbacks|.  If |callbacks| is
  * ``NULL``, this function does nothing.
  */

--- a/lib/includes/nghttp2/nghttp2.h
+++ b/lib/includes/nghttp2/nghttp2.h
@@ -2102,6 +2102,101 @@ typedef int (*nghttp2_error_callback2)(nghttp2_session *session,
                                        int lib_error_code, const char *msg,
                                        size_t len, void *user_data);
 
+/**
+ * @functypedef
+ *
+ * Custom memory allocator to replace malloc().  The |mem_user_data|
+ * is the mem_user_data member of :type:`nghttp2_mem` structure.
+ */
+typedef void *(*nghttp2_malloc)(size_t size, void *mem_user_data);
+
+/**
+ * @functypedef
+ *
+ * Custom memory allocator to replace free().  The |mem_user_data| is
+ * the mem_user_data member of :type:`nghttp2_mem` structure.
+ */
+typedef void (*nghttp2_free)(void *ptr, void *mem_user_data);
+
+/**
+ * @functypedef
+ *
+ * Custom memory allocator to replace calloc().  The |mem_user_data|
+ * is the mem_user_data member of :type:`nghttp2_mem` structure.
+ */
+typedef void *(*nghttp2_calloc)(size_t nmemb, size_t size, void *mem_user_data);
+
+/**
+ * @functypedef
+ *
+ * Custom memory allocator to replace realloc().  The |mem_user_data|
+ * is the mem_user_data member of :type:`nghttp2_mem` structure.
+ */
+typedef void *(*nghttp2_realloc)(void *ptr, size_t size, void *mem_user_data);
+
+/**
+ * @struct
+ *
+ * Custom memory allocator functions and user defined pointer.  The
+ * |mem_user_data| member is passed to each allocator function.  This
+ * can be used, for example, to achieve per-session memory pool.
+ *
+ * In the following example code, ``my_malloc``, ``my_free``,
+ * ``my_calloc`` and ``my_realloc`` are the replacement of the
+ * standard allocators ``malloc``, ``free``, ``calloc`` and
+ * ``realloc`` respectively::
+ *
+ *     void *my_malloc_cb(size_t size, void *mem_user_data) {
+ *       return my_malloc(size);
+ *     }
+ *
+ *     void my_free_cb(void *ptr, void *mem_user_data) { my_free(ptr); }
+ *
+ *     void *my_calloc_cb(size_t nmemb, size_t size, void *mem_user_data) {
+ *       return my_calloc(nmemb, size);
+ *     }
+ *
+ *     void *my_realloc_cb(void *ptr, size_t size, void *mem_user_data) {
+ *       return my_realloc(ptr, size);
+ *     }
+ *
+ *     void session_new() {
+ *       nghttp2_session *session;
+ *       nghttp2_session_callbacks *callbacks;
+ *       nghttp2_mem mem = {NULL, my_malloc_cb, my_free_cb, my_calloc_cb,
+ *                          my_realloc_cb};
+ *
+ *       ...
+ *
+ *       nghttp2_session_client_new3(&session, callbacks, NULL, NULL, &mem);
+ *
+ *       ...
+ *     }
+ */
+typedef struct {
+  /**
+   * An arbitrary user supplied data.  This is passed to each
+   * allocator function.
+   */
+  void *mem_user_data;
+  /**
+   * Custom allocator function to replace malloc().
+   */
+  nghttp2_malloc malloc;
+  /**
+   * Custom allocator function to replace free().
+   */
+  nghttp2_free free;
+  /**
+   * Custom allocator function to replace calloc().
+   */
+  nghttp2_calloc calloc;
+  /**
+   * Custom allocator function to replace realloc().
+   */
+  nghttp2_realloc realloc;
+} nghttp2_mem;
+
 struct nghttp2_session_callbacks;
 
 /**
@@ -2389,101 +2484,6 @@ NGHTTP2_EXTERN void nghttp2_session_callbacks_set_error_callback(
  */
 NGHTTP2_EXTERN void nghttp2_session_callbacks_set_error_callback2(
     nghttp2_session_callbacks *cbs, nghttp2_error_callback2 error_callback2);
-
-/**
- * @functypedef
- *
- * Custom memory allocator to replace malloc().  The |mem_user_data|
- * is the mem_user_data member of :type:`nghttp2_mem` structure.
- */
-typedef void *(*nghttp2_malloc)(size_t size, void *mem_user_data);
-
-/**
- * @functypedef
- *
- * Custom memory allocator to replace free().  The |mem_user_data| is
- * the mem_user_data member of :type:`nghttp2_mem` structure.
- */
-typedef void (*nghttp2_free)(void *ptr, void *mem_user_data);
-
-/**
- * @functypedef
- *
- * Custom memory allocator to replace calloc().  The |mem_user_data|
- * is the mem_user_data member of :type:`nghttp2_mem` structure.
- */
-typedef void *(*nghttp2_calloc)(size_t nmemb, size_t size, void *mem_user_data);
-
-/**
- * @functypedef
- *
- * Custom memory allocator to replace realloc().  The |mem_user_data|
- * is the mem_user_data member of :type:`nghttp2_mem` structure.
- */
-typedef void *(*nghttp2_realloc)(void *ptr, size_t size, void *mem_user_data);
-
-/**
- * @struct
- *
- * Custom memory allocator functions and user defined pointer.  The
- * |mem_user_data| member is passed to each allocator function.  This
- * can be used, for example, to achieve per-session memory pool.
- *
- * In the following example code, ``my_malloc``, ``my_free``,
- * ``my_calloc`` and ``my_realloc`` are the replacement of the
- * standard allocators ``malloc``, ``free``, ``calloc`` and
- * ``realloc`` respectively::
- *
- *     void *my_malloc_cb(size_t size, void *mem_user_data) {
- *       return my_malloc(size);
- *     }
- *
- *     void my_free_cb(void *ptr, void *mem_user_data) { my_free(ptr); }
- *
- *     void *my_calloc_cb(size_t nmemb, size_t size, void *mem_user_data) {
- *       return my_calloc(nmemb, size);
- *     }
- *
- *     void *my_realloc_cb(void *ptr, size_t size, void *mem_user_data) {
- *       return my_realloc(ptr, size);
- *     }
- *
- *     void session_new() {
- *       nghttp2_session *session;
- *       nghttp2_session_callbacks *callbacks;
- *       nghttp2_mem mem = {NULL, my_malloc_cb, my_free_cb, my_calloc_cb,
- *                          my_realloc_cb};
- *
- *       ...
- *
- *       nghttp2_session_client_new3(&session, callbacks, NULL, NULL, &mem);
- *
- *       ...
- *     }
- */
-typedef struct {
-  /**
-   * An arbitrary user supplied data.  This is passed to each
-   * allocator function.
-   */
-  void *mem_user_data;
-  /**
-   * Custom allocator function to replace malloc().
-   */
-  nghttp2_malloc malloc;
-  /**
-   * Custom allocator function to replace free().
-   */
-  nghttp2_free free;
-  /**
-   * Custom allocator function to replace calloc().
-   */
-  nghttp2_calloc calloc;
-  /**
-   * Custom allocator function to replace realloc().
-   */
-  nghttp2_realloc realloc;
-} nghttp2_mem;
 
 struct nghttp2_option;
 

--- a/lib/nghttp2_callbacks.c
+++ b/lib/nghttp2_callbacks.c
@@ -23,21 +23,39 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 #include "nghttp2_callbacks.h"
+#include "nghttp2_mem.h"
 
 #include <stdlib.h>
 
 int nghttp2_session_callbacks_new(nghttp2_session_callbacks **callbacks_ptr) {
-  *callbacks_ptr = calloc(1, sizeof(nghttp2_session_callbacks));
+  nghttp2_session_callbacks_new2(callbacks_ptr, NULL);
+}
+
+int nghttp2_session_callbacks_new2(nghttp2_session_callbacks **callbacks_ptr,
+                                   nghttp2_mem *mem) {
+  if (mem == NULL) {
+    mem = nghttp2_mem_default();
+  }
+
+  *callbacks_ptr = nghttp2_mem_calloc(mem, 1, sizeof(nghttp2_session_callbacks));
 
   if (*callbacks_ptr == NULL) {
     return NGHTTP2_ERR_NOMEM;
   }
 
+  (*callbacks_ptr)->mem = *mem;
+
   return 0;
 }
 
 void nghttp2_session_callbacks_del(nghttp2_session_callbacks *callbacks) {
-  free(callbacks);
+  if (callbacks == NULL) {
+    return;
+  }
+  nghttp2_mem *mem;
+
+  mem = &callbacks->mem;
+  nghttp2_mem_free(mem, callbacks);
 }
 
 void nghttp2_session_callbacks_set_send_callback(

--- a/lib/nghttp2_callbacks.h
+++ b/lib/nghttp2_callbacks.h
@@ -120,6 +120,10 @@ struct nghttp2_session_callbacks {
   nghttp2_on_extension_chunk_recv_callback on_extension_chunk_recv_callback;
   nghttp2_error_callback error_callback;
   nghttp2_error_callback2 error_callback2;
+  /**
+   * Memory allocator
+   */
+  nghttp2_mem mem;
 };
 
 #endif /* NGHTTP2_CALLBACKS_H */


### PR DESCRIPTION
Add custom memory allocator support for session callbacks. 
First commit is just moving the nghttp2_mem up, second commit is the actual addition.
Let me know if you have any question!