### PR TITLE
fix: Add defensive bounds checking in hd_ringbuf_init()

### DIFF
--- a/lib/nghttp2_hd.c
+++ b/lib/nghttp2_hd.c
@@ -600,7 +600,7 @@ static int hd_ringbuf_init(nghttp2_hd_ringbuf *ringbuf, size_t bufsize,
     return NGHTTP2_ERR_NOMEM;
   }
 
-  for (size = 1; size < bufsize && size < max_size / 2; size <<= 1)
+  for (size = 1; size < bufsize; size <<= 1)
     ;
 
   if (size * sizeof(nghttp2_hd_entry *) > max_size) {

--- a/lib/nghttp2_hd.c
+++ b/lib/nghttp2_hd.c
@@ -594,9 +594,8 @@ static void hd_map_remove(nghttp2_hd_map *map, nghttp2_hd_entry *ent) {
 static int hd_ringbuf_init(nghttp2_hd_ringbuf *ringbuf, size_t bufsize,
                            nghttp2_mem *mem) {
   size_t size;
-  size_t max_size;
+  const size_t max_size = SIZE_MAX / sizeof(nghttp2_hd_entry *);
 
-  max_size = SIZE_MAX / sizeof(nghttp2_hd_entry *);
   if (bufsize > max_size) {
     return NGHTTP2_ERR_NOMEM;
   }

--- a/lib/nghttp2_hd.c
+++ b/lib/nghttp2_hd.c
@@ -594,8 +594,20 @@ static void hd_map_remove(nghttp2_hd_map *map, nghttp2_hd_entry *ent) {
 static int hd_ringbuf_init(nghttp2_hd_ringbuf *ringbuf, size_t bufsize,
                            nghttp2_mem *mem) {
   size_t size;
-  for (size = 1; size < bufsize; size <<= 1)
+  size_t max_size;
+
+  max_size = SIZE_MAX / sizeof(nghttp2_hd_entry *);
+  if (bufsize > max_size) {
+    return NGHTTP2_ERR_NOMEM;
+  }
+
+  for (size = 1; size < bufsize && size < max_size / 2; size <<= 1)
     ;
+
+  if (size * sizeof(nghttp2_hd_entry *) > max_size) {
+    return NGHTTP2_ERR_NOMEM;
+  }
+
   ringbuf->buffer = nghttp2_mem_malloc(mem, sizeof(nghttp2_hd_entry *) * size);
   if (ringbuf->buffer == NULL) {
     return NGHTTP2_ERR_NOMEM;

--- a/lib/nghttp2_hd.c
+++ b/lib/nghttp2_hd.c
@@ -603,7 +603,7 @@ static int hd_ringbuf_init(nghttp2_hd_ringbuf *ringbuf, size_t bufsize,
   for (size = 1; size < bufsize; size <<= 1)
     ;
 
-  if (size * sizeof(nghttp2_hd_entry *) > max_size) {
+  if (size > max_size) {
     return NGHTTP2_ERR_NOMEM;
   }
 


### PR DESCRIPTION
Add bounds checking in hd_ringbuf_init() to prevent potential integer overflow during size calculations. While HPACK decoder controls its own buffer size (4-8K typical) and is not vulnerable to remote exploitation, this adds defensive programming guards for robustness.