### PR TITLE
Getting server thread info before blocking loop

### DIFF
--- a/examples/asio-sv.cc
+++ b/examples/asio-sv.cc
@@ -42,6 +42,13 @@
 using namespace nghttp2::asio_http2;
 using namespace nghttp2::asio_http2::server;
 
+void all_threads_created_cb(
+    std::vector<std::shared_ptr<thread_info>> all_threads_info) {
+  for (auto thread_info : all_threads_info) {
+    std::cout << "thread pid: " << thread_info->pid << std::endl;
+  }
+}
+
 int main(int argc, char *argv[]) {
   try {
     // Check command line arguments.
@@ -61,6 +68,8 @@ int main(int argc, char *argv[]) {
     http2 server;
 
     server.num_threads(num_threads);
+
+    server.set_on_all_threads_created_callback(all_threads_created_cb);
 
     server.handle("/", [](const request &req, const response &res) {
       res.write_head(200, {{"foo", {"bar"}}});

--- a/examples/asio-sv.cc
+++ b/examples/asio-sv.cc
@@ -42,13 +42,6 @@
 using namespace nghttp2::asio_http2;
 using namespace nghttp2::asio_http2::server;
 
-void all_threads_created_cb(
-    std::vector<std::shared_ptr<thread_info>> all_threads_info) {
-  for (auto thread_info : all_threads_info) {
-    std::cout << "thread pid: " << thread_info->pid << std::endl;
-  }
-}
-
 int main(int argc, char *argv[]) {
   try {
     // Check command line arguments.
@@ -69,7 +62,12 @@ int main(int argc, char *argv[]) {
 
     server.num_threads(num_threads);
 
-    server.set_on_all_threads_created_callback(all_threads_created_cb);
+    server.set_on_all_threads_created_callback(
+        [](const auto &all_threads_info) {
+          for (auto &thread_info : all_threads_info) {
+            std::cout << "thread pid: " << thread_info->pid << std::endl;
+          }
+        });
 
     server.handle("/", [](const request &req, const response &res) {
       res.write_head(200, {{"foo", {"bar"}}});

--- a/src/asio_io_service_pool.h
+++ b/src/asio_io_service_pool.h
@@ -59,7 +59,8 @@ public:
   explicit io_service_pool(std::size_t pool_size);
 
   /// Run all io_service objects in the pool.
-  void run(bool asynchronous = false);
+  void run(bool asynchronous = false,
+           on_all_threads_created_cb all_threads_created_cb = nullptr);
 
   /// Stop all io_service objects in the pool.
   void force_stop();
@@ -87,8 +88,14 @@ private:
   /// The next io_service to use for a connection.
   std::size_t next_io_service_;
 
-  /// Futures to all the io_service objects
+  /// Futures to all the io_service objects.
   std::vector<std::future<std::size_t>> futures_;
+
+  /// Execute this function when new thread is created.
+  size_t io_thread_run(size_t index);
+
+  /// Hold the thread info for all io_services.
+  std::vector<std::shared_ptr<thread_info>> io_services_thread_info_;
 };
 
 } // namespace asio_http2

--- a/src/asio_server.cc
+++ b/src/asio_server.cc
@@ -71,7 +71,7 @@ server::listen_and_serve(boost::system::error_code &ec,
     }
   }
 
-  io_service_pool_.run(asynchronous, all_threads_created_cb);
+  io_service_pool_.run(asynchronous, std::move(all_threads_created_cb));
 
   return ec;
 }

--- a/src/asio_server.cc
+++ b/src/asio_server.cc
@@ -55,7 +55,8 @@ boost::system::error_code
 server::listen_and_serve(boost::system::error_code &ec,
                          boost::asio::ssl::context *tls_context,
                          const std::string &address, const std::string &port,
-                         int backlog, serve_mux &mux, bool asynchronous) {
+                         int backlog, serve_mux &mux, bool asynchronous,
+                         on_all_threads_created_cb all_threads_created_cb) {
   ec.clear();
 
   if (bind_and_listen(ec, address, port, backlog)) {
@@ -70,7 +71,7 @@ server::listen_and_serve(boost::system::error_code &ec,
     }
   }
 
-  io_service_pool_.run(asynchronous);
+  io_service_pool_.run(asynchronous, all_threads_created_cb);
 
   return ec;
 }

--- a/src/asio_server.h
+++ b/src/asio_server.h
@@ -71,7 +71,8 @@ public:
   listen_and_serve(boost::system::error_code &ec,
                    boost::asio::ssl::context *tls_context,
                    const std::string &address, const std::string &port,
-                   int backlog, serve_mux &mux, bool asynchronous = false);
+                   int backlog, serve_mux &mux, bool asynchronous = false,
+                   on_all_threads_created_cb all_threads_created_cb = nullptr);
   void join();
   void stop();
 

--- a/src/asio_server_http2.cc
+++ b/src/asio_server_http2.cc
@@ -69,6 +69,10 @@ void http2::num_threads(size_t num_threads) { impl_->num_threads(num_threads); }
 
 void http2::backlog(int backlog) { impl_->backlog(backlog); }
 
+void http2::set_on_all_threads_created_callback(on_all_threads_created_cb cb) {
+  impl_->set_on_all_threads_created_callback(cb);
+}
+
 void http2::tls_handshake_timeout(const boost::posix_time::time_duration &t) {
   impl_->tls_handshake_timeout(t);
 }

--- a/src/asio_server_http2_impl.cc
+++ b/src/asio_server_http2_impl.cc
@@ -59,7 +59,7 @@ void http2_impl::backlog(int backlog) { backlog_ = backlog; }
 
 void http2_impl::set_on_all_threads_created_callback(
     on_all_threads_created_cb cb) {
-  all_threads_created_cb_ = cb;
+  all_threads_created_cb_ = std::move(cb);
 }
 
 void http2_impl::tls_handshake_timeout(

--- a/src/asio_server_http2_impl.cc
+++ b/src/asio_server_http2_impl.cc
@@ -41,7 +41,8 @@ http2_impl::http2_impl()
     : num_threads_(1),
       backlog_(-1),
       tls_handshake_timeout_(boost::posix_time::seconds(60)),
-      read_timeout_(boost::posix_time::seconds(60)) {}
+      read_timeout_(boost::posix_time::seconds(60)),
+      all_threads_created_cb_(nullptr) {}
 
 boost::system::error_code http2_impl::listen_and_serve(
     boost::system::error_code &ec, boost::asio::ssl::context *tls_context,
@@ -49,12 +50,17 @@ boost::system::error_code http2_impl::listen_and_serve(
   server_.reset(
       new server(num_threads_, tls_handshake_timeout_, read_timeout_));
   return server_->listen_and_serve(ec, tls_context, address, port, backlog_,
-                                   mux_, asynchronous);
+                                   mux_, asynchronous, all_threads_created_cb_);
 }
 
 void http2_impl::num_threads(size_t num_threads) { num_threads_ = num_threads; }
 
 void http2_impl::backlog(int backlog) { backlog_ = backlog; }
+
+void http2_impl::set_on_all_threads_created_callback(
+    on_all_threads_created_cb cb) {
+  all_threads_created_cb_ = cb;
+}
 
 void http2_impl::tls_handshake_timeout(
     const boost::posix_time::time_duration &t) {

--- a/src/asio_server_http2_impl.h
+++ b/src/asio_server_http2_impl.h
@@ -47,6 +47,7 @@ public:
       const std::string &address, const std::string &port, bool asynchronous);
   void num_threads(size_t num_threads);
   void backlog(int backlog);
+  void set_on_all_threads_created_callback(on_all_threads_created_cb cb);
   void tls_handshake_timeout(const boost::posix_time::time_duration &t);
   void read_timeout(const boost::posix_time::time_duration &t);
   bool handle(std::string pattern, request_cb cb);
@@ -63,6 +64,7 @@ private:
   serve_mux mux_;
   boost::posix_time::time_duration tls_handshake_timeout_;
   boost::posix_time::time_duration read_timeout_;
+  on_all_threads_created_cb all_threads_created_cb_;
 };
 
 } // namespace server

--- a/src/includes/nghttp2/asio_http2.h
+++ b/src/includes/nghttp2/asio_http2.h
@@ -131,8 +131,6 @@ enum nghttp2_asio_error {
 
 struct thread_info {
   thread_info(pid_t id) : pid(id) {}
-  // Thread info is ready to be read.
-  bool ready;
   pid_t pid;
 };
 

--- a/src/includes/nghttp2/asio_http2.h
+++ b/src/includes/nghttp2/asio_http2.h
@@ -134,7 +134,7 @@ struct thread_info {
   pid_t pid;
 };
 
-typedef std::function<void(std::vector<std::shared_ptr<thread_info>>)>
+typedef std::function<void(const std::vector<std::shared_ptr<thread_info>> &)>
     on_all_threads_created_cb;
 
 } // namespace asio_http2

--- a/src/includes/nghttp2/asio_http2.h
+++ b/src/includes/nghttp2/asio_http2.h
@@ -31,6 +31,7 @@
 #include <vector>
 #include <functional>
 #include <map>
+#include <unistd.h>
 
 #include <boost/system/error_code.hpp>
 #include <boost/asio.hpp>
@@ -127,6 +128,16 @@ enum nghttp2_asio_error {
   NGHTTP2_ASIO_ERR_NO_ERROR = 0,
   NGHTTP2_ASIO_ERR_TLS_NO_APP_PROTO_NEGOTIATED = 1,
 };
+
+struct thread_info {
+  thread_info(pid_t id) : pid(id) {}
+  // Thread info is ready to be read.
+  bool ready;
+  pid_t pid;
+};
+
+typedef std::function<void(std::vector<std::shared_ptr<thread_info>>)>
+    on_all_threads_created_cb;
 
 } // namespace asio_http2
 

--- a/src/includes/nghttp2/asio_http2_server.h
+++ b/src/includes/nghttp2/asio_http2_server.h
@@ -198,8 +198,8 @@ public:
   // connections.
   void backlog(int backlog);
 
-  // Sets the callback to be executed after all threads
-  // of |num_threads| is created.
+  // Sets the callback to be executed after |num_threads|
+  // of threads is created.
   void set_on_all_threads_created_callback(on_all_threads_created_cb cb);
 
   // Sets TLS handshake timeout, which defaults to 60 seconds.

--- a/src/includes/nghttp2/asio_http2_server.h
+++ b/src/includes/nghttp2/asio_http2_server.h
@@ -198,6 +198,10 @@ public:
   // connections.
   void backlog(int backlog);
 
+  // Sets the callback to be executed after all threads
+  // of |num_threads| is created.
+  void set_on_all_threads_created_callback(on_all_threads_created_cb cb);
+
   // Sets TLS handshake timeout, which defaults to 60 seconds.
   void tls_handshake_timeout(const boost::posix_time::time_duration &t);
 


### PR DESCRIPTION
This PR is for providing an interface to get all threads info before the server enters blocking listen state.

A new thread_info structure is added to hold thread information(currently only pid):
```
struct thread_info {
  thread_info(pid_t id) : pid(id) {}
  pid_t pid;
};
```

Also, provide a method to set callback:
```
typedef std::function<void(const std::vector<std::shared_ptr<thread_info>> &)>
    on_all_threads_created_cb;

void set_on_all_threads_created_callback(on_all_threads_created_cb cb);
```
This callback is called after all threads are created,
with a vector of pointers to thread_info as argument.

note: If this callback is provided, io_service_pool wait until all threads ready:
```
  if (all_threads_created_cb) {
    // Wait until all thread created.
    while (1) {
      if (std::all_of(io_services_thread_info_.cbegin(),
                      io_services_thread_info_.cend(),
                      [](auto i) { return i && i != nullptr; })) {
        break;
      }
      usleep(10);
    }
    // Execute callback before blocking.
    all_threads_created_cb(io_services_thread_info_);
  }
```
 

Reference issue: #1606