### PR TITLE
Make Docker speak HTTP/3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,6 +66,9 @@ RUN git clone --depth 1 https://github.com/nghttp2/nghttp2.git && \
 FROM gcr.io/distroless/base-debian11
 
 COPY --from=build \
+    /usr/local/share/nghttp2/ \
+    /usr/local/share/nghttp2/
+COPY --from=build \
     /usr/local/bin/h2load \
     /usr/local/bin/nghttpx \
     /usr/local/bin/nghttp \


### PR DESCRIPTION
Thank you so much for the wonderful project!

## Problem

I found the Dockerfile emits a warning below and can not speak HTTP/3.

```
2021-12-12T14:02:21.285Z 1 1 4ca9edca WARN (shrpx.cc:3658) --fetch-ocsp-response-file: /usr/local/share/nghttp2/fetch-ocsp-response not found.  OCSP stapling has been disabled.
...
```

So, the PR copies `/usr/local/share/nghttp2/`.

## Operation verification

I did docker-build the fixed Dockerfile as `nghttp2` image and docker-run as follows. Suppose an HTTP server is running on localhost:80.

```bash
 docker run --rm -it -v /etc/letsencrypt/live/ex.nwtgck.org/privkey.pem:/shared/server.key -v /etc/letsencrypt/live/ex.nwtgck.org/fullchain.pem:/shared/server.crt --net=host --privileged nghttp2 nghttpx --add-response-header='alt-svc: h3=":8443"; ma=3600, h3-29=":8443"; ma=3600' /shared/server.key /shared/server.crt -f '*,8443' -f '*,8443;quic' -b localhost,80 --rlimit-memlock 524288
```

I confirmed it speaks HTTP/3.

<img width="683" alt="image" src="https://user-images.githubusercontent.com/10933561/145716154-31b7f522-620a-4113-8180-c120d2192199.png">
