### PR TITLE
fix: `-Wextra-semi` errors in `nghttp2_helper.h`

### DIFF
--- a/lib/nghttp2_helper.h
+++ b/lib/nghttp2_helper.h
@@ -38,28 +38,28 @@
 #define nghttp2_max_def(SUFFIX, T)                                             \
   static inline T nghttp2_max_##SUFFIX(T a, T b) { return a < b ? b : a; }
 
-nghttp2_max_def(int8, int8_t);
-nghttp2_max_def(int16, int16_t);
-nghttp2_max_def(int32, int32_t);
-nghttp2_max_def(int64, int64_t);
-nghttp2_max_def(uint8, uint8_t);
-nghttp2_max_def(uint16, uint16_t);
-nghttp2_max_def(uint32, uint32_t);
-nghttp2_max_def(uint64, uint64_t);
-nghttp2_max_def(size, size_t);
+nghttp2_max_def(int8, int8_t)
+nghttp2_max_def(int16, int16_t)
+nghttp2_max_def(int32, int32_t)
+nghttp2_max_def(int64, int64_t)
+nghttp2_max_def(uint8, uint8_t)
+nghttp2_max_def(uint16, uint16_t)
+nghttp2_max_def(uint32, uint32_t)
+nghttp2_max_def(uint64, uint64_t)
+nghttp2_max_def(size, size_t)
 
 #define nghttp2_min_def(SUFFIX, T)                                             \
   static inline T nghttp2_min_##SUFFIX(T a, T b) { return a < b ? a : b; }
 
-nghttp2_min_def(int8, int8_t);
-nghttp2_min_def(int16, int16_t);
-nghttp2_min_def(int32, int32_t);
-nghttp2_min_def(int64, int64_t);
-nghttp2_min_def(uint8, uint8_t);
-nghttp2_min_def(uint16, uint16_t);
-nghttp2_min_def(uint32, uint32_t);
-nghttp2_min_def(uint64, uint64_t);
-nghttp2_min_def(size, size_t);
+nghttp2_min_def(int8, int8_t)
+nghttp2_min_def(int16, int16_t)
+nghttp2_min_def(int32, int32_t)
+nghttp2_min_def(int64, int64_t)
+nghttp2_min_def(uint8, uint8_t)
+nghttp2_min_def(uint16, uint16_t)
+nghttp2_min_def(uint32, uint32_t)
+nghttp2_min_def(uint64, uint64_t)
+nghttp2_min_def(size, size_t)
 
 #define lstreq(A, B, N) ((sizeof((A)) - 1) == (N) && memcmp((A), (B), (N)) == 0)
 


### PR DESCRIPTION
This PR fixes the following `-Wextra-semi` errors in `nghttp2_helper.h` - seen when upgrading Electron to newer Node.js major version.

<details><summary>Details</summary>
<p>

```
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_helper.h:41:30: error: extra ';' outside of a function [-Werror,-Wextra-semi]
   41 | nghttp2_max_def(int8, int8_t);
      |                              ^
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_helper.h:42:32: error: extra ';' outside of a function [-Werror,-Wextra-semi]
   42 | nghttp2_max_def(int16, int16_t);
      |                                ^
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_helper.h:43:32: error: extra ';' outside of a function [-Werror,-Wextra-semi]
   43 | nghttp2_max_def(int32, int32_t);
      |                                ^
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_helper.h:44:32: error: extra ';' outside of a function [-Werror,-Wextra-semi]
   44 | nghttp2_max_def(int64, int64_t);
      |                                ^
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_helper.h:45:32: error: extra ';' outside of a function [-Werror,-Wextra-semi]
   45 | nghttp2_max_def(uint8, uint8_t);
      |                                ^
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_helper.h:46:34: error: extra ';' outside of a function [-Werror,-Wextra-semi]
   46 | nghttp2_max_def(uint16, uint16_t);
      |                                  ^
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_helper.h:47:34: error: extra ';' outside of a function [-Werror,-Wextra-semi]
   47 | nghttp2_max_def(uint32, uint32_t);
      |                                  ^
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_helper.h:48:34: error: extra ';' outside of a function [-Werror,-Wextra-semi]
   48 | nghttp2_max_def(uint64, uint64_t);
      |                                  ^
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_helper.h:49:30: error: extra ';' outside of a function [-Werror,-Wextra-semi]
   49 | nghttp2_max_def(size, size_t);
      |                              ^
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_helper.h:54:30: error: extra ';' outside of a function [-Werror,-Wextra-semi]
   54 | nghttp2_min_def(int8, int8_t);
      |                              ^
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_helper.h:55:32: error: extra ';' outside of a function [-Werror,-Wextra-semi]
   55 | nghttp2_min_def(int16, int16_t);
      |                                ^
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_helper.h:56:32: error: extra ';' outside of a function [-Werror,-Wextra-semi]
   56 | nghttp2_min_def(int32, int32_t);
      |                                ^
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_helper.h:57:32: error: extra ';' outside of a function [-Werror,-Wextra-semi]
   57 | nghttp2_min_def(int64, int64_t);
      |                                ^
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_helper.h:58:32: error: extra ';' outside of a function [-Werror,-Wextra-semi]
   58 | nghttp2_min_def(uint8, uint8_t);
      |                                ^
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_helper.h:59:34: error: extra ';' outside of a function [-Werror,-Wextra-semi]
   59 | nghttp2_min_def(uint16, uint16_t);
      |                                  ^
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_helper.h:60:34: error: extra ';' outside of a function [-Werror,-Wextra-semi]
   60 | nghttp2_min_def(uint32, uint32_t);
      |                                  ^
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_helper.h:61:34: error: extra ';' outside of a function [-Werror,-Wextra-semi]
   61 | nghttp2_min_def(uint64, uint64_t);
      |                                  ^
../../third_party/electron_node/deps/nghttp2/lib/nghttp2_helper.h:62:30: error: extra ';' outside of a function [-Werror,-Wextra-semi]
   62 | nghttp2_min_def(size, size_t);
      |                              ^
18 errors generated.
```

</p>
</details> 