### PR TITLE
workflow: Disable python bindings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
     - name: Configure autotools
       run: |
         autoreconf -i
-        ./configure
+        ./configure --disable-python-bindings
     - name: Configure cmake (Linux)
       if: matrix.buildtool == 'cmake' && runner.os == 'Linux'
       run: |


### PR DESCRIPTION
Disable python bindings because it has been deprecated, and mac OS build with python binding is broken.