### PR TITLE
nghttpx: Fix broken session affinity

### DIFF
--- a/src/shrpx_worker.cc
+++ b/src/shrpx_worker.cc
@@ -333,9 +333,6 @@ void Worker::replace_downstream_config(
     auto it = addr_groups_indexer.find(dkey);
 
     if (it == std::end(addr_groups_indexer)) {
-      std::shuffle(std::begin(shared_addr->addrs), std::end(shared_addr->addrs),
-                   randgen_);
-
       auto shared_addr_ptr = shared_addr.get();
 
       for (auto &addr : shared_addr->addrs) {


### PR DESCRIPTION
Session affinity has been broken since
fdcdb21c38ef7acf23853d47d1dc5bda69d5398f.  This commit reverts the
relevant part of the commit to fix the session affinity.

