### PR TITLE
nghttpx: Simplify quic connection close handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,7 +128,7 @@ following libraries are required:
   LibreSSL (does not support 0RTT); or aws-lc; or
   `BoringSSL <https://boringssl.googlesource.com/boringssl/>`_ (commit
   fae0964b3d44e94ca2a2d21f86e61dabe683d130)
-* `ngtcp2 <https://github.com/ngtcp2/ngtcp2>`_ >= 1.0.0
+* `ngtcp2 <https://github.com/ngtcp2/ngtcp2>`_ >= 1.4.0
 * `nghttp3 <https://github.com/ngtcp2/nghttp3>`_ >= 1.1.0
 
 Use ``--enable-http3`` configure option to enable HTTP/3 feature for

--- a/configure.ac
+++ b/configure.ac
@@ -481,7 +481,7 @@ fi
 # ngtcp2 (for src)
 have_libngtcp2=no
 if test "x${request_libngtcp2}" != "xno"; then
-  PKG_CHECK_MODULES([LIBNGTCP2], [libngtcp2 >= 1.0.0], [have_libngtcp2=yes],
+  PKG_CHECK_MODULES([LIBNGTCP2], [libngtcp2 >= 1.4.0], [have_libngtcp2=yes],
                     [have_libngtcp2=no])
   if test "x${have_libngtcp2}" = "xno"; then
     AC_MSG_NOTICE($LIBNGTCP2_PKG_ERRORS)

--- a/src/shrpx_http3_upstream.h
+++ b/src/shrpx_http3_upstream.h
@@ -167,7 +167,6 @@ private:
   ngtcp2_ccerr last_error_;
   nghttp3_conn *httpconn_;
   DownstreamQueue downstream_queue_;
-  bool retry_close_;
   std::vector<uint8_t> conn_close_;
 
   struct {


### PR DESCRIPTION
Simplify quic connection close handling with new ngtcp2 API.