### PR TITLE
bump openssl min required version to 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ if(NOT ENABLE_LIB_ONLY)
   find_package(ZLIB 1.2.3)
 endif()
 
-find_package(OpenSSL 1.1.1)
+find_package(OpenSSL 3.0)
 find_package(Libngtcp2 1.0.0)
 find_package(Libngtcp2_crypto_quictls 1.0.0)
 if(LIBNGTCP2_CRYPTO_QUICTLS_FOUND)


### PR DESCRIPTION
openssl 1.1 is already eol, bump min required version to 3.0 (which is LTS)

<img width="779" alt="image" src="https://github.com/snort3/snort3/assets/1580956/e0689afb-164b-4482-85ec-bc4885d57404">
