### PR TITLE
Do not verify host field specific characters for response field

### DIFF
--- a/lib/nghttp2_http.c
+++ b/lib/nghttp2_http.c
@@ -369,7 +369,11 @@ int nghttp2_http_on_header(nghttp2_session *session, nghttp2_stream *stream,
     break;
   case NGHTTP2_TOKEN__AUTHORITY:
   case NGHTTP2_TOKEN_HOST:
-    rv = nghttp2_check_authority(nv->value->base, nv->value->len);
+    if (session->server || frame->hd.type == NGHTTP2_PUSH_PROMISE) {
+      rv = nghttp2_check_authority(nv->value->base, nv->value->len);
+    } else {
+      rv = nghttp2_check_header_value(nv->value->base, nv->value->len);
+    }
     break;
   case NGHTTP2_TOKEN__SCHEME:
     rv = check_scheme(nv->value->base, nv->value->len);

--- a/tests/nghttp2_session_test.c
+++ b/tests/nghttp2_session_test.c
@@ -11227,6 +11227,8 @@ void test_nghttp2_http_mandatory_headers(void) {
   const nghttp2_nv clnonzero204_resnv[] = {MAKE_NV(":status", "204"),
                                            MAKE_NV("content-length", "100")};
   const nghttp2_nv status101_resnv[] = {MAKE_NV(":status", "101")};
+  const nghttp2_nv unexpectedhost_resnv[] = {MAKE_NV(":status", "200"),
+                                             MAKE_NV("host", "/localhost")};
 
   /* test case for request */
   const nghttp2_nv nopath_reqnv[] = {MAKE_NV(":scheme", "https"),
@@ -11363,6 +11365,12 @@ void test_nghttp2_http_mandatory_headers(void) {
   check_nghttp2_http_recv_headers_fail(session, &deflater, 23,
                                        NGHTTP2_STREAM_OPENING, status101_resnv,
                                        ARRLEN(status101_resnv));
+
+  /* Specific characters check for host field in response header
+     should not be done as its use is undefined. */
+  check_nghttp2_http_recv_headers_ok(
+      session, &deflater, 25, NGHTTP2_STREAM_OPENING, unexpectedhost_resnv,
+      ARRLEN(unexpectedhost_resnv));
 
   nghttp2_hd_deflate_free(&deflater);
 


### PR DESCRIPTION
Do not verify host field specific characters for response field
section because host field in response field section is undefined.

Fixes #1726 