### PR TITLE
enable asio client to attach to an existing stream

### DIFF
--- a/src/asio_client_session.cc
+++ b/src/asio_client_session.cc
@@ -87,6 +87,18 @@ session::session(boost::asio::io_service &io_service,
   impl_->start_resolve(host, service);
 }
 
+session::session(boost::asio::io_service &io_service,
+                 std::shared_ptr<http_stream> stream)
+    : impl_(std::make_shared<session_tcp_impl>(io_service, stream)) {
+  impl_->attached();
+}
+
+session::session(boost::asio::io_service &io_service,
+                 std::shared_ptr<https_stream> stream)
+    : impl_(std::make_shared<session_tls_impl>(io_service, stream)) {
+  impl_->attached();
+}
+
 session::~session() {}
 
 session::session(session &&other) noexcept : impl_(std::move(other.impl_)) {}

--- a/src/asio_client_session_impl.h
+++ b/src/asio_client_session_impl.h
@@ -51,6 +51,7 @@ public:
 
   void connected(tcp::resolver::iterator endpoint_it);
   void not_connected(const boost::system::error_code &ec);
+  void attached();
 
   void on_connect(connect_cb cb);
   void on_error(error_cb cb);
@@ -99,6 +100,8 @@ public:
   void stop();
   bool stopped() const;
 
+  void call_error_cb(const boost::system::error_code &ec);
+
 protected:
   boost::array<uint8_t, 8_k> rb_;
   boost::array<uint8_t, 64_k> wb_;
@@ -107,7 +110,6 @@ protected:
 private:
   bool should_stop() const;
   bool setup_session();
-  void call_error_cb(const boost::system::error_code &ec);
   void handle_deadline();
   void start_ping();
   void handle_ping(const boost::system::error_code &ec);

--- a/src/asio_client_session_tcp_impl.h
+++ b/src/asio_client_session_tcp_impl.h
@@ -44,6 +44,9 @@ public:
                    const boost::asio::ip::tcp::endpoint &local_endpoint,
                    const std::string &host, const std::string &service,
                    const boost::posix_time::time_duration &connect_timeout);
+  session_tcp_impl(boost::asio::io_service &io_service,
+                   std::shared_ptr<tcp::socket> socket);
+
   virtual ~session_tcp_impl();
 
   virtual void start_connect(tcp::resolver::iterator endpoint_it);
@@ -57,7 +60,7 @@ public:
   virtual void shutdown_socket();
 
 private:
-  tcp::socket socket_;
+  std::shared_ptr<tcp::socket> socket_;
 };
 
 } // namespace client

--- a/src/asio_client_session_tls_impl.h
+++ b/src/asio_client_session_tls_impl.h
@@ -43,6 +43,9 @@ public:
                    boost::asio::ssl::context &tls_ctx, const std::string &host,
                    const std::string &service,
                    const boost::posix_time::time_duration &connect_timeout);
+  session_tls_impl(boost::asio::io_service &io_service,
+                   std::shared_ptr<ssl_socket> socket);
+
   virtual ~session_tls_impl();
 
   virtual void start_connect(tcp::resolver::iterator endpoint_it);
@@ -56,7 +59,7 @@ public:
   virtual void shutdown_socket();
 
 private:
-  ssl_socket socket_;
+  std::shared_ptr<ssl_socket> socket_;
 };
 
 } // namespace client

--- a/src/includes/nghttp2/asio_http2_client.h
+++ b/src/includes/nghttp2/asio_http2_client.h
@@ -26,6 +26,7 @@
 #define ASIO_HTTP2_CLIENT_H
 
 #include <nghttp2/asio_http2.h>
+#include <memory>
 
 namespace nghttp2 {
 
@@ -142,6 +143,9 @@ private:
 
 class session_impl;
 
+using http_stream = boost::asio::ip::tcp::socket;
+using https_stream = boost::asio::ssl::stream<http_stream>;
+
 class session {
 public:
   // Starts HTTP/2 session by connecting to |host| and |service|
@@ -182,6 +186,13 @@ public:
           boost::asio::ssl::context &tls_context, const std::string &host,
           const std::string &service,
           const boost::posix_time::time_duration &connect_timeout);
+
+  // Starts HTTP/2 session by attaching to a stream. The stream must out live
+  // the session.
+  session(boost::asio::io_service &io_service,
+          std::shared_ptr<http_stream> stream);
+  session(boost::asio::io_service &io_service,
+          std::shared_ptr<https_stream> stream);
 
   ~session();
 


### PR DESCRIPTION
The purpose of the change to asio client is to have the ability to attach to an existing stream. One use case is that caller can establish an tunnel through a proxy, then start http/2 over the tunnel.