### PR TITLE
Have less stuff in config.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,7 +278,6 @@ check_include_file("pwd.h"          HAVE_PWD_H)
 check_include_file("sys/socket.h"   HAVE_SYS_SOCKET_H)
 check_include_file("sys/time.h"     HAVE_SYS_TIME_H)
 check_include_file("syslog.h"       HAVE_SYSLOG_H)
-check_include_file("time.h"         HAVE_TIME_H)
 check_include_file("unistd.h"       HAVE_UNISTD_H)
 check_include_file("windows.h"      HAVE_WINDOWS_H)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,10 +309,6 @@ endif()
 include(CheckStructHasMember)
 check_struct_has_member("struct tm" tm_gmtoff time.h HAVE_STRUCT_TM_TM_GMTOFF)
 
-# Check size of pointer to decide we need 8 bytes alignment adjustment.
-check_type_size("int *"   SIZEOF_INT_P)
-check_type_size("time_t"  SIZEOF_TIME_T)
-
 # Checks for library functions.
 include(CheckFunctionExists)
 check_function_exists(_Exit     HAVE__EXIT)

--- a/cmakeconfig.h.in
+++ b/cmakeconfig.h.in
@@ -19,12 +19,6 @@
 /* Define to 1 if you have `neverbleed` library. */
 #cmakedefine HAVE_NEVERBLEED 1
 
-/* sizeof(int *) */
-#cmakedefine SIZEOF_INT_P   @SIZEOF_INT_P@
-
-/* sizeof(time_t) */
-#cmakedefine SIZEOF_TIME_T  @SIZEOF_TIME_T@
-
 /* Define to 1 if you have the `_Exit` function. */
 #cmakedefine HAVE__EXIT 1
 

--- a/cmakeconfig.h.in
+++ b/cmakeconfig.h.in
@@ -85,9 +85,6 @@
 /* Define to 1 if you have the <syslog.h> header file. */
 #cmakedefine HAVE_SYSLOG_H 1
 
-/* Define to 1 if you have the <time.h> header file. */
-#cmakedefine HAVE_TIME_H 1
-
 /* Define to 1 if you have the <unistd.h> header file. */
 #cmakedefine HAVE_UNISTD_H 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -907,12 +907,6 @@ if test "x$have_struct_tm_tm_gmtoff" = "xyes"; then
             [Define to 1 if you have `struct tm.tm_gmtoff` member.])
 fi
 
-# Check size of pointer to decide we need 8 bytes alignment
-# adjustment.
-AC_CHECK_SIZEOF([int *])
-
-AC_CHECK_SIZEOF([time_t])
-
 # Checks for library functions.
 
 # Don't check malloc, since it does not play nicely with C++ stdlib

--- a/configure.ac
+++ b/configure.ac
@@ -856,7 +856,6 @@ AC_CHECK_HEADERS([ \
   sys/socket.h \
   sys/time.h \
   syslog.h \
-  time.h \
   unistd.h \
   windows.h \
 ])

--- a/lib/nghttp2_time.c
+++ b/lib/nghttp2_time.c
@@ -24,13 +24,11 @@
  */
 #include "nghttp2_time.h"
 
-#ifdef HAVE_TIME_H
-#  include <time.h>
-#endif /* HAVE_TIME_H */
-
 #ifdef HAVE_WINDOWS_H
 #  include <windows.h>
 #endif /* HAVE_WINDOWS_H */
+
+#include <time.h>
 
 #if !defined(HAVE_GETTICKCOUNT64) || defined(__CYGWIN__)
 static uint64_t time_now_sec(void) {

--- a/src/timegm.c
+++ b/src/timegm.c
@@ -45,11 +45,11 @@ time_t nghttp2_timegm(struct tm *tm) {
   days = (tm->tm_year - 70) * 365 + num_leap_year + tm->tm_yday;
   t = ((int64_t)days * 24 + tm->tm_hour) * 3600 + tm->tm_min * 60 + tm->tm_sec;
 
-#if SIZEOF_TIME_T == 4
-  if (t < INT32_MIN || t > INT32_MAX) {
-    return -1;
+  if (sizeof(time_t) == 4) {
+    if (t < INT32_MIN || t > INT32_MAX) {
+      return -1;
+    }
   }
-#endif /* SIZEOF_TIME_T == 4 */
 
   return (time_t)t;
 }
@@ -78,11 +78,11 @@ time_t nghttp2_timegm_without_yday(struct tm *tm) {
   }
   t = ((int64_t)days * 24 + tm->tm_hour) * 3600 + tm->tm_min * 60 + tm->tm_sec;
 
-#if SIZEOF_TIME_T == 4
-  if (t < INT32_MIN || t > INT32_MAX) {
-    return -1;
+  if (sizeof(time_t) == 4) {
+    if (t < INT32_MIN || t > INT32_MAX) {
+      return -1;
+    }
   }
-#endif /* SIZEOF_TIME_T == 4 */
 
   return (time_t)t;
 }

--- a/src/timegm.h
+++ b/src/timegm.h
@@ -29,13 +29,11 @@
 #  include <config.h>
 #endif /* HAVE_CONFIG_H */
 
+#include <time.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
-
-#ifdef HAVE_TIME_H
-#  include <time.h>
-#endif // HAVE_TIME_H
 
 time_t nghttp2_timegm(struct tm *tm);
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -24,9 +24,6 @@
  */
 #include "util.h"
 
-#ifdef HAVE_TIME_H
-#  include <time.h>
-#endif // HAVE_TIME_H
 #include <sys/types.h>
 #ifdef HAVE_SYS_SOCKET_H
 #  include <sys/socket.h>
@@ -59,6 +56,7 @@
 #include <cassert>
 #include <cstdio>
 #include <cstring>
+#include <ctime>
 #include <iostream>
 #include <fstream>
 #include <iomanip>


### PR DESCRIPTION
Speeds up the build minimally, doesn't check for stuff that's always there.