### PR TITLE
Workaround the lack of ssize_t type under Windows

### DIFF
--- a/lib/includes/nghttp2/nghttp2.h
+++ b/lib/includes/nghttp2/nghttp2.h
@@ -55,6 +55,11 @@ extern "C" {
 
 #include <nghttp2/nghttp2ver.h>
 
+#if defined(_MSC_VER)
+#  include <basetsd.h>
+   typedef SSIZE_T ssize_t;
+#endif
+
 #ifdef NGHTTP2_STATICLIB
 #  define NGHTTP2_EXTERN
 #elif defined(WIN32) ||                                                        \


### PR DESCRIPTION
As [MSDN says](https://learn.microsoft.com/en-us/windows/win32/winprog/windows-data-types):

```
A signed version of SIZE_T.
This type is declared in BaseTsd.h as follows:
typedef LONG_PTR SSIZE_T;
```