### PR TITLE
src: prevent Coverity from reporting resource leak

### DIFF
--- a/src/HttpServer.cc
+++ b/src/HttpServer.cc
@@ -2053,6 +2053,7 @@ int start_listen(HttpServer *sv, struct ev_loop *loop, Sessions *sessions,
       if (!acceptor) {
         acceptor = std::make_shared<AcceptHandler>(sv, sessions, config);
       }
+      // coverity[leaked_storage]
       new ListenEventHandler(sessions, fd, acceptor);
 
       if (config->verbose) {


### PR DESCRIPTION
... on allocation of `ListenEventHandler`:
```
Error: RESOURCE_LEAK (CWE-772):
src/HttpServer.cc:2056: alloc_fn: Storage is returned from allocation function "operator new".
src/HttpServer.cc:2056: leaked_storage: Ignoring storage allocated by "new nghttp2::ListenEventHandler(sessions, fd, std::shared_ptr<nghttp2::AcceptHandler>(acceptor))" leaks it.
```