### PR TITLE
Not finding packages when `ENABLE_LIB_ONLY` is set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,10 +56,13 @@ include(GNUInstallDirs)
 find_package(Python3 COMPONENTS Interpreter)
 
 # Auto-detection of features that can be toggled
+if(NOT ENABLE_LIB_ONLY)
+  find_package(Libev 4.11)
+  find_package(Libcares 1.7.5)
+  find_package(ZLIB 1.2.3)
+endif()
+
 find_package(OpenSSL 1.1.1)
-find_package(Libev 4.11)
-find_package(Libcares 1.7.5)
-find_package(ZLIB 1.2.3)
 find_package(Libngtcp2 1.0.0)
 find_package(Libngtcp2_crypto_quictls 1.0.0)
 if(LIBNGTCP2_CRYPTO_QUICTLS_FOUND)


### PR DESCRIPTION
We shouldn't need to call `find_package()` on dependencies that aren't required. As per the README:

> If you need libnghttp2 (C library) only, then the above packages are all you need. Use --enable-lib-only to ensure that only libnghttp2 is built. This avoids potential build error related to building bundled applications.

> To build and run the application programs (nghttp, nghttpd, nghttpx and h2load) in the src directory, the following packages are required:

> OpenSSL >= 1.1.1; or LibreSSL >= 3.8.1; or aws-lc >= 1.19.0; or BoringSSL
> libev >= 4.11
> zlib >= 1.2.3
> libc-ares >= 1.7.5

This change fixes that.