### PR TITLE
Add a server option to fallback to RFC 7540 priorities

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -69,6 +69,7 @@ APIDOCS= \
 	nghttp2_option_set_no_http_messaging.rst \
 	nghttp2_option_set_no_recv_client_magic.rst \
 	nghttp2_option_set_peer_max_concurrent_streams.rst \
+	nghttp2_option_set_server_fallback_rfc7540_priorities.rst \
 	nghttp2_option_set_user_recv_extension_type.rst \
 	nghttp2_option_set_max_outbound_ack.rst \
 	nghttp2_option_set_max_settings.rst \

--- a/lib/includes/nghttp2/nghttp2.h
+++ b/lib/includes/nghttp2/nghttp2.h
@@ -2735,6 +2735,24 @@ NGHTTP2_EXTERN void nghttp2_option_set_max_settings(nghttp2_option *option,
 /**
  * @function
  *
+ * This option, if set to nonzero, allows server to fallback to
+ * :rfc:`7540` priorities if SETTINGS_NO_RFC7540_PRIORITIES was not
+ * received from client, and server submitted
+ * :enum:`nghttp2_settings_id.NGHTTP2_SETTINGS_NO_RFC7540_PRIORITIES`
+ * = 1 via `nghttp2_submit_settings()`.  Most of the advanced
+ * functionality for RFC 7540 priorities are still disabled.  This
+ * fallback only enables the minimal feature set of RFC 7540
+ * priorities to deal with priority signaling from client.
+ *
+ * Client session ignores this option.
+ */
+NGHTTP2_EXTERN void
+nghttp2_option_set_server_fallback_rfc7540_priorities(nghttp2_option *option,
+                                                      int val);
+
+/**
+ * @function
+ *
  * Initializes |*session_ptr| for client use.  The all members of
  * |callbacks| are copied to |*session_ptr|.  Therefore |*session_ptr|
  * does not store |callbacks|.  The |user_data| is an arbitrary user

--- a/lib/nghttp2_option.c
+++ b/lib/nghttp2_option.c
@@ -130,3 +130,9 @@ void nghttp2_option_set_max_settings(nghttp2_option *option, size_t val) {
   option->opt_set_mask |= NGHTTP2_OPT_MAX_SETTINGS;
   option->max_settings = val;
 }
+
+void nghttp2_option_set_server_fallback_rfc7540_priorities(
+    nghttp2_option *option, int val) {
+  option->opt_set_mask |= NGHTTP2_OPT_SERVER_FALLBACK_RFC7540_PRIORITIES;
+  option->server_fallback_rfc7540_priorities = val;
+}

--- a/lib/nghttp2_option.h
+++ b/lib/nghttp2_option.h
@@ -68,6 +68,7 @@ typedef enum {
   NGHTTP2_OPT_NO_CLOSED_STREAMS = 1 << 10,
   NGHTTP2_OPT_MAX_OUTBOUND_ACK = 1 << 11,
   NGHTTP2_OPT_MAX_SETTINGS = 1 << 12,
+  NGHTTP2_OPT_SERVER_FALLBACK_RFC7540_PRIORITIES = 1 << 13,
 } nghttp2_option_flag;
 
 /**
@@ -127,6 +128,10 @@ struct nghttp2_option {
    * NGHTTP2_OPT_NO_CLOSED_STREAMS
    */
   int no_closed_streams;
+  /**
+   * NGHTTP2_OPT_SERVER_FALLBACK_RFC7540_PRIORITIES
+   */
+  int server_fallback_rfc7540_priorities;
   /**
    * NGHTTP2_OPT_USER_RECV_EXT_TYPES
    */

--- a/lib/nghttp2_session.h
+++ b/lib/nghttp2_session.h
@@ -52,7 +52,8 @@ typedef enum {
   NGHTTP2_OPTMASK_NO_RECV_CLIENT_MAGIC = 1 << 1,
   NGHTTP2_OPTMASK_NO_HTTP_MESSAGING = 1 << 2,
   NGHTTP2_OPTMASK_NO_AUTO_PING_ACK = 1 << 3,
-  NGHTTP2_OPTMASK_NO_CLOSED_STREAMS = 1 << 4
+  NGHTTP2_OPTMASK_NO_CLOSED_STREAMS = 1 << 4,
+  NGHTTP2_OPTMASK_SERVER_FALLBACK_RFC7540_PRIORITIES = 1 << 5
 } nghttp2_optmask;
 
 /*
@@ -340,6 +341,8 @@ struct nghttp2_session {
   /* Unacked local SETTINGS_NO_RFC7540_PRIORITIES value, which is
      effective before it is acknowledged. */
   uint8_t pending_no_rfc7540_priorities;
+  /* Turn on fallback to RFC 7540 priorities; for server use only. */
+  uint8_t fallback_rfc7540_priorities;
   /* Nonzero if the session is server side. */
   uint8_t server;
   /* Flags indicating GOAWAY is sent and/or received. The flags are

--- a/tests/main.c
+++ b/tests/main.c
@@ -339,6 +339,8 @@ int main(void) {
                    test_nghttp2_session_set_stream_user_data) ||
       !CU_add_test(pSuite, "session_no_rfc7540_priorities",
                    test_nghttp2_session_no_rfc7540_priorities) ||
+      !CU_add_test(pSuite, "session_server_fallback_rfc7540_priorities",
+                   test_nghttp2_session_server_fallback_rfc7540_priorities) ||
       !CU_add_test(pSuite, "http_mandatory_headers",
                    test_nghttp2_http_mandatory_headers) ||
       !CU_add_test(pSuite, "http_content_length",

--- a/tests/nghttp2_session_test.h
+++ b/tests/nghttp2_session_test.h
@@ -166,6 +166,7 @@ void test_nghttp2_session_pause_data(void);
 void test_nghttp2_session_no_closed_streams(void);
 void test_nghttp2_session_set_stream_user_data(void);
 void test_nghttp2_session_no_rfc7540_priorities(void);
+void test_nghttp2_session_server_fallback_rfc7540_priorities(void);
 void test_nghttp2_http_mandatory_headers(void);
 void test_nghttp2_http_content_length(void);
 void test_nghttp2_http_content_length_mismatch(void);


### PR DESCRIPTION
Add nghttp2_option_set_server_fallback_rfc7540_priorities.  If it is
set to nonzero, and server submits SETTINGS_NO_RFC7540_PRIORITIES = 1,
but it does not receive SETTINGS_NO_RFC7540_PRIORITIES from client,
server falls back to RFC 7540 priorities.  Only minimal set of
features are enabled in this fallback case.