### PR TITLE
cmake: speed up warning option detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,74 +339,12 @@ if(CMAKE_C_COMPILER_ID MATCHES "MSVC")
   endif()
 else()
   if(ENABLE_WERROR)
-    extract_valid_c_flags(WARNCFLAGS    -Werror)
-    extract_valid_c_flags(WARNCXXFLAGS  -Werror)
+    set(WARNCFLAGS   "-Werror")
+    set(WARNCXXFLAGS "-Werror")
   endif()
 
-  # For C compiler
-  extract_valid_c_flags(WARNCFLAGS
-    -Wall
-    -Wextra
-    -Wmissing-prototypes
-    -Wstrict-prototypes
-    -Wmissing-declarations
-    -Wpointer-arith
-    -Wdeclaration-after-statement
-    -Wformat-security
-    -Wwrite-strings
-    -Wshadow
-    -Winline
-    -Wnested-externs
-    -Wfloat-equal
-    -Wundef
-    -Wendif-labels
-    -Wempty-body
-    -Wcast-align
-    -Wclobbered
-    -Wvla
-    -Wpragmas
-    -Wunreachable-code
-    -Waddress
-    -Wattributes
-    -Wdiv-by-zero
-    -Wshorten-64-to-32
-
-    -Wconversion
-    -Wextended-offsetof
-    -Wformat-nonliteral
-    -Wlanguage-extension-token
-    -Wmissing-field-initializers
-    -Wmissing-noreturn
-    -Wmissing-variable-declarations
-    # Not used because we cannot change public structs
-    # -Wpadded
-    -Wsign-conversion
-    # Not used because this basically disallows default case
-    # -Wswitch-enum
-    -Wunreachable-code-break
-    -Wunused-macros
-    -Wunused-parameter
-    -Wredundant-decls
-    # Only work with Clang for the moment
-    -Wheader-guard
-    # This is required because we pass format string as "const char*.
-    -Wno-format-nonliteral
-  )
-
-  extract_valid_cxx_flags(WARNCXXFLAGS
-    # For C++ compiler
-    -Wall
-    -Wformat-security
-  )
-endif()
-
-if(ENABLE_STATIC_CRT)
-  foreach(lang C CXX)
-    foreach(suffix "" _DEBUG _MINSIZEREL _RELEASE _RELWITHDEBINFO)
-      set(var "CMAKE_${lang}_FLAGS${suffix}")
-      string(REPLACE "/MD" "/MT" ${var} "${${var}}")
-    endforeach()
-  endforeach()
+  include(PickyWarningsC)
+  include(PickyWarningsCXX)
 endif()
 
 if(ENABLE_DEBUG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -440,6 +440,7 @@ message(STATUS "summary of build options:
       CXXFLAGS:       ${CMAKE_CXX_FLAGS_${_build_type}} ${CMAKE_CXX_FLAGS}
       WARNCFLAGS:     ${WARNCFLAGS}
       CXX1XCXXFLAGS:  ${CXX1XCXXFLAGS}
+      WARNCXXFLAGS:   ${WARNCXXFLAGS}
     Python:
       Python:          ${Python3_EXECUTABLE}
       Python3_VERSION: ${Python3_VERSION}

--- a/Makefile.am
+++ b/Makefile.am
@@ -44,7 +44,9 @@ EXTRA_DIST = nghttpx.conf.sample proxy.pac.sample android-config android-env \
 	cmake/FindLibbpf.cmake \
 	cmake/FindLibnghttp3.cmake \
 	cmake/FindLibngtcp2.cmake \
-	cmake/FindLibngtcp2_crypto_quictls.cmake
+	cmake/FindLibngtcp2_crypto_quictls.cmake \
+	cmake/PickyWarningsC.cmake \
+	cmake/PickyWarningsCXX.cmake
 
 .PHONY: clang-format
 

--- a/cmake/PickyWarningsC.cmake
+++ b/cmake/PickyWarningsC.cmake
@@ -1,0 +1,163 @@
+# nghttp2
+#
+# Copyright (c) 2023 nghttp2 contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# C
+
+include(CheckCCompilerFlag)
+
+if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+
+  # https://clang.llvm.org/docs/DiagnosticsReference.html
+  # https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
+
+  # WPICKY_ENABLE = Options we want to enable as-is.
+  # WPICKY_DETECT = Options we want to test first and enable if available.
+
+  # Prefer the -Wextra alias with clang.
+  if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+    set(WPICKY_ENABLE "-Wextra")
+  else()
+    set(WPICKY_ENABLE "-W")
+  endif()
+
+  list(APPEND WPICKY_ENABLE
+    -Wall
+  )
+
+  # ----------------------------------
+  # Add new options here, if in doubt:
+  # ----------------------------------
+  set(WPICKY_DETECT
+  )
+
+  # Assume these options always exist with both clang and gcc.
+  # Require clang 3.0 / gcc 2.95 or later.
+  list(APPEND WPICKY_ENABLE
+    -Wconversion                         # clang  3.0  gcc  2.95
+    -Winline                             # clang  1.0  gcc  1.0
+    -Wmissing-declarations               # clang  1.0  gcc  2.7
+    -Wmissing-prototypes                 # clang  1.0  gcc  1.0
+    -Wnested-externs                     # clang  1.0  gcc  2.7
+    -Wpointer-arith                      # clang  1.0  gcc  1.4
+    -Wshadow                             # clang  1.0  gcc  2.95
+    -Wundef                              # clang  1.0  gcc  2.95
+    -Wwrite-strings                      # clang  1.0  gcc  1.4
+  )
+
+  # Always enable with clang, version dependent with gcc
+  set(WPICKY_COMMON_OLD
+    -Waddress                            # clang  3.0  gcc  4.3
+    -Wattributes                         # clang  3.0  gcc  4.1
+    -Wcast-align                         # clang  1.0  gcc  4.2
+    -Wdeclaration-after-statement        # clang  1.0  gcc  3.4
+    -Wdiv-by-zero                        # clang  3.0  gcc  4.1
+    -Wempty-body                         # clang  3.0  gcc  4.3
+    -Wendif-labels                       # clang  1.0  gcc  3.3
+    -Wfloat-equal                        # clang  1.0  gcc  2.96 (3.0)
+    -Wformat-nonliteral                  # clang  3.0  gcc  4.1
+    -Wformat-security                    # clang  3.0  gcc  4.1
+    -Wmissing-field-initializers         # clang  3.0  gcc  4.1
+    -Wmissing-noreturn                   # clang  3.0  gcc  4.1
+    -Wno-format-nonliteral               # clang  1.0  gcc  2.96 (3.0)        # This is required because we pass format string as "const char*"
+  # -Wpadded                             # clang  3.0  gcc  4.1               # Not used because we cannot change public structs
+    -Wredundant-decls                    # clang  3.0  gcc  4.1
+    -Wsign-conversion                    # clang  3.0  gcc  4.3
+    -Wstrict-prototypes                  # clang  1.0  gcc  3.3
+  # -Wswitch-enum                        # clang  3.0  gcc  4.1               # Not used because this basically disallows default case
+    -Wunreachable-code                   # clang  3.0  gcc  4.1
+    -Wunused-macros                      # clang  3.0  gcc  4.1
+    -Wunused-parameter                   # clang  3.0  gcc  4.1
+    -Wvla                                # clang  2.8  gcc  4.3
+  )
+
+  set(WPICKY_COMMON
+    -Wpragmas                            # clang  3.5  gcc  4.1  appleclang  6.0
+  )
+
+  if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+    list(APPEND WPICKY_ENABLE
+      ${WPICKY_COMMON_OLD}
+      -Wshorten-64-to-32                 # clang  1.0
+      -Wlanguage-extension-token         # clang  3.0
+    )
+    # Enable based on compiler version
+    if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.6) OR
+       (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.3))
+      list(APPEND WPICKY_ENABLE
+        ${WPICKY_COMMON}
+        -Wunreachable-code-break         # clang  3.5            appleclang  6.0
+        -Wheader-guard                   # clang  3.4            appleclang  5.1
+      )
+    endif()
+    if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.9) OR
+       (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 8.3))
+      list(APPEND WPICKY_ENABLE
+        -Wmissing-variable-declarations  # clang  3.2            appleclang  4.6
+      )
+    endif()
+    if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0) OR
+       (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 9.4))
+      list(APPEND WPICKY_ENABLE
+      )
+    endif()
+    if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 7.0) OR
+       (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 10.3))
+      list(APPEND WPICKY_ENABLE
+      )
+    endif()
+  else()  # gcc
+    list(APPEND WPICKY_DETECT
+      ${WPICKY_COMMON}
+    )
+    # Enable based on compiler version
+    if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.3)
+      list(APPEND WPICKY_ENABLE
+        ${WPICKY_COMMON_OLD}
+        -Wclobbered                      #             gcc  4.3
+      )
+    endif()
+  endif()
+
+  #
+
+  unset(_wpicky)
+
+  foreach(_CCOPT IN LISTS WPICKY_ENABLE)
+    set(_wpicky "${_wpicky} ${_CCOPT}")
+  endforeach()
+
+  foreach(_CCOPT IN LISTS WPICKY_DETECT)
+    # surprisingly, CHECK_C_COMPILER_FLAG needs a new variable to store each new
+    # test result in.
+    string(MAKE_C_IDENTIFIER "OPT${_CCOPT}" _optvarname)
+    # GCC only warns about unknown -Wno- options if there are also other diagnostic messages,
+    # so test for the positive form instead
+    string(REPLACE "-Wno-" "-W" _CCOPT_ON "${_CCOPT}")
+    check_c_compiler_flag(${_CCOPT_ON} ${_optvarname})
+    if(${_optvarname})
+      set(_wpicky "${_wpicky} ${_CCOPT}")
+    endif()
+  endforeach()
+
+  set(WARNCFLAGS "${WARNCFLAGS} ${_wpicky}")
+endif()

