### PR TITLE
python3: add condition to check is NPN extension is enable

### DIFF
--- a/python/nghttp2.pyx
+++ b/python/nghttp2.pyx
@@ -310,9 +310,12 @@ def negotiated_protocol(ssl_obj):
 
 def set_application_protocol(ssl_ctx):
     app_protos = [cnghttp2.NGHTTP2_PROTO_VERSION_ID.decode('utf-8')]
-    ssl_ctx.set_npn_protocols(app_protos)
-    if tls.HAS_ALPN:
+    if tls.HAS_NPN:
+        ssl_ctx.set_npn_protocols(app_protos)
+    elif tls.HAS_ALPN:
         ssl_ctx.set_alpn_protocols(app_protos)
+    else:
+        raise Exception('nghttp2_set_application_protocol: NPM or ALPN extension required')
 
 cdef _get_stream_user_data(cnghttp2.nghttp2_session *session,
                            int32_t stream_id):


### PR DESCRIPTION
If python3 build without NPN extension, nghttp2.HTTP2Server call failed with error: `NotImplementedError: The NPN extension requires OpenSSL 1.0.1 or later.`

Environment:

        # openssl version
        OpenSSL 1.1.1k  25 Mar 2021

        # python3
        Python 3.9.7 (default, Oct 13 2021, 09:00:49) 
        [GCC 10.2.1 20210110] on linux
        Type "help", "copyright", "credits" or "license" for more information.
        >>> import ssl
        >>> ssl.HAS_NPN
        False
        >>> ssl.HAS_ALPN
        True

Example script:

        #!/usr/bin/env python3
        
        import io, ssl
        
        import nghttp2
        
        class Handler(nghttp2.BaseRequestHandler):
        
            def on_headers(self):
                self.push(path='/css/style.css',
                          request_headers = [('content-type', 'text/css')],
                          status=200,
                          body='body{margin:0;}')
        
                self.send_response(status=200,
                                   headers = [('content-type', 'text/plain')],
                                   body=io.BytesIO(b'nghttp2-python FTW'))
        
        ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
        ctx.options = ssl.OP_ALL | ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3
        ctx.load_cert_chain('test.devel.crt', 'test.devel.key')
        
        # give None to ssl to make the server non-SSL/TLS
        server = nghttp2.HTTP2Server(('0.0.0.0', 8443), Handler, ssl=ctx)
        server.serve_forever()

Failed with error:

        # ./test.py 
        Traceback (most recent call last):
          File "/opt/git/ssl/./test.py", line 24, in <module>
            server = nghttp2.HTTP2Server(('0.0.0.0', 8443), Handler, ssl=ctx)
          File "nghttp2.pyx", line 1371, in nghttp2.HTTP2Server.__init__
          File "nghttp2.pyx", line 313, in nghttp2.set_application_protocol
          File "/usr/local/lib/python3.9/ssl.py", line 529, in set_npn_protocols
            self._set_npn_protocols(protos)
        NotImplementedError: The NPN extension requires OpenSSL 1.0.1 or later.

This commit add condition to check is NPN extension is enable