### PR TITLE
fix race condition on h1 connection close

### DIFF
--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -697,6 +697,10 @@ int Client::try_again_or_fail() {
         worker->stats.req_error += req_inflight;
 
         req_inflight = 0;
+      } else if (worker->current_phase == Phase::DURATION_OVER) {
+        // fix a race condition when h2load is sending connection: close over h1
+        // prevents new clients from spawning after the test should have ended.
+        return -1;
       }
 
       // Keep using current address


### PR DESCRIPTION
Running a duration test over http/1.1 with connection close, will usually fail to complete. Eg: 
```
h2load -c50 -t1 -D10 --h1 --connect-to 10.10.0.148:4443 -H "Connection: close"  https://www.foo.com/0k.html
```
This is because there is a race condition between a client being terminated and it spawning a new connection. This patch prevents new clients being launched after entering the `DURATION_OVER` phase.