### PR TITLE
Use `#include <windows.h>` instead of `#include <sysinfoapi.h>`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,10 +277,10 @@ check_include_file("netinet/ip.h"   HAVE_NETINET_IP_H)
 check_include_file("pwd.h"          HAVE_PWD_H)
 check_include_file("sys/socket.h"   HAVE_SYS_SOCKET_H)
 check_include_file("sys/time.h"     HAVE_SYS_TIME_H)
-check_include_file("sysinfoapi.h"   HAVE_SYSINFOAPI_H)
 check_include_file("syslog.h"       HAVE_SYSLOG_H)
 check_include_file("time.h"         HAVE_TIME_H)
 check_include_file("unistd.h"       HAVE_UNISTD_H)
+check_include_file("windows.h"      HAVE_WINDOWS_H)
 
 include(CheckTypeSize)
 # Checks for typedefs, structures, and compiler characteristics.

--- a/cmakeconfig.h.in
+++ b/cmakeconfig.h.in
@@ -82,9 +82,6 @@
 /* Define to 1 if you have the <sys/time.h> header file. */
 #cmakedefine HAVE_SYS_TIME_H 1
 
-/* Define to 1 if you have the <sysinfoapi.h> header file. */
-#cmakedefine HAVE_SYSINFOAPI_H 1
-
 /* Define to 1 if you have the <syslog.h> header file. */
 #cmakedefine HAVE_SYSLOG_H 1
 
@@ -93,6 +90,9 @@
 
 /* Define to 1 if you have the <unistd.h> header file. */
 #cmakedefine HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the <windows.h> header file. */
+#cmakedefine HAVE_WINDOWS_H 1
 
 /* Define to 1 if HTTP/3 is enabled. */
 #cmakedefine ENABLE_HTTP3 1

--- a/configure.ac
+++ b/configure.ac
@@ -855,10 +855,10 @@ AC_CHECK_HEADERS([ \
   string.h \
   sys/socket.h \
   sys/time.h \
-  sysinfoapi.h \
   syslog.h \
   time.h \
   unistd.h \
+  windows.h \
 ])
 
 # Checks for typedefs, structures, and compiler characteristics.
@@ -959,7 +959,7 @@ AC_CHECK_FUNC([timerfd_create],
 AC_MSG_CHECKING([checking for GetTickCount64])
 AC_LINK_IFELSE([AC_LANG_PROGRAM(
 [[
-#include <sysinfoapi.h>
+#include <windows.h>
 ]],
 [[
 GetTickCount64();

--- a/lib/nghttp2_time.c
+++ b/lib/nghttp2_time.c
@@ -28,9 +28,9 @@
 #  include <time.h>
 #endif /* HAVE_TIME_H */
 
-#ifdef HAVE_SYSINFOAPI_H
-#  include <sysinfoapi.h>
-#endif /* HAVE_SYSINFOAPI_H */
+#ifdef HAVE_WINDOWS_H
+#  include <windows.h>
+#endif /* HAVE_WINDOWS_H */
 
 #if !defined(HAVE_GETTICKCOUNT64) || defined(__CYGWIN__)
 static uint64_t time_now_sec(void) {


### PR DESCRIPTION
This is the recommended way of including Windows headers:

https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-gettickcount64

> Header: sysinfoapi.h (include Windows.h)