### PR TITLE
shrpx: make nghttpx -v show ngtcp2 and nghttp3 version as well

### DIFF
--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -2053,7 +2053,12 @@ void fill_default_config(Config *config) {
 
 namespace {
 void print_version(std::ostream &out) {
-  out << "nghttpx nghttp2/" NGHTTP2_VERSION << std::endl;
+  out << "nghttpx nghttp2/" NGHTTP2_VERSION
+#ifdef ENABLE_HTTP3
+    " ngtcp2/" NGTCP2_VERSION
+    " nghttp3/" NGHTTP3_VERSION
+#endif
+      << std::endl;
 }
 } // namespace
 


### PR DESCRIPTION
... if HTTP/3 support is built in.