### PR TITLE
nghttpd: Use nghttp2_ssize

### DIFF
--- a/src/HttpServer.h
+++ b/src/HttpServer.h
@@ -245,9 +245,10 @@ private:
   const Config *config_;
 };
 
-ssize_t file_read_callback(nghttp2_session *session, int32_t stream_id,
-                           uint8_t *buf, size_t length, uint32_t *data_flags,
-                           nghttp2_data_source *source, void *user_data);
+nghttp2_ssize file_read_callback(nghttp2_session *session, int32_t stream_id,
+                                 uint8_t *buf, size_t length,
+                                 uint32_t *data_flags,
+                                 nghttp2_data_source *source, void *user_data);
 
 } // namespace nghttp2
 


### PR DESCRIPTION
Otherwise, produces compiler errors on platforms where ssize_t is not the same type as nghttp2_ssize i.e. ptrdiff_t, e.g. s390-linux.

	HttpServer.cc:1085:15: error: ambiguating new declaration of 'nghttp2_ssize nghttp2::file_read_callback(nghttp2_session*, int32_t, uint8_t*, size_t, uint32_t*, nghttp2_data_source*, void*)'
	 1085 | nghttp2_ssize file_read_callback(nghttp2_session *session, intnghttp2> In file included from HttpServer.cc:25:
	HttpServer.h:248:9: note: old declaration 'ssize_t nghttp2::file_read_callback(nghttp2_session*, int32_t, uint8_t*, size_t, uint32_t*, nghttp2_data_source*, void*)'
	  248 | ssize_t file_read_callback(nghttp2_session *session, int32_t stream_id,
	      |         ^~~~~~~~~~~~~~~~~~
	HttpServer.cc: In function 'void nghttp2::{anonymous}::prepare_status_response(nghttp2::Stream*, nghttp2::Http2Handler*, int)':
	HttpServer.cc:1139:28: error: invalid conversion from 'ssize_t (*)(nghttp2_session*, int32_t, uint8_t*, size_t, uint32_t*, nghttp2_data_source*, void*)' {aka 'long int (*)(nghttp2_session*, int, unsigned char*, long unsigned int, unsigned int*, nghttp2_data_source*, void*)'} to 'nghttp2_data_source_read_callback2' {aka 'int (*)(nghttp2_session*, int, unsigned char*, long unsigned intnghttp2>       |                            ^~~~~~~~~~~~~~~~~~
	      |                            |
	      |                            ssize_t (*)(nghttp2_session*, int32_t, uint8_t*, size_t, uint32_t*, nghttp2_data_source*, void*) {aka long int (*)(nghttp2_session*, int, unsigned char*, long unsigned int, unsigned int*, nghttp2_data_source*, void*)}