### PR TITLE
Fix segfault for for session shutdown

### DIFF
--- a/src/asio_client_session_impl.cc
+++ b/src/asio_client_session_impl.cc
@@ -577,7 +577,7 @@ const request *session_impl::submit(boost::system::error_code &ec,
 }
 
 void session_impl::shutdown() {
-  if (stopped_) {
+  if (session_ == nullptr || stopped_) {
     return;
   }
 


### PR DESCRIPTION
I would like to call shutdown() in the session on_error handler.
Sometimes it provides a crash because session_impl::session_  can be nullptr
I guess it will be more comfortable to check it inside the shutdown() call