### PR TITLE
nghttpx: Fix broken PROXY-protocol

### DIFF
--- a/src/shrpx_client_handler.h
+++ b/src/shrpx_client_handler.h
@@ -68,6 +68,8 @@ public:
   // Performs clear text I/O
   int read_clear();
   int write_clear();
+  // Specialized for PROXY-protocol use; peek data from socket.
+  int proxy_protocol_peek_clear();
   // Performs TLS handshake
   int tls_handshake();
   // Performs TLS I/O

--- a/src/shrpx_connection.h
+++ b/src/shrpx_connection.h
@@ -141,6 +141,10 @@ struct Connection {
   ssize_t write_clear(const void *data, size_t len);
   ssize_t writev_clear(struct iovec *iov, int iovcnt);
   ssize_t read_clear(void *data, size_t len);
+  // Read at most |len| bytes of data from socket without rate limit.
+  ssize_t read_nolim_clear(void *data, size_t len);
+  // Peek at most |len| bytes of data from socket without rate limit.
+  ssize_t peek_clear(void *data, size_t len);
 
   void handle_tls_pending_read();
 


### PR DESCRIPTION
Fix PROXY-protocol that is enabled for TLS connection.

Fixes #1746 