### PR TITLE
Add option to control TLS full handshake rate.

### DIFF
--- a/src/h2load.h
+++ b/src/h2load.h
@@ -104,6 +104,7 @@ struct Config {
   uint16_t default_port;
   uint16_t connect_to_port;
   bool verbose;
+  uint32_t full_handshake_rate;
   bool timing_script;
   std::string base_uri;
   // true if UNIX domain socket is used.  In this case, base_uri is


### PR DESCRIPTION
It can be useful to adjust the rate of TLS session resumption vs full TLS
handshakes during load testing.

This change adds support for setting TLS session handshake rate.