### PR TITLE
nghttp: Remove RFC 7540 priorities

### DIFF
--- a/src/http2.cc
+++ b/src/http2.cc
@@ -2023,6 +2023,17 @@ bool check_transfer_encoding(const StringRef &s) {
   }
 }
 
+std::string encode_extpri(const nghttp2_extpri &extpri) {
+  std::string res = "u=";
+
+  res += extpri.urgency + '0';
+  if (extpri.inc) {
+    res += ",i";
+  }
+
+  return res;
+}
+
 } // namespace http2
 
 } // namespace nghttp2

--- a/src/http2.h
+++ b/src/http2.h
@@ -434,6 +434,9 @@ bool legacy_http1(int major, int minor);
 // list elements.
 bool check_transfer_encoding(const StringRef &s);
 
+// Encodes |extpri| in the wire format.
+std::string encode_extpri(const nghttp2_extpri &extpri);
+
 } // namespace http2
 
 } // namespace nghttp2

--- a/src/nghttp.h
+++ b/src/nghttp.h
@@ -72,7 +72,7 @@ struct Config {
 
   Headers headers;
   Headers trailer;
-  std::vector<int32_t> weight;
+  std::vector<nghttp2_extpri> extpris;
   std::string certfile;
   std::string keyfile;
   std::string datafile;
@@ -100,13 +100,11 @@ struct Config {
   bool upgrade;
   bool continuation;
   bool no_content_length;
-  bool no_dep;
   bool hexdump;
   bool no_push;
   bool expect_continue;
   bool verify_peer;
   bool ktls;
-  bool no_rfc7540_pri;
 };
 
 enum class RequestState { INITIAL, ON_REQUEST, ON_RESPONSE, ON_COMPLETE };
@@ -146,7 +144,7 @@ struct Request {
   // For pushed request, |uri| is empty and |u| is zero-cleared.
   Request(const std::string &uri, const urlparse_url &u,
           const nghttp2_data_provider2 *data_prd, int64_t data_length,
-          const nghttp2_priority_spec &pri_spec, int level = 0);
+          const nghttp2_extpri &extpri, int level = 0);
   ~Request();
 
   void init_inflater();
@@ -180,7 +178,7 @@ struct Request {
   // URI without fragment
   std::string uri;
   urlparse_url u;
-  nghttp2_priority_spec pri_spec;
+  nghttp2_extpri extpri;
   RequestTiming timing;
   int64_t data_length;
   int64_t data_offset;
@@ -255,7 +253,7 @@ struct HttpClient {
   void update_hostport();
   bool add_request(const std::string &uri,
                    const nghttp2_data_provider2 *data_prd, int64_t data_length,
-                   const nghttp2_priority_spec &pri_spec, int level = 0);
+                   const nghttp2_extpri &extpri, int level = 0);
 
   void record_start_time();
   void record_domain_lookup_end_time();


### PR DESCRIPTION
This change removes RFC 7540 priorities from nghttp.  nghttp now does not create the initial dependency tree.  --no-dep and --no-rfc7540-pri options have been removed.

nghttp now always sends NGHTTP2_SETTINGS_NO_RFC7540_PRIORITIES. --extpri option has been added to set priority for a given URI.