### PR TITLE
CRUD operation support

### DIFF
--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -729,7 +729,7 @@ void Client::process_abandoned_streams() {
 
 void restart_client_w_cb(struct ev_loop *loop, ev_timer *w, int revents) {
   auto client = static_cast<Client *>(w->data);
-  ev_timer_stop(client->worker->loop, &client->worker->retart_client_watcher);
+  ev_timer_stop(client->worker->loop, &client->retart_client_watcher);
   std::cout << "Restart client:"<<std::endl;
   client->terminate_session();
   client->disconnect();
@@ -769,9 +769,9 @@ void Client::process_request_failure(int errCode) {
   }
   if (MAX_STREAM_TO_BE_EXHAUSTED == errCode) {
       std::cout << "stream exhausted on this client. Restart client:"<<std::endl;
-      worker->retart_client_watcher.data = this;
-      ev_timer_init(&worker->retart_client_watcher, restart_client_w_cb, 0.1, 0.);
-      ev_timer_start(worker->loop, &worker->retart_client_watcher);
+      retart_client_watcher.data = this;
+      ev_timer_init(&retart_client_watcher, restart_client_w_cb, 0.0, 0.);
+      ev_timer_start(worker->loop, &retart_client_watcher);
       return;
   }
   std::cout << "Process Request Failure:" << worker->stats.req_failed

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -2211,13 +2211,13 @@ Options:
               HTTP METHOD for Create operationto override the  default
               method (GET/POST)
   --crud-read-method=<METHOD>
-              HTTP METHOD to for CRUD Read operation
+              HTTP METHOD for CRUD Read operation
   --crud-update-method=<METHOD>
-              HTTP METHOD to for CRUD Update operation
+              HTTP METHOD for CRUD Update operation
   --crud-delete-method=<METHOD>
-              HTTP METHOD to for CRUD Delete operation
+              HTTP METHOD for CRUD Delete operation
   --crud-resource-header-name=<header name>
-              name of the header which containers the resource created
+              name of the  header  which contains the resource created
               If not specified, header name 'location' is assumed
   --crud-create-data-file=<file name>
               name of the data file for  Create operation. If present,

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -2218,7 +2218,6 @@ Options:
               HTTP METHOD for CRUD Delete operation
   --crud-resource-header-name=<header name>
               name of the  header  which contains the resource created
-              If not specified, header name 'location' is assumed
   --crud-create-data-file=<file name>
               name of the data file for  Create operation. If present,
               this overrides the file name provided in 'data' option
@@ -2974,12 +2973,6 @@ int main(int argc, char **argv) {
     config.nva.push_back(std::move(nva));
   }
 
-  if ((!config.crud_read_method.empty() ||
-       !config.crud_update_method.empty() ||
-       !config.crud_delete_method.empty()) &&
-      config.crud_resource_header_name.empty()) {
-    config.crud_resource_header_name = "location";
-  }
   if (!config.crud_read_method.empty()) {
     config.read_nva = config.nva[0];
     replace_header_in_nva(config.read_nva, ":method", config.crud_read_method);

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -3164,7 +3164,7 @@ int main(int argc, char **argv) {
 
   std::future<void> fu_update_rps =
           std::async(std::launch::async, [&workers_stopped]() {
-            while (!workers_stopped) {
+            while (!config.rps_file.empty() && !workers_stopped) {
               std::this_thread::sleep_for(std::chrono::seconds(1));
               std::ifstream file;
               file.open(config.rps_file);

--- a/src/h2load.h
+++ b/src/h2load.h
@@ -303,7 +303,6 @@ struct Worker {
   ev_timer duration_watcher;
   ev_timer warmup_watcher;
   uint64_t curr_req_variable_value;
-  ev_timer retart_client_watcher;
 
   Worker(uint32_t id, SSL_CTX *ssl_ctx, size_t nreq_todo, size_t nclients,
          size_t rate, size_t max_samples, Config *config);
@@ -397,6 +396,7 @@ struct Client {
   std::map<int32_t, CRUD_data> streams_waiting_for_update_response;
   int32_t curr_stream_id;
   std::unique_ptr<Client> ancestor;
+  ev_timer retart_client_watcher;
 
   enum { ERR_CONNECT_FAIL = -100 };
 

--- a/src/h2load.h
+++ b/src/h2load.h
@@ -246,6 +246,8 @@ struct Stats {
   std::vector<RequestStat> req_stats;
   // The statistics per client
   std::vector<ClientStat> client_stats;
+  std::atomic<uint64_t> max_resp_time_us;
+  std::atomic<uint64_t> min_resp_time_us;
 };
 
 enum ClientState { CLIENT_IDLE, CLIENT_CONNECTED };

--- a/src/h2load.h
+++ b/src/h2load.h
@@ -122,7 +122,7 @@ struct Config {
   // preference.
   std::vector<std::string> npn_list;
   // The number of request per second for each client.
-  double rps;
+  std::atomic<double> rps;
   uint64_t req_variable_start;
   uint64_t req_variable_end;
   std::string req_variable_name;
@@ -141,6 +141,7 @@ struct Config {
   std::vector<nghttp2_nv> update_nva;
   std::vector<nghttp2_nv> delete_nva;
   uint16_t stream_timeout_in_ms;
+  std::string rps_file;
 
   Config();
   ~Config();

--- a/src/h2load.h
+++ b/src/h2load.h
@@ -380,6 +380,7 @@ struct Client {
   // rps_watcher is a timer to invoke callback periodically to
   // generate a new request.
   ev_timer rps_watcher;
+  ev_timer stream_timeout_watcher;
   // The timestamp that starts the period which contributes to the
   // next request generation.
   ev_tstamp rps_duration_started;

--- a/src/h2load_http2_session.h
+++ b/src/h2load_http2_session.h
@@ -43,6 +43,7 @@ public:
   virtual int on_write();
   virtual void terminate();
   virtual size_t max_concurrent_streams();
+  virtual void submit_rst_stream(int32_t stream_id);
 
 private:
   Client *client_;

--- a/src/h2load_session.h
+++ b/src/h2load_session.h
@@ -52,6 +52,7 @@ public:
   virtual void terminate() = 0;
   // Return the maximum concurrency per connection
   virtual size_t max_concurrent_streams() = 0;
+  virtual void submit_rst_stream(int32_t stream_id) {};
 };
 
 } // namespace h2load


### PR DESCRIPTION
This request adds CRUD operation to h2load:

support varible in URI and data file, and replace it with a value in given range in config when send the request

monitor the response for a header matching given name from config, and find the valid uri from it

send read/update/delete to the uri found in step 2, with method for each operation type configurable

add stream timeout support, send RST_STREAM if no response comes in given interval (configurable)

print RPS and success rate every second

fix bug around --rps_req_inflight