--- a/cmake/PickyWarningsCXX.cmake
+++ b/cmake/PickyWarningsCXX.cmake
@@ -1,0 +1,117 @@
+# nghttp2
+#
+# Copyright (c) 2023 nghttp2 contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# C++
+
+include(CheckCXXCompilerFlag)
+
+if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+
+  # https://clang.llvm.org/docs/DiagnosticsReference.html
+  # https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
+
+  # WPICKY_ENABLE = Options we want to enable as-is.
+  # WPICKY_DETECT = Options we want to test first and enable if available.
+
+  set(WPICKY_ENABLE "-Wall")
+
+  # ----------------------------------
+  # Add new options here, if in doubt:
+  # ----------------------------------
+  set(WPICKY_DETECT
+  )
+
+  # Assume these options always exist with both clang and gcc.
+  # Require clang 3.0 / gcc 2.95 or later.
+  list(APPEND WPICKY_ENABLE
+  )
+
+  # Always enable with clang, version dependent with gcc
+  set(WPICKY_COMMON_OLD
+    -Wformat-security                    # clang  3.0  gcc  4.1
+  )
+
+  set(WPICKY_COMMON
+  )
+
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    list(APPEND WPICKY_ENABLE
+      ${WPICKY_COMMON_OLD}
+    )
+    # Enable based on compiler version
+    if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.6) OR
+       (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.3))
+      list(APPEND WPICKY_ENABLE
+        ${WPICKY_COMMON}
+      )
+    endif()
+    if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.9) OR
+       (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.3))
+      list(APPEND WPICKY_ENABLE
+      )
+    endif()
+    if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0) OR
+       (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.4))
+      list(APPEND WPICKY_ENABLE
+      )
+    endif()
+    if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0) OR
+       (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.3))
+      list(APPEND WPICKY_ENABLE
+      )
+    endif()
+  else()  # gcc
+    list(APPEND WPICKY_DETECT
+      ${WPICKY_COMMON}
+    )
+    # Enable based on compiler version
+    if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.3)
+      list(APPEND WPICKY_ENABLE
+        ${WPICKY_COMMON_OLD}
+      )
+    endif()
+  endif()
+
+  #
+
+  unset(_wpicky)
+
+  foreach(_CCOPT IN LISTS WPICKY_ENABLE)
+    set(_wpicky "${_wpicky} ${_CCOPT}")
+  endforeach()
+
+  foreach(_CCOPT IN LISTS WPICKY_DETECT)
+    # surprisingly, CHECK_CXX_COMPILER_FLAG needs a new variable to store each new
+    # test result in.
+    string(MAKE_C_IDENTIFIER "OPT${_CCOPT}" _optvarname)
+    # GCC only warns about unknown -Wno- options if there are also other diagnostic messages,
+    # so test for the positive form instead
+    string(REPLACE "-Wno-" "-W" _CCOPT_ON "${_CCOPT}")
+    check_cxx_compiler_flag(${_CCOPT_ON} ${_optvarname})
+    if(${_optvarname})
+      set(_wpicky "${_wpicky} ${_CCOPT}")
+    endif()
+  endforeach()
+
+  set(WARNCXXFLAGS "${WARNCXXFLAGS} ${_wpicky}")
+endif()


### PR DESCRIPTION
This patch makes CMake configuration faster by dropping feature checks
for each individual "picky" C/C++ compiler warning options and instead
enable them based on compiler version. It also allows to add options using
the old, feature-check method.

I've implemented this for libssh2 [1], curl [2] and ngtcp2 [3] earlier.
This patch is based on those, by adapting it to the warning options used
by nghttp2.

It brings CMake configuration time down from 22 to 15 seconds on my local
machine.

Also add missing `WARNCXXFLAGS` to the build config summary.

[1] libssh2
https://github.com/libssh2/libssh2/commit/ec0feae7920d695ce234a5aba13014bf29824c09
https://github.com/libssh2/libssh2/pull/952

[2] curl
https://github.com/curl/curl/commit/9c543de0ecf14880c3324d3d24591fb695dd1917
https://github.com/curl/curl/pull/10973

[3] ngtcp2
https://github.com/ngtcp2/ngtcp2/pull/964
