### PR TITLE
Revert "nghttpx: Shutdown h3 stream write if reset by a remote endpoint"

### DIFF
--- a/src/shrpx_http3_upstream.cc
+++ b/src/shrpx_http3_upstream.cc
@@ -422,31 +422,13 @@ int stream_reset(ngtcp2_conn *conn, int64_t stream_id, uint64_t final_size,
                  void *stream_user_data) {
   auto upstream = static_cast<Http3Upstream *>(user_data);
 
-  if (upstream->stream_reset(stream_id) != 0) {
+  if (upstream->http_shutdown_stream_read(stream_id) != 0) {
     return NGTCP2_ERR_CALLBACK_FAILURE;
   }
 
   return 0;
 }
 } // namespace
-
-int Http3Upstream::stream_reset(int64_t stream_id) {
-  if (http_shutdown_stream_read(stream_id) != 0) {
-    return -1;
-  }
-
-  if (ngtcp2_is_bidi_stream(stream_id)) {
-    auto rv = ngtcp2_conn_shutdown_stream_write(conn_, 0, stream_id,
-                                                NGHTTP3_H3_NO_ERROR);
-    if (rv != 0) {
-      ULOG(ERROR, this) << "ngtcp2_conn_shutdown_stream_write: "
-                        << ngtcp2_strerror(rv);
-      return -1;
-    }
-  }
-
-  return 0;
-}
 
 int Http3Upstream::http_shutdown_stream_read(int64_t stream_id) {
   if (!httpconn_) {

--- a/src/shrpx_http3_upstream.h
+++ b/src/shrpx_http3_upstream.h
@@ -125,7 +125,6 @@ public:
   void consume(int64_t stream_id, size_t nconsumed);
   void remove_downstream(Downstream *downstream);
   int stream_close(int64_t stream_id, uint64_t app_error_code);
-  int stream_reset(int64_t stream_id);
   void log_response_headers(Downstream *downstream,
                             const std::vector<nghttp3_nv> &nva) const;
   int http_acked_stream_data(Downstream *downstream, uint64_t datalen);


### PR DESCRIPTION
This reverts commit e103726f4d39a6cbcd29381f10fb837a1361b3a5.

See #2035 