### PR TITLE
Allow server to override RFC 9218 stream priority

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -107,6 +107,7 @@ APIDOCS= \
 	nghttp2_session_callbacks_set_send_callback.rst \
 	nghttp2_session_callbacks_set_send_data_callback.rst \
 	nghttp2_session_callbacks_set_unpack_extension_callback.rst \
+	nghttp2_session_change_extpri_stream_priority.rst \
 	nghttp2_session_change_stream_priority.rst \
 	nghttp2_session_check_request_allowed.rst \
 	nghttp2_session_check_server_session.rst \

--- a/lib/includes/nghttp2/nghttp2.h
+++ b/lib/includes/nghttp2/nghttp2.h
@@ -4904,6 +4904,40 @@ NGHTTP2_EXTERN int nghttp2_submit_priority_update(nghttp2_session *session,
 /**
  * @function
  *
+ * Changes the priority of the existing stream denoted by |stream_id|.
+ * The new priority is |extpri|.  This function is meant to be used by
+ * server for :rfc:`9218` extensible prioritization scheme.
+ *
+ * If |session| is initialized as client, this function returns
+ * :enum:`nghttp2_error.NGHTTP2_ERR_INVALID_STATE`.  For client, use
+ * `nghttp2_submit_priority_update()` instead.
+ *
+ * If :member:`extpri->urgency <nghttp2_extpri.urgency>` is out of
+ * bound, it is set to :macro:`NGHTTP2_EXTPRI_URGENCY_LOW`.
+ *
+ * If |ignore_client_signal| is nonzero, server starts to ignore
+ * client priority signals for this stream.
+ *
+ * If
+ * :enum:`nghttp2_settings_id.NGHTTP2_SETTINGS_NO_RFC7540_PRIORITIES`
+ * of value of 1 is not submitted via `nghttp2_submit_settings()`,
+ * this function does nothing and returns 0.
+ *
+ * :enum:`nghttp2_error.NGHTTP2_ERR_NOMEM`
+ *     Out of memory.
+ * :enum:`nghttp2_error.NGHTTP2_ERR_INVALID_STATE`
+ *     The |session| is initialized as client.
+ * :enum:`nghttp2_error.NGHTTP2_ERR_INVALID_ARGUMENT`
+ *     |stream_id| is zero; or a stream denoted by |stream_id| is not
+ *     found.
+ */
+NGHTTP2_EXTERN int nghttp2_session_change_extpri_stream_priority(
+    nghttp2_session *session, int32_t stream_id, const nghttp2_extpri *extpri,
+    int ignore_client_signal);
+
+/**
+ * @function
+ *
  * Compares ``lhs->name`` of length ``lhs->namelen`` bytes and
  * ``rhs->name`` of length ``rhs->namelen`` bytes.  Returns negative
  * integer if ``lhs->name`` is found to be less than ``rhs->name``; or

--- a/lib/nghttp2_stream.h
+++ b/lib/nghttp2_stream.h
@@ -94,6 +94,8 @@ typedef enum {
   /* Indicates that this stream is not subject to RFC7540
      priorities scheme. */
   NGHTTP2_STREAM_FLAG_NO_RFC7540_PRIORITIES = 0x10,
+  /* Ignore client RFC 9218 priority signal. */
+  NGHTTP2_STREAM_FLAG_IGNORE_CLIENT_PRIORITIES = 0x20,
 } nghttp2_stream_flag;
 
 /* HTTP related flags to enforce HTTP semantics */

--- a/tests/main.c
+++ b/tests/main.c
@@ -317,6 +317,8 @@ int main(void) {
       !CU_add_test(pSuite, "session_flooding", test_nghttp2_session_flooding) ||
       !CU_add_test(pSuite, "session_change_stream_priority",
                    test_nghttp2_session_change_stream_priority) ||
+      !CU_add_test(pSuite, "session_change_extpri_stream_priority",
+                   test_nghttp2_session_change_extpri_stream_priority) ||
       !CU_add_test(pSuite, "session_create_idle_stream",
                    test_nghttp2_session_create_idle_stream) ||
       !CU_add_test(pSuite, "session_repeated_priority_change",

--- a/tests/nghttp2_session_test.h
+++ b/tests/nghttp2_session_test.h
@@ -155,6 +155,7 @@ void test_nghttp2_session_defer_then_close(void);
 void test_nghttp2_session_detach_item_from_closed_stream(void);
 void test_nghttp2_session_flooding(void);
 void test_nghttp2_session_change_stream_priority(void);
+void test_nghttp2_session_change_extpri_stream_priority(void);
 void test_nghttp2_session_create_idle_stream(void);
 void test_nghttp2_session_repeated_priority_change(void);
 void test_nghttp2_session_repeated_priority_submission(void);


### PR DESCRIPTION
Allow server to override RFC 9218 stream priority with
nghttp2_session_change_extpri_stream_priority.