### PR TITLE
Avoid detecting OpenSSL 3.2 as quictls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,9 +180,9 @@ if(OPENSSL_FOUND)
   if(WIN32)
     set(CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES}" "ws2_32" "bcrypt")
   endif()
-  check_symbol_exists(SSL_is_quic "openssl/ssl.h" HAVE_SSL_IS_QUIC)
-  if(NOT HAVE_SSL_IS_QUIC)
-    message(WARNING "OpenSSL in ${OPENSSL_LIBRARIES} does not have SSL_is_quic.  HTTP/3 support cannot be enabled")
+  check_symbol_exists(SSL_provide_quic_data "openssl/ssl.h" HAVE_SSL_PROVIDE_QUIC_DATA)
+  if(NOT HAVE_SSL_PROVIDE_QUIC_DATA)
+    message(WARNING "OpenSSL in ${OPENSSL_LIBRARIES} does not have SSL_provide_quic_data.  HTTP/3 support cannot be enabled")
   endif()
   cmake_pop_check_state()
 else()
@@ -240,7 +240,7 @@ endif()
 
 # HTTP/3 requires quictls/openssl, libngtcp2, libngtcp2_crypto_quictls
 # and libnghttp3.
-if(ENABLE_HTTP3 AND NOT (HAVE_SSL_IS_QUIC AND LIBNGTCP2_FOUND AND LIBNGTCP2_CRYPTO_QUICTLS_FOUND AND LIBNGHTTP3_FOUND))
+if(ENABLE_HTTP3 AND NOT (HAVE_SSL_PROVIDE_QUIC_DATA AND LIBNGTCP2_FOUND AND LIBNGTCP2_CRYPTO_QUICTLS_FOUND AND LIBNGHTTP3_FOUND))
   message(FATAL_ERROR "HTTP/3 was requested (ENABLE_HTTP3=1) but dependencies are not met.")
 endif()
 

--- a/configure.ac
+++ b/configure.ac
@@ -457,17 +457,17 @@ if test "x${request_openssl}" != "xno"; then
     CFLAGS="$OPENSSL_CFLAGS $CFLAGS"
     LIBS="$OPENSSL_LIBS $LIBS"
 
-    # quictls/openssl has SSL_is_quic.
-    have_ssl_is_quic=no
-    AC_MSG_CHECKING([for SSL_is_quic])
+    # quictls/openssl has SSL_provide_quic_data.  boringssl also has
+    # it.  We will deal with it later.
+    have_ssl_provide_quic_data=no
+    AC_MSG_CHECKING([for SSL_provide_quic_data])
     AC_LINK_IFELSE([AC_LANG_PROGRAM([[
       #include <openssl/ssl.h>
     ]], [[
-      SSL *ssl = NULL;
-      SSL_is_quic(ssl);
+      SSL_provide_quic_data(NULL, 0, NULL, 0);
     ]])],
-    [AC_MSG_RESULT([yes]); have_ssl_is_quic=yes],
-    [AC_MSG_RESULT([no]); have_ssl_is_quic=no])
+    [AC_MSG_RESULT([yes]); have_ssl_provide_quic_data=yes],
+    [AC_MSG_RESULT([no]); have_ssl_provide_quic_data=no])
 
     # boringssl has SSL_set_quic_early_data_context.
     AC_MSG_CHECKING([for SSL_set_quic_early_data_context])
@@ -522,7 +522,8 @@ fi
 
 # ngtcp2_crypto_quictls (for src)
 have_libngtcp2_crypto_quictls=no
-if test "x${have_ssl_is_quic}" = "xyes" &&
+if test "x${have_ssl_provide_quic_data}" = "xyes" &&
+   test "x${have_boringssl_quic}" != "xyes" &&
    test "x${request_libngtcp2}" != "xno"; then
   PKG_CHECK_MODULES([LIBNGTCP2_CRYPTO_QUICTLS],
                     [libngtcp2_crypto_quictls >= 1.0.0],
@@ -536,7 +537,8 @@ if test "x${have_ssl_is_quic}" = "xyes" &&
   fi
 fi
 
-if test "x${have_ssl_is_quic}" = "xyes" &&
+if test "x${have_ssl_provide_quic_data}" = "xyes" &&
+   test "x${have_boringssl_quic}" != "xyes" &&
    test "x${request_libngtcp2}" = "xyes" &&
    test "x${have_libngtcp2_crypto_quictls}" != "xyes"; then
   AC_MSG_ERROR([libngtcp2_crypto_quictls was requested (--with-libngtcp2) but not found])
@@ -752,8 +754,6 @@ AM_CONDITIONAL([ENABLE_APP], [ test "x${enable_app}" = "xyes" ])
 # Check HTTP/3 support
 enable_http3=no
 if test "x${request_http3}" != "xno" &&
-   (test "x${have_ssl_is_quic}" = "xyes" ||
-    test "x${have_boringssl_quic}" = "xyes") &&
    test "x${have_libngtcp2}" = "xyes" &&
    (test "x${have_libngtcp2_crypto_quictls}" = "xyes" ||
     test "x${have_libngtcp2_crypto_boringssl}" = "xyes") &&


### PR DESCRIPTION
Previously, SSL_is_quic is used to detect quictls.  But OpenSSL 3.2 has added it as a part of its own QUIC implementation which breaks our script.  Use SSL_provide_quic_data to correctly identify quictls and avoid OpenSSL 3.2.