### PR TITLE
nghttpx: Allocate 3 bits for QUIC configuration in Connection ID

### DIFF
--- a/doc/sources/nghttpx-howto.rst
+++ b/doc/sources/nghttpx-howto.rst
@@ -547,7 +547,7 @@ The construction of Connection ID closely follows Block Cipher CID
 Algorithm described in `QUIC-LB draft
 <https://datatracker.ietf.org/doc/html/draft-ietf-quic-load-balancers>`_.
 A Connection ID that nghttpx generates is always 17 bytes long.  It
-uses first 2 bits as a configuration ID.  The remaining bits in the
+uses first 3 bits as a configuration ID.  The remaining bits in the
 first byte are reserved and random.  The next 4 bytes are server ID.
 The next 4 bytes are used to route UDP datagram to a correct
 ``SO_REUSEPORT`` socket.  The remaining bytes are randomly generated.

--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -3555,12 +3555,12 @@ HTTP/3 and QUIC:
               encrypting tokens and Connection IDs.  It is not used to
               encrypt  QUIC  packets.  Each  line  of  this file  must
               contain  exactly  136  bytes  hex-encoded  string  (when
-              decoded the byte string is  68 bytes long).  The first 2
+              decoded the byte string is  68 bytes long).  The first 3
               bits of  decoded byte  string are  used to  identify the
               keying material.  An  empty line or a  line which starts
               '#'  is ignored.   The file  can contain  more than  one
-              keying materials.  Because the  identifier is 2 bits, at
-              most 4 keying materials are  read and the remaining data
+              keying materials.  Because the  identifier is 3 bits, at
+              most 8 keying materials are  read and the remaining data
               is discarded.  The first keying  material in the file is
               primarily  used for  encryption and  decryption for  new
               connection.  The other ones are used to decrypt data for

--- a/src/shrpx_config.cc
+++ b/src/shrpx_config.cc
@@ -282,9 +282,9 @@ read_quic_secret_file(const StringRef &path) {
 
     assert(static_cast<size_t>(p - std::begin(s)) == expectedlen * 2);
 
-    qkm.id = qkm.reserved[0] & 0xc0;
+    qkm.id = qkm.reserved[0] & SHRPX_QUIC_DCID_KM_ID_MASK;
 
-    if (kms.size() == 4) {
+    if (kms.size() == 8) {
       break;
     }
   }

--- a/src/shrpx_quic.cc
+++ b/src/shrpx_quic.cc
@@ -180,7 +180,7 @@ int generate_quic_retry_connection_id(ngtcp2_cid &cid, uint32_t server_id,
   }
 
   cid.datalen = SHRPX_QUIC_SCIDLEN;
-  cid.data[0] = (cid.data[0] & 0x3f) | km_id;
+  cid.data[0] = (cid.data[0] & (~SHRPX_QUIC_DCID_KM_ID_MASK)) | km_id;
 
   auto p = cid.data + SHRPX_QUIC_CID_WORKER_ID_OFFSET;
 
@@ -196,7 +196,7 @@ int generate_quic_connection_id(ngtcp2_cid &cid, const WorkerID &wid,
   }
 
   cid.datalen = SHRPX_QUIC_SCIDLEN;
-  cid.data[0] = (cid.data[0] & 0x3f) | km_id;
+  cid.data[0] = (cid.data[0] & (~SHRPX_QUIC_DCID_KM_ID_MASK)) | km_id;
 
   auto p = cid.data + SHRPX_QUIC_CID_WORKER_ID_OFFSET;
 

--- a/src/shrpx_quic.h
+++ b/src/shrpx_quic.h
@@ -81,7 +81,7 @@ constexpr size_t SHRPX_QUIC_STATELESS_RESET_BURST = 100;
 constexpr size_t SHRPX_QUIC_SECRET_RESERVEDLEN = 4;
 constexpr size_t SHRPX_QUIC_SECRETLEN = 32;
 constexpr size_t SHRPX_QUIC_SALTLEN = 32;
-constexpr uint8_t SHRPX_QUIC_DCID_KM_ID_MASK = 0xc0;
+constexpr uint8_t SHRPX_QUIC_DCID_KM_ID_MASK = 0xe0;
 
 struct WorkerID {
   union {


### PR DESCRIPTION
Allocate 3 bits for QUIC configuration in Connection ID that matches the current QUIC LB draft.