### PR TITLE
mruby: Support cross build for autotools

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -58,7 +58,7 @@ if(ENABLE_THIRD_PARTY)
         "MRUBY_CONFIG=${CMAKE_CURRENT_SOURCE_DIR}/build_config.rb"
         "BUILD_DIR=${MRUBY_BUILD_DIR}"
         "INSTALL_DIR=${MRUBY_BUILD_DIR}/install/bin"
-        "CC=${CMAKE_C_COMPILER}" "CXX=${CMAKE_CXX_COMPILER}"
+        "MRUBY_CC=${CMAKE_C_COMPILER}" "MRUBY_CXX=${CMAKE_CXX_COMPILER}"
         "${CMAKE_CURRENT_SOURCE_DIR}/mruby/minirake"
         -f "${CMAKE_CURRENT_SOURCE_DIR}/mruby/Rakefile"
       ${_byproducts}

--- a/third-party/Makefile.am
+++ b/third-party/Makefile.am
@@ -574,10 +574,9 @@ mruby:
 	MRUBY_CONFIG="${abs_builddir}/mruby/build/build_config.rb" \
 	BUILD_DIR="${abs_builddir}/mruby/build" \
 	INSTALL_DIR="${abs_builddir}/mruby/build/install/bin" \
-	CC="${CC}" CXX="$(firstword $(CXX))" LD="${LD}" \
-	CFLAGS="${CPPFLAGS} ${CFLAGS}" \
-	CXXFLAGS="$(wordlist 2, $(words $(CXX)), $(CXX)) ${CPPFLAGS} ${CXXFLAGS}" \
-	LDFLAGS="${LDFLAGS}" \
+	MRUBY_CC="${CC}" MRUBY_CXX="$(firstword $(CXX))" MRUBY_LD="${LD}" \
+	MRUBY_AR="${AR}" \
+	HOST="${host}" BUILD="${build}" \
 	"${srcdir}/mruby/minirake" -f "${srcdir}/mruby/Rakefile"
 
 all-local: mruby
@@ -586,7 +585,7 @@ clean-local:
 	[ ! -f "${abs_builddir}/mruby/build/build_config.rb" ] || \
 	MRUBY_CONFIG="${abs_builddir}/mruby/build/build_config.rb" \
 	BUILD_DIR="${abs_builddir}/mruby/build" \
-	CC="${CC}" \
+	MRUBY_CC="${CC}" \
 	"${srcdir}/mruby/minirake" -f "${srcdir}/mruby/Rakefile" clean
 
 endif # HAVE_MRUBY

--- a/third-party/build_config.rb
+++ b/third-party/build_config.rb
@@ -1,6 +1,16 @@
-MRuby::Build.new do |conf|
-  toolchain :clang if ENV['CC'].include? "clang"
-  toolchain :gcc if ENV['CC'].include? "gcc"
+def config(conf)
+  toolchain :clang if ENV['MRUBY_CC'].include? "clang"
+  toolchain :gcc if ENV['MRUBY_CC'].include? "gcc"
+
+  conf.cc.command = ENV['MRUBY_CC']
+  conf.cxx.command = ENV['MRUBY_CXX']
+
+  if ENV['MRUBY_LD']
+    conf.linker.command = ENV['MRUBY_LD']
+  end
+  if ENV['MRUBY_AR']
+    conf.archiver.command = ENV['MRUBY_AR']
+  end
 
   # C++ project needs this.  Without this, mruby exception does not
   # properly destroy C++ object allocated on stack.
@@ -11,4 +21,14 @@ MRuby::Build.new do |conf|
   # include the default GEMs
   conf.gembox 'default'
   conf.gem :core => 'mruby-eval'
+end
+
+if ENV['BUILD'] == ENV['HOST'] then
+  MRuby::Build.new do |conf|
+    config(conf)
+  end
+else
+  MRuby::CrossBuild.new(ENV['HOST']) do |conf|
+    config(conf)
+  end
 end


### PR DESCRIPTION
Support mruby cross build, but now we are unable to specify host C/C++ compiler on cross build.

Do not pass compiler and linker flags because mruby does its own.

Cross build only works with autotools.  It does not work with cmake.