### PR TITLE
nghttpx: Header field name must be lowercase

### DIFF
--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -3324,15 +3324,17 @@ HTTP:
               in HTTP/2 frontend.
   --add-request-header=<HEADER>
               Specify additional header field to add to request header
-              set.  This  option just  appends header field  and won't
-              replace anything  already set.  This option  can be used
-              several  times   to  specify  multiple   header  fields.
+              set.   The field  name must  be lowercase.   This option
+              just  appends header  field and  won't replace  anything
+              already set.  This  option can be used  several times to
+              specify multiple header fields.
               Example: --add-request-header="foo: bar"
   --add-response-header=<HEADER>
               Specify  additional  header  field to  add  to  response
-              header set.   This option just appends  header field and
-              won't replace anything already  set.  This option can be
-              used several  times to  specify multiple  header fields.
+              header  set.  The  field name  must be  lowercase.  This
+              option  just  appends  header field  and  won't  replace
+              anything already  set.  This option can  be used several
+              times to specify multiple header fields.
               Example: --add-response-header="foo: bar"
   --request-header-field-buffer=<SIZE>
               Set maximum buffer size for incoming HTTP request header


### PR DESCRIPTION
See #1952 