### PR TITLE
nghttpx: Split thread into worker_process and thread

### DIFF
--- a/src/shrpx_config.cc
+++ b/src/shrpx_config.cc
@@ -2975,13 +2975,28 @@ int parse_config(Config *config, int optid, const StringRef &opt,
 
     return 0;
   }
-  case SHRPX_OPTID_WORKERS:
+  case SHRPX_OPTID_WORKERS: {
 #ifdef NOTHREADS
     LOG(WARN) << "Threading disabled at build time, no threads created.";
     return 0;
 #else  // !NOTHREADS
-    return parse_uint(&config->num_worker, opt, optarg);
+    size_t n;
+
+    if (parse_uint(&n, opt, optarg) != 0) {
+      return -1;
+    }
+
+    if (n > 65530) {
+      LOG(ERROR) << opt << ": the number of workers must not exceed 65530";
+
+      return -1;
+    }
+
+    config->num_worker = n;
+
+    return 0;
 #endif // !NOTHREADS
+  }
   case SHRPX_OPTID_HTTP2_MAX_CONCURRENT_STREAMS: {
     LOG(WARN) << opt << ": deprecated. Use "
               << SHRPX_OPT_FRONTEND_HTTP2_MAX_CONCURRENT_STREAMS << " and "

--- a/src/shrpx_connection_handler.h
+++ b/src/shrpx_connection_handler.h
@@ -121,7 +121,6 @@ enum class QUICIPCType {
 
 // WorkerProcesses which are in graceful shutdown period.
 struct QUICLingeringWorkerProcess {
-  // |worker_ids| must be sorted in the lexicographical order.
   QUICLingeringWorkerProcess(std::vector<WorkerID> worker_ids, int quic_ipc_fd)
       : worker_ids{std::move(worker_ids)}, quic_ipc_fd{quic_ipc_fd} {}
 
@@ -202,7 +201,6 @@ public:
   void set_quic_keying_materials(std::shared_ptr<QUICKeyingMaterials> qkms);
   const std::shared_ptr<QUICKeyingMaterials> &get_quic_keying_materials() const;
 
-  // |worker_ids| must be sorted in the lexicographical order.
   void set_worker_ids(std::vector<WorkerID> worker_ids);
   Worker *find_worker(const WorkerID &wid) const;
 

--- a/src/shrpx_quic.h
+++ b/src/shrpx_quic.h
@@ -87,7 +87,8 @@ struct WorkerID {
   union {
     struct {
       uint32_t server;
-      uint32_t thread;
+      uint16_t worker_process;
+      uint16_t thread;
     };
     uint64_t worker;
   };
@@ -102,10 +103,6 @@ inline bool operator==(const WorkerID &lhd, const WorkerID &rhd) {
 
 inline bool operator!=(const WorkerID &lhd, const WorkerID &rhd) {
   return lhd.worker != rhd.worker;
-}
-
-inline bool operator<(const WorkerID &lhd, const WorkerID &rhd) {
-  return lhd.worker < rhd.worker;
 }
 
 struct ConnectionID {

--- a/src/shrpx_worker.cc
+++ b/src/shrpx_worker.cc
@@ -1441,17 +1441,4 @@ void downstream_failure(DownstreamAddr *addr, const Address *raddr) {
   }
 }
 
-#ifdef ENABLE_HTTP3
-int create_worker_id(WorkerID &dest, uint32_t server_id) {
-  dest.server = server_id;
-
-  if (RAND_bytes(reinterpret_cast<unsigned char *>(&dest.thread),
-                 sizeof(dest.thread)) != 1) {
-    return -1;
-  }
-
-  return 0;
-}
-#endif // ENABLE_HTTP3
-
 } // namespace shrpx

--- a/src/shrpx_worker.h
+++ b/src/shrpx_worker.h
@@ -468,12 +468,6 @@ size_t match_downstream_addr_group(
 // nullptr.  This function may schedule live check.
 void downstream_failure(DownstreamAddr *addr, const Address *raddr);
 
-#ifdef ENABLE_HTTP3
-// Creates WorkerID used as a prefix of QUIC Connection ID.  This
-// function returns -1 on failure.
-int create_worker_id(WorkerID &dest, uint32_t server_id);
-#endif // ENABLE_HTTP3
-
 } // namespace shrpx
 
 #endif // SHRPX_WORKER_H


### PR DESCRIPTION
Split thread into worker_process and thread.  Use thread to O(1) lookup for Worker.  This new machinery is not compatible to the previous version.  The old instance of nghttpx must not be upgraded with USR2 signal.  It should be restarted instead.