### PR TITLE
add variable support in path and data file

### DIFF
--- a/src/h2load.h
+++ b/src/h2load.h
@@ -42,6 +42,7 @@
 #include <memory>
 #include <chrono>
 #include <array>
+#include <atomic>
 
 #include <nghttp2/nghttp2.h>
 
@@ -116,6 +117,10 @@ struct Config {
   std::vector<std::string> npn_list;
   // The number of request per second for each client.
   double rps;
+  uint64_t req_variable_start;
+  uint64_t req_variable_end;
+  std::string req_variable_name;
+  std::string data_buffer;
 
   Config();
   ~Config();
@@ -188,10 +193,10 @@ struct Stats {
   // The number of requests issued so far
   size_t req_started;
   // The number of requests finished
-  size_t req_done;
+  std::atomic<size_t> req_done;
   // The number of requests completed successful, but not necessarily
   // means successful HTTP status code.
-  size_t req_success;
+  std::atomic<size_t> req_success;
   // The number of requests marked as success.  HTTP status code is
   // also considered as success. This is subset of req_done.
   size_t req_status_success;
@@ -277,6 +282,7 @@ struct Worker {
   // specified
   ev_timer duration_watcher;
   ev_timer warmup_watcher;
+  uint64_t curr_req_variable_value;
 
   Worker(uint32_t id, SSL_CTX *ssl_ctx, size_t nreq_todo, size_t nclients,
          size_t rate, size_t max_samples, Config *config);
@@ -302,6 +308,7 @@ struct Stream {
 struct Client {
   DefaultMemchunks wb;
   std::unordered_map<int32_t, Stream> streams;
+  std::unordered_map<int32_t, std::string> streams_data_buffer;
   ClientStat cstat;
   std::unique_ptr<Session> session;
   ev_io wev;
@@ -409,7 +416,7 @@ struct Client {
   // on_stream_close(stream_id, ...).  Otherwise, this will return
   // nullptr.
   RequestStat *get_req_stat(int32_t stream_id);
-
+  std::string& get_stream_buffer(int32_t stream_id);
   void record_request_time(RequestStat *req_stat);
   void record_connect_start_time();
   void record_connect_time();

--- a/src/h2load_http2_session.cc
+++ b/src/h2load_http2_session.cc
@@ -281,11 +281,16 @@ void Http2Session::on_connect() {
   auto connection_window = (1 << config->connection_window_bits) - 1;
   nghttp2_session_set_local_window_size(session_, NGHTTP2_FLAG_NONE, 0,
                                         connection_window);
-
-  std::random_device                  rand_dev;
-  std::mt19937                        generator(rand_dev());
-  std::uniform_int_distribution<int>  distr(config->req_variable_start, config->req_variable_end);
-  client_->worker->curr_req_variable_value = distr(generator);
+  if (config->nclients > 1)
+  {
+    std::random_device                  rand_dev;
+    std::mt19937                        generator(rand_dev());
+    std::uniform_int_distribution<uint64_t>  distr(config->req_variable_start, config->req_variable_end);
+    client_->worker->curr_req_variable_value = distr(generator);
+  }
+  else {
+    client_->worker->curr_req_variable_value = config->req_variable_start;
+  }
 
   client_->signal_write();
 }


### PR DESCRIPTION
This change would like to enhance h2load to support variables in request uri and data file in this way:

root@ubuntuvm:~/nghttp2/nghttp2-master/build# cat datafile.json
{"callbackReference": "http://10.96.44.10:9090/imsi-2621012-USER_ID/notification","nfInstanceId": "3fa85f64-5717-4562-a3fc-2c963f66afa6", "expires": "2100-01-31T06:50:35.266Z", "monitoredResourceUris": ["/nudm-sdm/v2/imsi-2621012-USER_ID/am-data"]}

h2load http://10.67.34.200:8080/nudm-sdm/v2/imsi-2621012-USER_ID/sdm-subscriptions/ -V "-USER_ID" -S 1 -E 1000 -D 5 -d datafile.json -H "Content-Type: application/json" -v -t 2 -c 2

The actual request would look like this, every request would have "-USER_ID" replaced with a value in range between 1 and 1000:

Frame 25: 373 bytes on wire (2984 bits), 373 bytes captured (2984 bits)
Linux cooked capture
Internet Protocol Version 4, Src: 192.168.215.94, Dst: 10.67.34.200
Transmission Control Protocol, Src Port: 57298, Dst Port: 8080, Seq: 415, Ack: 108, Len: 305
HyperText Transfer Protocol 2
Stream: HEADERS, Stream ID: 3, Length 46, POST /nudm-sdm/v2/imsi-26210120047/sdm-subscriptions/
Length: 46
Type: HEADERS (1)
Flags: 0x04
0... .... .... .... .... .... .... .... = Reserved: 0x0
.000 0000 0000 0000 0000 0000 0000 0011 = Stream Identifier: 3
[Pad Length: 0]
Header Block Fragment: 04a262ab64a564494b1dc4c1a94196138208022001a75844…
[Header Length: 235]
[Header Count: 7]
Header: :path: /nudm-sdm/v2/imsi-26210120047/sdm-subscriptions/
Header: :scheme: http
Header: :authority: 10.67.34.200:8080
Header: :method: POST
Header: user-agent: h2load nghttp2/1.43.90
Header: content-type: application/json
Header: content-length: 241
Stream: DATA, Stream ID: 3, Length 241
JavaScript Object Notation: application/json
Object
Member Key: callbackReference
String value: http://10.96.44.10:9090/imsi-26210120047/notification
Key: callbackReference
Member Key: nfInstanceId
Member Key: expires
Member Key: monitoredResourceUris
Array
String value: /nudm-sdm/v2/imsi-26210120047/am-data
Key: monitoredResourceUris


This change also adds a new task to display request per second and success rate every second, to let the user know the status of the load test in realtime.