### PR TITLE
Fix stream stall when initial window size is decreased

### DIFF
--- a/lib/nghttp2_session.c
+++ b/lib/nghttp2_session.c
@@ -4259,9 +4259,16 @@ static int update_local_initial_window_size_func(void *entry, void *ptr) {
     return nghttp2_session_add_rst_stream(arg->session, stream->stream_id,
                                           NGHTTP2_FLOW_CONTROL_ERROR);
   }
-  if (!(arg->session->opt_flags & NGHTTP2_OPTMASK_NO_AUTO_WINDOW_UPDATE) &&
-      stream->window_update_queued == 0 &&
-      nghttp2_should_send_window_update(stream->local_window_size,
+
+  if (stream->window_update_queued) {
+    return 0;
+  }
+
+  if (arg->session->opt_flags & NGHTTP2_OPTMASK_NO_AUTO_WINDOW_UPDATE) {
+    return session_update_stream_consumed_size(arg->session, stream, 0);
+  }
+
+  if (nghttp2_should_send_window_update(stream->local_window_size,
                                         stream->recv_window_size)) {
 
     rv = nghttp2_session_add_window_update(arg->session, NGHTTP2_FLAG_NONE,


### PR DESCRIPTION
Fix the bug that causes a stream to stall when a receiver, which
enables nghttp2_option_set_no_auto_window_update() option on, sends
SETTINGS_INITIAL_WINDOW_SIZE with the value that is less than or equal
to the amount of data received.  Previously, in this particular case,
when SETTINGS is acknowledged by the sender, the receiver does not try
to send WINDOW_UPDATE frame.  The sender is unable to send more data
because its stream-level window size is smaller than or equal to the
amount of data it has sent.

Fixes #1679 