### PR TITLE
fix quotes in --altsvc example

### DIFF
--- a/doc/nghttpx.1
+++ b/doc/nghttpx.1
@@ -1517,7 +1517,7 @@ they  are treated  as  nothing is  specified.  They  are
 advertised  in alt\-svc  header  field  only in  HTTP/1.1
 frontend.   This option  can be  used multiple  times to
 specify multiple alternative services.
-Example: \fI\%\-\-altsvc\fP="h2,443,,,ma=3600; persist=1\(aq
+Example: \fI\%\-\-altsvc\fP="h2,443,,,ma=3600; persist=1"
 .UNINDENT
 .INDENT 0.0
 .TP

--- a/doc/nghttpx.1.rst
+++ b/doc/nghttpx.1.rst
@@ -1376,7 +1376,7 @@ HTTP
     advertised  in alt-svc  header  field  only in  HTTP/1.1
     frontend.   This option  can be  used multiple  times to
     specify multiple alternative services.
-    Example: :option:`--altsvc`\="h2,443,,,ma=3600; persist=1'
+    Example: :option:`--altsvc`\="h2,443,,,ma=3600; persist=1"
 
 .. option:: --http2-altsvc=<PROTOID,PORT[,HOST,[ORIGIN[,PARAMS]]]>
 

--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -3174,7 +3174,7 @@ HTTP:
               advertised  in alt-svc  header  field  only in  HTTP/1.1
               frontend.   This option  can be  used multiple  times to
               specify multiple alternative services.
-              Example: --altsvc="h2,443,,,ma=3600; persist=1'
+              Example: --altsvc="h2,443,,,ma=3600; persist=1"
   --http2-altsvc=<PROTOID,PORT[,HOST,[ORIGIN[,PARAMS]]]>
               Just like --altsvc option, but  this altsvc is only sent
               in HTTP/2 frontend.


### PR DESCRIPTION
Thank you so much for the wonderful project.

I just corrected --altsvc example: `"...'` → `"..."`.