### PR TITLE
Bump NDK and others to the latest

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -12,59 +12,42 @@
 
 
 # Only use standalone-toolchain for reduce size
-FROM ubuntu:bionic
+FROM ubuntu:22.04
 MAINTAINER Tatsuhiro Tsujikawa
-ENV ANDROID_HOME /root
-ENV TOOLCHAIN $ANDROID_HOME/toolchain
-ENV PATH $TOOLCHAIN/bin:$PATH
 
-ENV NDK_VERSION r14b
+ENV NDK_VERSION r25b
+ENV NDK /root/android-ndk-$NDK_VERSION
+ENV TOOLCHAIN $NDK/toolchains/llvm/prebuilt/linux-x86_64
+ENV TARGET aarch64-linux-android
+ENV API 33
+ENV AR $TOOLCHAIN/bin/llvm-ar
+ENV CC $TOOLCHAIN/bin/$TARGET$API-clang
+ENV CXX $TOOLCHAIN/bin/$TARGET$API-clang++
+ENV LD $TOOLCHAIN/bin/ld
+ENV RANDLIB $TOOLCHAIN/bin/llvm-ranlib
+ENV STRIP $TOOLCHAIN/bin/llvm-strip
+ENV PREFIX /root/usr/local
+ENV PATH $TOOLCHAIN/bin:$PATH
 
 WORKDIR /root
 RUN apt-get update && \
     apt-get install -y unzip make binutils autoconf \
       automake autotools-dev libtool pkg-config git \
       curl dpkg-dev libxml2-dev genisoimage libc6-i386 \
