### PR TITLE
Fix build when `AI_NUMERICSERV` is undefined

### DIFF
--- a/src/shrpx_config.cc
+++ b/src/shrpx_config.cc
@@ -66,6 +66,10 @@
 #include "ssl_compat.h"
 #include "xsi_strerror.h"
 
+#ifndef AI_NUMERICSERV
+#define AI_NUMERICSERV 0
+#endif
+
 namespace shrpx {
 
 namespace {

--- a/src/shrpx_tls_test.cc
+++ b/src/shrpx_tls_test.cc
@@ -225,7 +225,10 @@ static Address parse_addr(const char *ipaddr) {
   addrinfo hints{};
 
   hints.ai_family = AF_UNSPEC;
-  hints.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV;
+  hints.ai_flags = AI_NUMERICHOST;
+#ifdef AI_NUMERICSERV
+  hints.ai_flags |= AI_NUMERICSERV;
+#endif
 
   addrinfo *res = nullptr;
 


### PR DESCRIPTION
Fixes for older macOS (and possibly some other platforms where `AI_NUMERICSERV` is not available).