### PR TITLE
FIX_BEFORE_MERGE: stream can get stuck when SETTINGS_INITIAL_WINDOW_SIZE lowers window size

### DIFF
--- a/lib/nghttp2_session.c
+++ b/lib/nghttp2_session.c
@@ -4259,8 +4259,7 @@ static int update_local_initial_window_size_func(void *entry, void *ptr) {
     return nghttp2_session_add_rst_stream(arg->session, stream->stream_id,
                                           NGHTTP2_FLOW_CONTROL_ERROR);
   }
-  if (!(arg->session->opt_flags & NGHTTP2_OPTMASK_NO_AUTO_WINDOW_UPDATE) &&
-      stream->window_update_queued == 0 &&
+  if (stream->window_update_queued == 0 &&
       nghttp2_should_send_window_update(stream->local_window_size,
                                         stream->recv_window_size)) {
 

--- a/tests/main.c
+++ b/tests/main.c
@@ -196,6 +196,8 @@ int main(void) {
                    test_nghttp2_submit_settings) ||
       !CU_add_test(pSuite, "session_submit_settings_update_local_window_size",
                    test_nghttp2_submit_settings_update_local_window_size) ||
+      !CU_add_test(pSuite, "test_nghttp2_submit_settings_update_local_window_size_before_initial_settings_ack",
+                   test_nghttp2_submit_settings_update_local_window_size_before_initial_settings_ack) ||
       !CU_add_test(pSuite, "session_submit_settings_multiple_times",
                    test_nghttp2_submit_settings_multiple_times) ||
       !CU_add_test(pSuite, "session_submit_push_promise",

--- a/tests/nghttp2_session_test.h
+++ b/tests/nghttp2_session_test.h
@@ -94,6 +94,7 @@ void test_nghttp2_submit_headers_continuation_extra_large(void);
 void test_nghttp2_submit_priority(void);
 void test_nghttp2_submit_settings(void);
 void test_nghttp2_submit_settings_update_local_window_size(void);
+void test_nghttp2_submit_settings_update_local_window_size_before_initial_settings_ack(void);
 void test_nghttp2_submit_settings_multiple_times(void);
 void test_nghttp2_submit_push_promise(void);
 void test_nghttp2_submit_window_update(void);


### PR DESCRIPTION
I am hitting this in my unit tests where I lower Initial window size.

Client connects to server. Server operating in manual window update mode sends SETTINGS. Client sends request headers and a bunch of data that does not yet require WINDOW_UPDATE to be sent. Client sends SETTINGS ACK; this applies new settings. This makes window completely full for the client; however server does not check nghttp2_should_send_window_update from within nghttp2_session_update_local_settings. This leads to stream being stuck.

The testcase included emulates what was described above; it is perhaps too complicated.

CAUTION: this fix breaks 
  Test: session_submit_settings_update_local_window_size ...FAILED
    1. .../nghttp2_session_test.c:5800  - 32768 == stream->recv_window_size
    2. .../nghttp2_session_test.c:5804  - 0 == nghttp2_session_get_stream_local_window_size(session, 1)
This needs to be fixed somehow...