-      lib32stdc++6 python&& \
+      lib32stdc++6 python3 && \
     rm -rf /var/cache/apt/*
 
-# Install toolchain
-RUN curl -L -O https://dl.google.com/android/repository/android-ndk-$NDK_VERSION-linux-x86_64.zip && \
-   unzip -q android-ndk-$NDK_VERSION-linux-x86_64.zip && \
-   rm android-ndk-$NDK_VERSION-linux-x86_64.zip && \
-   mkdir -p $ANDROID_HOME/toolchain && \
-   $ANDROID_HOME/android-ndk-$NDK_VERSION/build/tools/make-standalone-toolchain.sh \
-       --install-dir=$ANDROID_HOME/toolchain \
-       --toolchain=arm-linux-androideabi-4.9 \
-       --force && \
-   rm -r android-ndk-$NDK_VERSION
-
-ENV PREFIX /root/usr/local
+# Download NDK
+RUN curl -L -O https://dl.google.com/android/repository/android-ndk-$NDK_VERSION-linux.zip && \
+   unzip -q android-ndk-$NDK_VERSION-linux.zip && \
+   rm android-ndk-$NDK_VERSION-linux.zip
 
 # Setup version of libraries
-ENV OPENSSL_VERSION 1.0.2u
-ENV SPDYLAY_VERSION v1.4.0
-ENV LIBEV_VERSION 4.19
-ENV ZLIB_VERSION 1.2.11
-ENV CARES_VERSION 1.17.2
-ENV NGHTTP2_VERSION v1.40.0
-
-WORKDIR /root/build
-RUN git clone https://github.com/tatsuhiro-t/spdylay -b $SPDYLAY_VERSION --depth 1
-WORKDIR /root/build/spdylay
-RUN autoreconf -i && \
-    ./configure \
-    --disable-shared \
-    --host=arm-linux-androideabi \
-    --build=`dpkg-architecture -qDEB_BUILD_GNU_TYPE` \
-    --prefix=$PREFIX \
-    --without-libxml2 \
-    --disable-src \
-    --disable-examples \
-    CPPFLAGS="-I$PREFIX/include" \
-    PKG_CONFIG_LIBDIR="$PREFIX/lib/pkgconfig" \
-    LDFLAGS="-L$PREFIX/lib" && \
-    make install
+ENV OPENSSL_VERSION 1.1.1q
+ENV LIBEV_VERSION 4.33
+ENV ZLIB_VERSION 1.2.12
+ENV CARES_VERSION 1.18.1
+ENV NGHTTP2_VERSION master
 
 WORKDIR /root/build
 RUN curl -L -O https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz && \
@@ -72,20 +55,18 @@ RUN curl -L -O https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz &&
     rm openssl-$OPENSSL_VERSION.tar.gz
 
 WORKDIR /root/build/openssl-$OPENSSL_VERSION
-RUN export CROSS_COMPILE=$TOOLCHAIN/bin/arm-linux-androideabi- && \
-    ./Configure --prefix=$PREFIX android && \
+RUN export ANDROID_NDK_HOME=$NDK && \
+    ./Configure --prefix=$PREFIX android-arm64 && \
     make && make install_sw
 
 WORKDIR /root/build
 RUN curl -L -O http://dist.schmorp.de/libev/Attic/libev-$LIBEV_VERSION.tar.gz && \
-    curl -L -O https://gist.github.com/tatsuhiro-t/48c45f08950f587180ed/raw/80a8f003b5d1091eae497c5995bbaa68096e739b/libev-4.19-android.patch && \
     tar xf libev-$LIBEV_VERSION.tar.gz && \
     rm libev-$LIBEV_VERSION.tar.gz
 
 WORKDIR /root/build/libev-$LIBEV_VERSION
-RUN patch -p1 < ../libev-4.19-android.patch && \
-    ./configure \
-    --host=arm-linux-androideabi \
+RUN ./configure \
+    --host=$TARGET \
     --build=`dpkg-architecture -qDEB_BUILD_GNU_TYPE` \
     --prefix=$PREFIX \
     --disable-shared \
@@ -95,17 +76,12 @@ RUN patch -p1 < ../libev-4.19-android.patch && \
     make install
 
 WORKDIR /root/build
-RUN curl -L -O https://downloads.sourceforge.net/project/libpng/zlib/$ZLIB_VERSION/zlib-$ZLIB_VERSION.tar.gz && \
+RUN curl -L -O https://zlib.net/zlib-$ZLIB_VERSION.tar.gz && \
     tar xf zlib-$ZLIB_VERSION.tar.gz && \
     rm zlib-$ZLIB_VERSION.tar.gz
 
 WORKDIR /root/build/zlib-$ZLIB_VERSION
-RUN HOST=arm-linux-androideabi \
-    CC=$HOST-gcc \
-    AR=$HOST-ar \
-    LD=$HOST-ld \
-    RANLIB=$HOST-ranlib \
-    STRIP=$HOST-strip \
+RUN HOST=$TARGET \
     ./configure \
     --prefix=$PREFIX \
     --libdir=$PREFIX/lib \
@@ -121,7 +97,7 @@ RUN curl -L -O https://c-ares.haxx.se/download/c-ares-$CARES_VERSION.tar.gz && \
 
 WORKDIR /root/build/c-ares-$CARES_VERSION
 RUN ./configure \
-      --host=arm-linux-androideabi \
+      --host=$TARGET \
       --build=`dpkg-architecture -qDEB_BUILD_GNU_TYPE` \
       --prefix=$PREFIX \
       --disable-shared && \
@@ -134,17 +110,15 @@ RUN autoreconf -i && \
     ./configure \
     --enable-app \
     --disable-shared \
-    --host=arm-linux-androideabi \
+    --host=$TARGET \
     --build=`dpkg-architecture -qDEB_BUILD_GNU_TYPE` \
     --with-xml-prefix="$PREFIX" \
     --without-libxml2 \
     --disable-python-bindings \
     --disable-examples \
     --disable-threads \
-      CC="$TOOLCHAIN"/bin/arm-linux-androideabi-clang \
-      CXX="$TOOLCHAIN"/bin/arm-linux-androideabi-clang++ \
       CPPFLAGS="-fPIE -I$PREFIX/include" \
       PKG_CONFIG_LIBDIR="$PREFIX/lib/pkgconfig" \
       LDFLAGS="-fPIE -pie -L$PREFIX/lib" && \
     make && \
-    arm-linux-androideabi-strip src/nghttpx src/nghttpd src/nghttp
+    $STRIP src/nghttpx src/nghttpd src/nghttp

--- a/configure.ac
+++ b/configure.ac
@@ -364,8 +364,8 @@ APPLDFLAGS=
 case "$host_os" in
   *android*)
     android_build=yes
-    # android does not need -pthread, but needs following 3 libs for C++
-    APPLDFLAGS="$APPLDFLAGS -lstdc++ -latomic -lsupc++"
+    # android does not need -pthread, but needs following 2 libs for C++
+    APPLDFLAGS="$APPLDFLAGS -lstdc++ -latomic"
     ;;
   *)
     PTHREAD_LDFLAGS="-pthread"


### PR DESCRIPTION
The latest nghttp2 release version cannot be built with the latest NDK.  The nghttp2 version in Dockerfile points to master for now.