### PR TITLE
nghttpx: Remove SHRPX_QUIC_MAX_UDP_PAYLOAD_SIZE

### DIFF
--- a/src/shrpx_http3_upstream.cc
+++ b/src/shrpx_http3_upstream.cc
@@ -635,7 +635,6 @@ int Http3Upstream::init(const UpstreamAddr *faddr, const Address &remote_addr,
   settings.cc_algo = quicconf.upstream.congestion_controller;
   settings.max_window = http3conf.upstream.max_connection_window_size;
   settings.max_stream_window = http3conf.upstream.max_window_size;
-  settings.max_tx_udp_payload_size = SHRPX_QUIC_MAX_UDP_PAYLOAD_SIZE;
   settings.rand_ctx.native_handle = &worker->get_randgen();
   settings.token = token;
   settings.tokenlen = tokenlen;

--- a/src/shrpx_quic.h
+++ b/src/shrpx_quic.h
@@ -72,7 +72,6 @@ constexpr size_t SHRPX_QUIC_CID_PREFIXLEN = 8;
 constexpr size_t SHRPX_QUIC_CID_PREFIX_OFFSET = 1;
 constexpr size_t SHRPX_QUIC_DECRYPTED_DCIDLEN = 16;
 constexpr size_t SHRPX_QUIC_CID_ENCRYPTION_KEYLEN = 16;
-constexpr size_t SHRPX_QUIC_MAX_UDP_PAYLOAD_SIZE = 1472;
 constexpr size_t SHRPX_QUIC_CONN_CLOSE_PKTLEN = 256;
 constexpr size_t SHRPX_QUIC_STATELESS_RESET_BURST = 100;
 constexpr size_t SHRPX_QUIC_SECRET_RESERVEDLEN = 4;


### PR DESCRIPTION
Remove SHRPX_QUIC_MAX_UDP_PAYLOAD_SIZE and just rely on the ngtcp2 default.