### PR TITLE
Undefine NGHTTP2_NO_SSIZE_T if BUILDING_NGHTTP2 is defined

### DIFF
--- a/lib/includes/nghttp2/nghttp2.h
+++ b/lib/includes/nghttp2/nghttp2.h
@@ -72,6 +72,10 @@ extern "C" {
 #  endif /* !BUILDING_NGHTTP2 */
 #endif   /* !defined(WIN32) */
 
+#ifdef BUILDING_NGHTTP2
+#  undef NGHTTP2_NO_SSIZE_T
+#endif /* BUILDING_NGHTTP2 */
+
 /**
  * @typedef
  *


### PR DESCRIPTION
Fixes #2219 