### PR TITLE
asio_http2: provide access to local server endpoints

### DIFF
--- a/src/asio_server.cc
+++ b/src/asio_server.cc
@@ -209,6 +209,15 @@ const std::vector<int> server::ports() const {
   return ports;
 }
 
+const std::vector<boost::asio::ip::tcp::endpoint> server::endpoints() const {
+  std::vector<boost::asio::ip::tcp::endpoint> ports;
+  ports.reserve(acceptors_.size());
+  for (const auto &acceptor : acceptors_) {
+    ports.emplace_back(acceptor.local_endpoint());
+  }
+  return ports;
+}
+
 } // namespace server
 } // namespace asio_http2
 } // namespace nghttp2

--- a/src/asio_server.h
+++ b/src/asio_server.h
@@ -81,6 +81,8 @@ public:
 
   /// Returns a vector with all the acceptors ports in use.
   const std::vector<int> ports() const;
+  /// Returns a vector with all the acceptors endpoints.
+  const std::vector<boost::asio::ip::tcp::endpoint> endpoints() const;
 
 private:
   /// Initiate an asynchronous accept operation.

--- a/src/asio_server_http2.cc
+++ b/src/asio_server_http2.cc
@@ -92,6 +92,8 @@ http2::io_services() const {
 
 std::vector<int> http2::ports() const { return impl_->ports(); }
 
+std::vector<boost::asio::ip::tcp::endpoint> http2::endpoints() const { return impl_->endpoints(); }
+
 } // namespace server
 
 } // namespace asio_http2

--- a/src/asio_server_http2_impl.cc
+++ b/src/asio_server_http2_impl.cc
@@ -80,6 +80,8 @@ http2_impl::io_services() const {
 
 std::vector<int> http2_impl::ports() const { return server_->ports(); }
 
+std::vector<boost::asio::ip::tcp::endpoint> http2_impl::endpoints() const { return server_->endpoints(); }
+
 } // namespace server
 
 } // namespace asio_http2

--- a/src/asio_server_http2_impl.h
+++ b/src/asio_server_http2_impl.h
@@ -55,6 +55,7 @@ public:
   const std::vector<std::shared_ptr<boost::asio::io_service>> &
   io_services() const;
   std::vector<int> ports() const;
+  std::vector<boost::asio::ip::tcp::endpoint> endpoints() const;
 
 private:
   std::unique_ptr<server> server_;

--- a/src/includes/nghttp2/asio_http2_server.h
+++ b/src/includes/nghttp2/asio_http2_server.h
@@ -217,6 +217,9 @@ public:
   // Returns a vector with the ports in use
   std::vector<int> ports() const;
 
+  // Returns a vector of the endpoints in use
+  std::vector<boost::asio::ip::tcp::endpoint> endpoints() const;
+
 private:
   std::unique_ptr<http2_impl> impl_;
 };


### PR DESCRIPTION
with commit https://github.com/nghttp2/nghttp2/commit/6800d317e7838bdfb17b2f9bfca20d3ed4331ee8, support for retrieving the local endpoint port numbers was added. When starting the server with a port number of 0, the operating system will chose a free port on its own. This is useful in testcases, for example.

However, just returning the port numbers is not enough: By default, when starting the server with a bind address of "" and a port number of 0, two endpoints are created, for IPv4 and IPv6. These might be "127.0.0.1:12345" and "[::1]:56789". Yes, they may have different port numbers.

Now we can already retrieve the port numbers, but there is no way to find out which port number belongs to what endpoint. So, when trying to connect to one of those, a client doesn't know whether to use "127.0.0.1" or "[::1]" as localhost address. (again, this is useful in testcases)

The solution is to provide access to the complete endpoint information, not only the port numbers.