### PR TITLE
chore: fix `-Wunreachable-code-return`

### DIFF
--- a/lib/nghttp2_submit.c
+++ b/lib/nghttp2_submit.c
@@ -492,8 +492,6 @@ int nghttp2_session_set_local_window_size(nghttp2_session *session,
     return nghttp2_session_update_recv_stream_window_size(session, stream, 0,
                                                           1);
   }
-
-  return 0;
 }
 
 int nghttp2_submit_altsvc(nghttp2_session *session, uint8_t flags,


### PR DESCRIPTION
This PR ameliorates a clang compilation error encountered by Electron:

```console
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_submit.c:496:10: error: 'return' will never be executed [-Werror,-Wunreachable-code-return]
  return 0;
         ^
1 error generated.
[23/153] ACTION //components/resources:about_credits(//build/toolchain/mac:clang_x64)
ninja: build stopped: subcommand failed.
ERROR Error: Command failed: ninja -j 200 electron
    at checkExecSyncError (node:child_process:707:11)
    at Object.execFileSync (node:child_process:726:15)
    at Object.depotExecFileSync [as execFileSync] (/Users/codebytere/build-tools/src/utils/depot-tools.js:119:16)
    at runNinja (/Users/codebytere/build-tools/src/e-build.js:84:9)
    at Object.<anonymous> (/Users/codebytere/build-tools/src/e-build.js:142:3)
    at Module._compile (node:internal/modules/cjs/loader:1109:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1138:10)
    at Module.load (node:internal/modules/cjs/loader:989:32)
    at Function.Module._load (node:internal/modules/cjs/loader:829:14)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:76:12)
```

by removing a return statement that will never be executed.