### PR TITLE
nghttpd: Remove RFC 7540 priorities

### DIFF
--- a/src/HttpServer.cc
+++ b/src/HttpServer.cc
@@ -121,8 +121,7 @@ Config::Config()
     hexdump(false),
     echo_upload(false),
     no_content_length(false),
-    ktls(false),
-    no_rfc7540_pri(false) {}
+    ktls(false) {}
 
 Config::~Config() {}
 
@@ -859,10 +858,13 @@ int Http2Handler::connection_made() {
 
   auto config = sessions_->get_config();
   std::array<nghttp2_settings_entry, 4> entry;
-  size_t niv = 1;
+  size_t niv = 2;
 
   entry[0].settings_id = NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS;
   entry[0].value = config->max_concurrent_streams;
+
+  entry[1].settings_id = NGHTTP2_SETTINGS_NO_RFC7540_PRIORITIES;
+  entry[1].value = 1;
 
   if (config->header_table_size >= 0) {
     entry[niv].settings_id = NGHTTP2_SETTINGS_HEADER_TABLE_SIZE;
@@ -873,12 +875,6 @@ int Http2Handler::connection_made() {
   if (config->window_bits != -1) {
     entry[niv].settings_id = NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE;
     entry[niv].value = (1 << config->window_bits) - 1;
-    ++niv;
-  }
-
-  if (config->no_rfc7540_pri) {
-    entry[niv].settings_id = NGHTTP2_SETTINGS_NO_RFC7540_PRIORITIES;
-    entry[niv].value = 1;
     ++niv;
   }
 

--- a/src/HttpServer.h
+++ b/src/HttpServer.h
@@ -91,7 +91,6 @@ struct Config {
   bool echo_upload;
   bool no_content_length;
   bool ktls;
-  bool no_rfc7540_pri;
   Config();
   ~Config();
 };

--- a/src/nghttpd.cc
+++ b/src/nghttpd.cc
@@ -177,8 +177,6 @@ Options:
   --no-content-length
               Don't send content-length header field.
   --ktls      Enable ktls.
-  --no-rfc7540-pri
-              Disable RFC7540 priorities.
   --version   Display version information and exit.
   -h, --help  Display this help and exit.
 
@@ -413,7 +411,8 @@ int main(int argc, char **argv) {
         break;
       case 13:
         // no-rfc7540-pri option
-        config.no_rfc7540_pri = true;
+        std::cerr << "[WARNING]: --no-rfc7540-pri option has been deprecated."
+                  << std::endl;
         break;
       }
       break;


### PR DESCRIPTION
This change deprecates --no-rfc7540-pri option.
SETTINGS_NO_RFC7540_PRIORITIES is now always sent.