### PR TITLE
nghttpx: Disable RFC 7540 priorities

### DIFF
--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -1911,6 +1911,10 @@ void fill_default_config(Config *config) {
     nghttp2_option_set_no_recv_client_magic(upstreamconf.option, 1);
     nghttp2_option_set_max_deflate_dynamic_table_size(
         upstreamconf.option, upstreamconf.encoder_dynamic_table_size);
+    nghttp2_option_set_server_fallback_rfc7540_priorities(upstreamconf.option,
+                                                          1);
+    nghttp2_option_set_builtin_recv_extension_type(upstreamconf.option,
+                                                   NGHTTP2_PRIORITY_UPDATE);
 
     // For API endpoint, we enable automatic window update.  This is
     // because we are a sink.

--- a/src/shrpx_http2_session.cc
+++ b/src/shrpx_http2_session.cc
@@ -1693,13 +1693,16 @@ int Http2Session::connection_made() {
     return -1;
   }
 
-  std::array<nghttp2_settings_entry, 4> entry;
-  size_t nentry = 2;
+  std::array<nghttp2_settings_entry, 5> entry;
+  size_t nentry = 3;
   entry[0].settings_id = NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS;
   entry[0].value = http2conf.downstream.max_concurrent_streams;
 
   entry[1].settings_id = NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE;
   entry[1].value = http2conf.downstream.window_size;
+
+  entry[2].settings_id = NGHTTP2_SETTINGS_NO_RFC7540_PRIORITIES;
+  entry[2].value = 1;
 
   if (http2conf.no_server_push || config->http2_proxy) {
     entry[nentry].settings_id = NGHTTP2_SETTINGS_ENABLE_PUSH;

--- a/src/shrpx_http2_upstream.cc
+++ b/src/shrpx_http2_upstream.cc
@@ -1045,8 +1045,8 @@ Http2Upstream::Http2Upstream(ClientHandler *handler)
   flow_control_ = true;
 
   // TODO Maybe call from outside?
-  std::array<nghttp2_settings_entry, 4> entry;
-  size_t nentry = 2;
+  std::array<nghttp2_settings_entry, 5> entry;
+  size_t nentry = 3;
 
   entry[0].settings_id = NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS;
   entry[0].value = http2conf.upstream.max_concurrent_streams;
@@ -1057,6 +1057,9 @@ Http2Upstream::Http2Upstream(ClientHandler *handler)
   } else {
     entry[1].value = http2conf.upstream.window_size;
   }
+
+  entry[2].settings_id = NGHTTP2_SETTINGS_NO_RFC7540_PRIORITIES;
+  entry[2].value = 1;
 
   if (!config->http2_proxy) {
     entry[nentry].settings_id = NGHTTP2_SETTINGS_ENABLE_CONNECT_PROTOCOL;


### PR DESCRIPTION
Disable RFC 7540 priorities in nghttpx.  It enables RFC 9218
extensible prioritization scheme.  It also enables a mechanism for
server to fallback to RFC 7540 in order to handle the existing clients
which do not implement SETTINGS_NO_RFC7540_PRIORITIES.