### PR TITLE
allow setting max frame size for h2load

### DIFF
--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -106,6 +106,7 @@ Config::Config()
       max_concurrent_streams(1),
       window_bits(30),
       connection_window_bits(30),
+      max_frame_size(-1),
       rate(0),
       rate_period(1.0),
       duration(0.0),
@@ -2109,6 +2110,9 @@ Options:
               http/1.1  is used,  this  specifies the  number of  HTTP
               pipelining requests in-flight.
               Default: 1
+  -f, --max-frame-size=<SIZE>
+              Maximum frame size.
+              Default: 16k
   -w, --window-bits=<N>
               Sets the stream level initial window size to (2**<N>)-1.
               For QUIC, <N> is capped to 26 (roughly 64MiB).
@@ -2301,6 +2305,7 @@ int main(int argc, char **argv) {
         {"threads", required_argument, nullptr, 't'},
         {"max-concurrent-streams", required_argument, nullptr, 'm'},
         {"window-bits", required_argument, nullptr, 'w'},
+        {"max-frame-size", required_argument, nullptr, 'f'},
         {"connection-window-bits", required_argument, nullptr, 'W'},
         {"input-file", required_argument, nullptr, 'i'},
         {"header", required_argument, nullptr, 'H'},
@@ -2332,7 +2337,7 @@ int main(int argc, char **argv) {
         {nullptr, 0, nullptr, 0}};
     int option_index = 0;
     auto c = getopt_long(argc, argv,
-                         "hvW:c:d:m:n:p:t:w:H:i:r:T:N:D:B:", long_options,
+                         "hvW:c:d:m:n:p:t:w:f:H:i:r:T:N:D:B:", long_options,
                          &option_index);
     if (c == -1) {
       break;
@@ -2376,6 +2381,26 @@ int main(int argc, char **argv) {
                   << std::endl;
         exit(EXIT_FAILURE);
       }
+      break;
+    }
+    case 'f': {
+      auto n = util::parse_uint_with_unit(optarg);
+      if (n == -1) {
+        std::cerr << "--max-frame-size: bad option value: " << optarg
+                  << std::endl;
+        exit(EXIT_FAILURE);
+      }
+      if (static_cast<uint64_t>(n) < 16_k) {
+        std::cerr << "--max-frame-size: minimum 16k"
+                  << std::endl;
+        exit(EXIT_FAILURE);
+      }
+      if (static_cast<uint64_t>(n) > 16_m) {
+        std::cerr << "--max-frame-size: maximum 16M"
+                  << std::endl;
+        exit(EXIT_FAILURE);
+      }
+      config.max_frame_size = n;
       break;
     }
     case 'H': {

--- a/src/h2load.h
+++ b/src/h2load.h
@@ -95,6 +95,7 @@ struct Config {
   ssize_t max_concurrent_streams;
   size_t window_bits;
   size_t connection_window_bits;
+  size_t max_frame_size;
   // rate at which connections should be made
   size_t rate;
   ev_tstamp rate_period;

--- a/src/h2load_http2_session.cc
+++ b/src/h2load_http2_session.cc
@@ -215,7 +215,7 @@ void Http2Session::on_connect() {
 
   nghttp2_option_del(opt);
 
-  std::array<nghttp2_settings_entry, 3> iv;
+  std::array<nghttp2_settings_entry, 4> iv;
   size_t niv = 2;
   iv[0].settings_id = NGHTTP2_SETTINGS_ENABLE_PUSH;
   iv[0].value = 0;
@@ -225,6 +225,11 @@ void Http2Session::on_connect() {
   if (config->header_table_size != NGHTTP2_DEFAULT_HEADER_TABLE_SIZE) {
     iv[niv].settings_id = NGHTTP2_SETTINGS_HEADER_TABLE_SIZE;
     iv[niv].value = config->header_table_size;
+    ++niv;
+  }
+  if (config->max_frame_size != -1) {
+    iv[niv].settings_id = NGHTTP2_SETTINGS_MAX_FRAME_SIZE;
+    iv[niv].value = config->max_frame_size;
     ++niv;
   }
 


### PR DESCRIPTION
The http2 spec allows for clients to set the max frame size. This is essential for high-speed high-throughput downloads.

Fixes issue #1639.