### PR TITLE
Drop old OpenSSL support part 2

### DIFF
--- a/doc/sources/tutorial-client.rst
+++ b/doc/sources/tutorial-client.rst
@@ -60,9 +60,7 @@ The callback is added to the SSL_CTX object using
                               SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION);
       SSL_CTX_set_next_proto_select_cb(ssl_ctx, select_next_proto_cb, NULL);
 
-    #if OPENSSL_VERSION_NUMBER >= 0x10002000L
       SSL_CTX_set_alpn_protos(ssl_ctx, (const unsigned char *)"\x02h2", 3);
-    #endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
 
       return ssl_ctx;
     }
@@ -156,11 +154,9 @@ underlying network socket::
         ssl = bufferevent_openssl_get_ssl(session_data->bev);
 
         SSL_get0_next_proto_negotiated(ssl, &alpn, &alpnlen);
-    #if OPENSSL_VERSION_NUMBER >= 0x10002000L
         if (alpn == NULL) {
           SSL_get0_alpn_selected(ssl, &alpn, &alpnlen);
         }
-    #endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
 
         if (alpn == NULL || alpnlen != 2 || memcmp("h2", alpn, 2) != 0) {
           fprintf(stderr, "h2 is not negotiated\n");

--- a/doc/sources/tutorial-server.rst
+++ b/doc/sources/tutorial-server.rst
@@ -49,7 +49,6 @@ them.  We provide the callback for it::
       return SSL_TLSEXT_ERR_OK;
     }
 
-    #if OPENSSL_VERSION_NUMBER >= 0x10002000L
     static int alpn_select_proto_cb(SSL *ssl _U_, const unsigned char **out,
                                     unsigned char *outlen, const unsigned char *in,
                                     unsigned int inlen, void *arg _U_) {
@@ -63,7 +62,6 @@ them.  We provide the callback for it::
 
       return SSL_TLSEXT_ERR_OK;
     }
-    #endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
 
     static SSL_CTX *create_ssl_ctx(const char *key_file, const char *cert_file) {
       SSL_CTX *ssl_ctx;
@@ -80,9 +78,7 @@ them.  We provide the callback for it::
 
       SSL_CTX_set_next_protos_advertised_cb(ssl_ctx, next_proto_cb, NULL);
 
-    #if OPENSSL_VERSION_NUMBER >= 0x10002000L
       SSL_CTX_set_alpn_select_cb(ssl_ctx, alpn_select_proto_cb, NULL);
-    #endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
 
       return ssl_ctx;
     }
@@ -214,11 +210,9 @@ underlying network socket::
         ssl = bufferevent_openssl_get_ssl(session_data->bev);
 
         SSL_get0_next_proto_negotiated(ssl, &alpn, &alpnlen);
-    #if OPENSSL_VERSION_NUMBER >= 0x10002000L
         if (alpn == NULL) {
           SSL_get0_alpn_selected(ssl, &alpn, &alpnlen);
         }
