### PR TITLE
Suppress old compiler error

### DIFF
--- a/lib/nghttp2_submit.h
+++ b/lib/nghttp2_submit.h
@@ -31,7 +31,7 @@
 
 #include <nghttp2/nghttp2.h>
 
-typedef struct nghttp2_data_provider_wrap nghttp2_data_provider_wrap;
+#include "nghttp2_outbound_item.h"
 
 int nghttp2_submit_data_shared(nghttp2_session *session, uint8_t flags,
                                int32_t stream_id,


### PR DESCRIPTION
Fixes #2096 

I am not a fan of keeping supporting old generation of compilers, but this is a simple fix to achieve.