### PR TITLE
Fix warnings

### DIFF
--- a/third-party/url-parser/url_parser.c
+++ b/third-party/url-parser/url_parser.c
@@ -586,7 +586,7 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
         break;
 
       default:
-        assert(!"Unexpected state");
+        assert("Unexpected state" != NULL);
         return 1;
     }
 
@@ -624,9 +624,8 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
   if (u->field_set & (1 << UF_PORT)) {
     uint16_t off;
     uint16_t len;
-    const char* p;
     const char* end;
-    unsigned long v;
+    signed long v;
 
     off = u->field_data[UF_PORT].off;
     len = u->field_data[UF_PORT].len;


### PR DESCRIPTION
modified:   url_parser.c

url_parser.c:589:17: warning: implicit conversion turns string literal into bool: 'const char [17]' to '_Bool' [-Wstring-conversion]⏎
        assert(!"Unexpected state");⏎
               ~^~~~~~~~~~~~~~~~~~⏎
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/assert.h:99:25: note: expanded from macro 'assert'⏎
    (__builtin_expect(!(e), 0) ? __assert_rtn(__func__, __ASSERT_FILE_NAME, __LINE__, #e) : (void)0)⏎
                        ^⏎
url_parser.c:627:17: warning: declaration shadows a local variable [-Wshadow]⏎
    const char* p;⏎
                ^⏎
url_parser.c:536:15: note: previous declaration is here⏎
  const char *p;⏎
              ^⏎
url_parser.c:640:15: warning: implicit conversion changes signedness: 'int' to 'unsigned long' [-Wsign-conversion]⏎
      v += *p - '0';⏎
        ~~ ~~~^~~~~⏎
3 warnings generated.