### PR TITLE
account for bytes on closing connections

### DIFF
--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -1242,11 +1242,13 @@ int Client::connection_made() {
 
 int Client::on_read(const uint8_t *data, size_t len) {
   auto rv = session->on_read(data, len);
+  if (worker->current_phase == Phase::MAIN_DURATION) {
+    if ( len > 0 ) {
+      worker->stats.bytes_total += len;
+    }
+  }
   if (rv != 0) {
     return -1;
-  }
-  if (worker->current_phase == Phase::MAIN_DURATION) {
-    worker->stats.bytes_total += len;
   }
   signal_write();
   return 0;

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -1243,9 +1243,7 @@ int Client::connection_made() {
 int Client::on_read(const uint8_t *data, size_t len) {
   auto rv = session->on_read(data, len);
   if (worker->current_phase == Phase::MAIN_DURATION) {
-    if ( len > 0 ) {
-      worker->stats.bytes_total += len;
-    }
+    worker->stats.bytes_total += len;
   }
   if (rv != 0) {
     return -1;


### PR DESCRIPTION
If a connection is closing it returns -1 from on_read() and so the bytes in the last response are not counted in the stats.