### PR TITLE
chore: fix -Wimplicit-fallthrough

### DIFF
--- a/lib/nghttp2_hd.c
+++ b/lib/nghttp2_hd.c
@@ -1891,7 +1891,7 @@ ssize_t nghttp2_hd_inflate_hd_nv(nghttp2_hd_inflater *inflater,
         rv = NGHTTP2_ERR_HEADER_COMP;
         goto fail;
       }
-    /* fall through */
+      __attribute__((fallthrough));
     case NGHTTP2_HD_STATE_INFLATE_START:
     case NGHTTP2_HD_STATE_OPCODE:
       if ((*in & 0xe0u) == 0x20u) {
@@ -2001,7 +2001,7 @@ ssize_t nghttp2_hd_inflate_hd_nv(nghttp2_hd_inflater *inflater,
       inflater->left = 0;
       inflater->shift = 0;
       DEBUGF("inflatehd: huffman encoded=%d\n", inflater->huffman_encoded != 0);
-    /* Fall through */
+      __attribute__((fallthrough));
     case NGHTTP2_HD_STATE_NEWNAME_READ_NAMELEN:
       rfin = 0;
       rv = hd_inflate_read_len(inflater, &rfin, in, last, 7, NGHTTP2_HD_MAX_NV);
@@ -2085,7 +2085,7 @@ ssize_t nghttp2_hd_inflate_hd_nv(nghttp2_hd_inflater *inflater,
       inflater->left = 0;
       inflater->shift = 0;
       DEBUGF("inflatehd: huffman encoded=%d\n", inflater->huffman_encoded != 0);
-    /* Fall through */
+      __attribute__((fallthrough));
     case NGHTTP2_HD_STATE_READ_VALUELEN:
       rfin = 0;
       rv = hd_inflate_read_len(inflater, &rfin, in, last, 7, NGHTTP2_HD_MAX_NV);

--- a/lib/nghttp2_session.c
+++ b/lib/nghttp2_session.c
@@ -2644,10 +2644,10 @@ static int session_after_frame_sent1(nghttp2_session *session) {
     case NGHTTP2_HCAT_PUSH_RESPONSE:
       stream->flags = (uint8_t)(stream->flags & ~NGHTTP2_STREAM_FLAG_PUSH);
       ++session->num_outgoing_streams;
-    /* Fall through */
+      __attribute__((fallthrough));
     case NGHTTP2_HCAT_RESPONSE:
       stream->state = NGHTTP2_STREAM_OPENED;
-    /* Fall through */
+      __attribute__((fallthrough));
     case NGHTTP2_HCAT_HEADERS:
       if (frame->hd.flags & NGHTTP2_FLAG_END_STREAM) {
         nghttp2_stream_shutdown(stream, NGHTTP2_SHUT_WR);
@@ -5456,7 +5456,7 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
 
       iframe->state = NGHTTP2_IB_READ_HEAD;
 
-    /* Fall through */
+      __attribute__((fallthrough));
     case NGHTTP2_IB_READ_HEAD: {
       int on_begin_frame_called = 0;
 


### PR DESCRIPTION
Fixes `-Wimplicit-fallthrough` clang compilation errors encountered when building Electron and pulling in `nghttp2` as a dependency via Node.js.

```console
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_hd.c:1895:5: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
    case NGHTTP2_HD_STATE_INFLATE_START:
    ^
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_hd.c:1895:5: note: insert '__attribute__((fallthrough));' to silence this warning
    case NGHTTP2_HD_STATE_INFLATE_START:
    ^
    __attribute__((fallthrough));
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_hd.c:1895:5: note: insert 'break;' to avoid fall-through
    case NGHTTP2_HD_STATE_INFLATE_START:
    ^
    break;
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_hd.c:2005:5: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
    case NGHTTP2_HD_STATE_NEWNAME_READ_NAMELEN:
    ^
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_hd.c:2005:5: note: insert '__attribute__((fallthrough));' to silence this warning
    case NGHTTP2_HD_STATE_NEWNAME_READ_NAMELEN:
    ^
    __attribute__((fallthrough));
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_hd.c:2005:5: note: insert 'break;' to avoid fall-through
    case NGHTTP2_HD_STATE_NEWNAME_READ_NAMELEN:
    ^
    break;
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_hd.c:2089:5: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
    case NGHTTP2_HD_STATE_READ_VALUELEN:
    ^
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_hd.c:2089:5: note: insert '__attribute__((fallthrough));' to silence this warning
    case NGHTTP2_HD_STATE_READ_VALUELEN:
    ^
    __attribute__((fallthrough));
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_hd.c:2089:5: note: insert 'break;' to avoid fall-through
    case NGHTTP2_HD_STATE_READ_VALUELEN:
    ^
    break;
3 errors generated.
[2/24] CC obj/third_party/electron_node/deps/nghttp2/nghttp2/nghttp2_session.o
ninja: build stopped: subcommand failed.
ERROR Error: Command failed: ninja -j 200 electron
    at checkExecSyncError (node:child_process:707:11)
    at Object.execFileSync (node:child_process:726:15)
    at Object.depotExecFileSync [as execFileSync] (/Users/codebytere/build-tools/src/utils/depot-tools.js:119:16)
    at runNinja (/Users/codebytere/build-tools/src/e-build.js:84:9)
    at Object.<anonymous> (/Users/codebytere/build-tools/src/e-build.js:142:3)
    at Module._compile (node:internal/modules/cjs/loader:1109:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1138:10)
    at Module.load (node:internal/modules/cjs/loader:989:32)
    at Function.Module._load (node:internal/modules/cjs/loader:829:14)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:76:12)
```

which is fixed by adding the explicit fallthrough attribute. Please let me know if you all would prefer a different solution to this issue!