### PR TITLE
nghttpx: Fix affinity-cookie-stickiness parameter handling

### DIFF
--- a/src/shrpx_config.cc
+++ b/src/shrpx_config.cc
@@ -1265,6 +1265,7 @@ int parse_mapping(Config *config, DownstreamAddrConfig &addr,
                   downstreamconf.balloc, params.affinity.cookie.path);
             }
             g.affinity.cookie.secure = params.affinity.cookie.secure;
+            g.affinity.cookie.stickiness = params.affinity.cookie.stickiness;
           }
         } else if (g.affinity.type != params.affinity.type ||
                    g.affinity.cookie.name != params.affinity.cookie.name ||


### PR DESCRIPTION
Fix affinity-cookie-stickiness backend parameter handling. Previously, if 3 backend options are used for the same pattern, and the first one does not have affinity-cookie-stickiness, and the rest of them have affinity-cookie-stickiness=strict, nghttpx wrongly determines that they have inconsistent configurations.