-    #endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
 
         if (alpn == NULL || alpnlen != 2 || memcmp("h2", alpn, 2) != 0) {
           fprintf(stderr, "%s h2 is not negotiated\n", session_data->client_addr);

--- a/examples/client.c
+++ b/examples/client.c
@@ -381,9 +381,7 @@ static void init_ssl_ctx(SSL_CTX *ssl_ctx) {
   SSL_CTX_set_next_proto_select_cb(ssl_ctx, select_next_proto_cb, NULL);
 #endif /* !OPENSSL_NO_NEXTPROTONEG */
 
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
   SSL_CTX_set_alpn_protos(ssl_ctx, (const unsigned char *)"\x02h2", 3);
-#endif /* OPENSSL_VERSION_NUMBER >= 0x10002000L */
 }
 
 static void ssl_handshake(SSL *ssl, int fd) {
@@ -718,19 +716,6 @@ int main(int argc, char **argv) {
   memset(&act, 0, sizeof(struct sigaction));
   act.sa_handler = SIG_IGN;
   sigaction(SIGPIPE, &act, 0);
-
-#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
-  /* No explicit initialization is required. */
-#elif defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
-  CRYPTO_library_init();
-#else  /* !(OPENSSL_VERSION_NUMBER >= 0x1010000fL) &&                          \
-          !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC) */
-  OPENSSL_config(NULL);
-  SSL_load_error_strings();
-  SSL_library_init();
-  OpenSSL_add_all_algorithms();
-#endif /* !(OPENSSL_VERSION_NUMBER >= 0x1010000fL) &&                          \
-          !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC) */
 
   rv = parse_uri(&uri, argv[1]);
   if (rv != 0) {

--- a/examples/libevent-client.c
+++ b/examples/libevent-client.c
@@ -341,9 +341,7 @@ static SSL_CTX *create_ssl_ctx(void) {
   SSL_CTX_set_next_proto_select_cb(ssl_ctx, select_next_proto_cb, NULL);
 #endif /* !OPENSSL_NO_NEXTPROTONEG */
 
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
   SSL_CTX_set_alpn_protos(ssl_ctx, (const unsigned char *)"\x02h2", 3);
-#endif /* OPENSSL_VERSION_NUMBER >= 0x10002000L */
 
   return ssl_ctx;
 }
@@ -511,11 +509,9 @@ static void eventcb(struct bufferevent *bev, short events, void *ptr) {
 #ifndef OPENSSL_NO_NEXTPROTONEG
     SSL_get0_next_proto_negotiated(ssl, &alpn, &alpnlen);
 #endif /* !OPENSSL_NO_NEXTPROTONEG */
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
     if (alpn == NULL) {
       SSL_get0_alpn_selected(ssl, &alpn, &alpnlen);
     }
-#endif /* OPENSSL_VERSION_NUMBER >= 0x10002000L */
 
     if (alpn == NULL || alpnlen != 2 || memcmp("h2", alpn, 2) != 0) {
       fprintf(stderr, "h2 is not negotiated\n");
@@ -616,19 +612,6 @@ int main(int argc, char **argv) {
   memset(&act, 0, sizeof(struct sigaction));
   act.sa_handler = SIG_IGN;
   sigaction(SIGPIPE, &act, NULL);
-
-#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
-  /* No explicit initialization is required. */
-#elif defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
-  CRYPTO_library_init();
-#else  /* !(OPENSSL_VERSION_NUMBER >= 0x1010000fL) &&                          \
-          !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC) */
-  OPENSSL_config(NULL);
-  SSL_load_error_strings();
-  SSL_library_init();
-  OpenSSL_add_all_algorithms();
-#endif /* !(OPENSSL_VERSION_NUMBER >= 0x1010000fL) &&                          \
-          !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC) */
 
   run(argv[1]);
   return 0;

--- a/src/HttpServer.cc
+++ b/src/HttpServer.cc
@@ -910,11 +910,7 @@ int Http2Handler::verify_npn_result() {
       }
       break;
     } else {
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
       SSL_get0_alpn_selected(ssl_, &next_proto, &next_proto_len);
-#else  // OPENSSL_VERSION_NUMBER < 0x10002000L
-      break;
-#endif // OPENSSL_VERSION_NUMBER < 0x10002000L
     }
   }
   if (sessions_->get_config()->verbose) {
@@ -2089,7 +2085,6 @@ int start_listen(HttpServer *sv, struct ev_loop *loop, Sessions *sessions,
 }
 } // namespace
 
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
 namespace {
 int alpn_select_proto_cb(SSL *ssl, const unsigned char **out,
                          unsigned char *outlen, const unsigned char *in,
@@ -2111,7 +2106,6 @@ int alpn_select_proto_cb(SSL *ssl, const unsigned char **out,
   return SSL_TLSEXT_ERR_OK;
 }
 } // namespace
-#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
 
 int HttpServer::run() {
   SSL_CTX *ssl_ctx = nullptr;
@@ -2231,10 +2225,8 @@ int HttpServer::run() {
 #ifndef OPENSSL_NO_NEXTPROTONEG
     SSL_CTX_set_next_protos_advertised_cb(ssl_ctx, next_proto_cb, &next_proto);
 #endif // !OPENSSL_NO_NEXTPROTONEG
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
     // ALPN selection callback
     SSL_CTX_set_alpn_select_cb(ssl_ctx, alpn_select_proto_cb, this);
-#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
   }
 
   auto loop = EV_DEFAULT;

--- a/src/nghttp.cc
+++ b/src/nghttp.cc
@@ -1132,11 +1132,7 @@ int HttpClient::connection_made() {
         }
         break;
       }
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
       SSL_get0_alpn_selected(ssl, &next_proto, &next_proto_len);
-#else  // OPENSSL_VERSION_NUMBER < 0x10002000L
-      break;
-#endif // OPENSSL_VERSION_NUMBER < 0x10002000L
     }
     if (!next_proto) {
       print_protocol_nego_error();
@@ -2347,11 +2343,9 @@ int communicate(
                                      nullptr);
 #endif // !OPENSSL_NO_NEXTPROTONEG
 
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
     auto proto_list = util::get_default_alpn();
 
     SSL_CTX_set_alpn_protos(ssl_ctx, proto_list.data(), proto_list.size());
-#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
   }
   {
     HttpClient client{callbacks, loop, ssl_ctx};

--- a/src/shrpx_client_handler.cc
+++ b/src/shrpx_client_handler.cc
@@ -619,11 +619,9 @@ int ClientHandler::validate_next_proto() {
 #ifndef OPENSSL_NO_NEXTPROTONEG
   SSL_get0_next_proto_negotiated(conn_.tls.ssl, &next_proto, &next_proto_len);
 #endif // !OPENSSL_NO_NEXTPROTONEG
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
   if (next_proto == nullptr) {
     SSL_get0_alpn_selected(conn_.tls.ssl, &next_proto, &next_proto_len);
   }
-#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
 
   StringRef proto;
 

--- a/src/shrpx_connection.cc
+++ b/src/shrpx_connection.cc
@@ -797,11 +797,9 @@ int Connection::check_http2_requirement() {
 #ifndef OPENSSL_NO_NEXTPROTONEG
   SSL_get0_next_proto_negotiated(tls.ssl, &next_proto, &next_proto_len);
 #endif // !OPENSSL_NO_NEXTPROTONEG
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
   if (next_proto == nullptr) {
     SSL_get0_alpn_selected(tls.ssl, &next_proto, &next_proto_len);
   }
-#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
   if (next_proto == nullptr ||
       !util::check_h2_is_selected(StringRef{next_proto, next_proto_len})) {
     return 0;

--- a/src/shrpx_http2_session.cc
+++ b/src/shrpx_http2_session.cc
@@ -1675,11 +1675,9 @@ int Http2Session::connection_made() {
 #ifndef OPENSSL_NO_NEXTPROTONEG
     SSL_get0_next_proto_negotiated(conn_.tls.ssl, &next_proto, &next_proto_len);
 #endif // !OPENSSL_NO_NEXTPROTONEG
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
     if (!next_proto) {
       SSL_get0_alpn_selected(conn_.tls.ssl, &next_proto, &next_proto_len);
     }
-#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
 
     if (!next_proto) {
       downstream_failure(addr_, raddr_);

--- a/src/shrpx_live_check.cc
+++ b/src/shrpx_live_check.cc
@@ -408,11 +408,9 @@ int LiveCheck::tls_handshake() {
 #ifndef OPENSSL_NO_NEXTPROTONEG
   SSL_get0_next_proto_negotiated(conn_.tls.ssl, &next_proto, &next_proto_len);
 #endif // !OPENSSL_NO_NEXTPROTONEG
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
   if (next_proto == nullptr) {
     SSL_get0_alpn_selected(conn_.tls.ssl, &next_proto, &next_proto_len);
   }
-#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
 
   auto proto = StringRef{next_proto, next_proto_len};
 

--- a/src/shrpx_tls.cc
+++ b/src/shrpx_tls.cc
@@ -646,7 +646,6 @@ void info_callback(const SSL *ssl, int where, int ret) {
 }
 } // namespace
 
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
 namespace {
 int alpn_select_proto_cb(SSL *ssl, const unsigned char **out,
                          unsigned char *outlen, const unsigned char *in,
@@ -675,7 +674,6 @@ int alpn_select_proto_cb(SSL *ssl, const unsigned char **out,
   return SSL_TLSEXT_ERR_NOACK;
 }
 } // namespace
-#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
 
 #ifdef ENABLE_HTTP3
 namespace {
@@ -1071,10 +1069,8 @@ SSL_CTX *create_ssl_context(const char *private_key_file, const char *cert_file,
 #ifndef OPENSSL_NO_NEXTPROTONEG
   SSL_CTX_set_next_protos_advertised_cb(ssl_ctx, next_proto_cb, nullptr);
 #endif // !OPENSSL_NO_NEXTPROTONEG
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
   // ALPN selection callback
   SSL_CTX_set_alpn_select_cb(ssl_ctx, alpn_select_proto_cb, nullptr);
-#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
 
   auto tls_ctx_data = new TLSContextData();
   tls_ctx_data->cert_file = cert_file;
@@ -1328,10 +1324,8 @@ SSL_CTX *create_quic_ssl_context(const char *private_key_file,
   SSL_CTX_set_tlsext_status_cb(ssl_ctx, ocsp_resp_cb);
 #  endif // NGHTTP2_OPENSSL_IS_BORINGSSL
 
-#  if OPENSSL_VERSION_NUMBER >= 0x10002000L
   // ALPN selection callback
   SSL_CTX_set_alpn_select_cb(ssl_ctx, quic_alpn_select_proto_cb, nullptr);
-#  endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
 
   auto tls_ctx_data = new TLSContextData();
   tls_ctx_data->cert_file = cert_file;
@@ -2260,18 +2254,14 @@ SSL_CTX *setup_downstream_client_ssl_context(
 }
 
 void setup_downstream_http2_alpn(SSL *ssl) {
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
   // ALPN advertisement
   auto alpn = util::get_default_alpn();
   SSL_set_alpn_protos(ssl, alpn.data(), alpn.size());
-#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
 }
 
 void setup_downstream_http1_alpn(SSL *ssl) {
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
   // ALPN advertisement
   SSL_set_alpn_protos(ssl, NGHTTP2_H1_1_ALPN.byte(), NGHTTP2_H1_1_ALPN.size());
-#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L
 }
 
 std::unique_ptr<CertLookupTree> create_cert_lookup_tree() {


### PR DESCRIPTION
All OpenSSLs that we support have ALPN and SSL_get_server_tmp_key.