### PR TITLE
No need to check pseudo header lws

### DIFF
--- a/lib/nghttp2_http.c
+++ b/lib/nghttp2_http.c
@@ -73,22 +73,9 @@ static int64_t parse_uint(const uint8_t *s, size_t len) {
   return n;
 }
 
-static int lws(const uint8_t *s, size_t n) {
-  size_t i;
-  for (i = 0; i < n; ++i) {
-    if (s[i] != ' ' && s[i] != '\t') {
-      return 0;
-    }
-  }
-  return 1;
-}
-
 static int check_pseudo_header(nghttp2_stream *stream, const nghttp2_hd_nv *nv,
                                uint32_t flag) {
-  if (stream->http_flags & flag) {
-    return 0;
-  }
-  if (lws(nv->value->base, nv->value->len)) {
+  if ((stream->http_flags & flag) || nv->value->len == 0) {
     return 0;
   }
   stream->http_flags = stream->http_flags | flag;


### PR DESCRIPTION
No need to check pseudo header lws because it is guaranteed not to
have leading white spaces.