### PR TITLE
Fix prototype mismatch for function 'file_read_callback'

### DIFF
--- a/src/HttpServer.h
+++ b/src/HttpServer.h
@@ -242,7 +242,7 @@ private:
 };
 
 ssize_t file_read_callback(nghttp2_session *session, int32_t stream_id,
-                           uint8_t *buf, size_t length, int *eof,
+                           uint8_t *buf, size_t length, uint32_t *data_flags,
                            nghttp2_data_source *source, void *user_data);
 
 } // namespace nghttp2


### PR DESCRIPTION
Summary:
The [data_flags](https://github.com/lhuang04/nghttp2/blob/master/src/HttpServer.cc#L1078) is defined as `uint32_t*` in definition, but delared as [int*](https://github.com/lhuang04/nghttp2/blob/master/src/HttpServer.h#L245) in the prototype.

```
stderr: error: no previous prototype for function 'file_read_callback' [-Werror,-Wmissing-prototypes]
ssize_t file_read_callback(nghttp2_session *session, int32_t stream_id,
        ^
```

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: