### PR TITLE
Add QNX Support

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -57,6 +57,9 @@
 #include "template.h"
 #include "network.h"
 #include "allocator.h"
+#if defined(__QNX__)
+  #include <sys/time.h>
+#endif
 
 namespace nghttp2 {
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,14 +25,22 @@ set(MAIN_SOURCES
   munit/munit.c
 )
 
+if(QNX)
+add_executable(main
+  ${MAIN_SOURCES}
+)
+else()
 add_executable(main EXCLUDE_FROM_ALL
   ${MAIN_SOURCES}
 )
+endif()
 target_link_libraries(main
   nghttp2_static
 )
-add_test(main main)
-add_dependencies(check main)
+if(NOT QNX)
+  add_test(main main)
+  add_dependencies(check main)
+endif()
 
 if(ENABLE_FAILMALLOC)
   set(FAILMALLOC_SOURCES
@@ -41,12 +49,20 @@ if(ENABLE_FAILMALLOC)
     nghttp2_test_helper.c
     munit/munit.c
   )
-  add_executable(failmalloc EXCLUDE_FROM_ALL
-    ${FAILMALLOC_SOURCES}
-  )
+  if(QNX)
+    add_executable(failmalloc
+      ${MAIN_SOURCES}
+    )
+  else()
+    add_executable(failmalloc EXCLUDE_FROM_ALL
+      ${MAIN_SOURCES}
+    )
+  endif()
   target_link_libraries(failmalloc
     nghttp2_static
   )
-  add_test(failmalloc failmalloc)
-  add_dependencies(check failmalloc)
+  if(NOT QNX)
+    add_test(failmalloc failmalloc)
+    add_dependencies(check failmalloc)
+  endif()
 endif()


### PR DESCRIPTION
Hi Tatsuhiro,
This contribution adds cross-compilation support for QNX operating system to nghttp2.
 
### Motivation
QNX is an industry standard real-time operating system for embedded systems, particularly for vehicles, featuring safety focused features. It has also recently been made free for non-commercial use through the QNX Everywhere program, aiming for students, researchers and hobbyists to experiment with the OS.
 
Given that nghttp2 is a mature HTTP/2 implementation with easy to use APIs as well as supporting applications, it would be great to enable nghttp2 to run natively on free version of QNX OS.

### Changes
- Adds a sys/time.h header to be included in util.h if building for QNX
- Adds conditionals on test build commands, omitting add_test() when building for QNX. Reason being we cross compile the library from a Linux Host and then transfer essential files to QNX target system, since we do not support self-hosted compilation toolchain for QNX yet.

### How to build
The build files and instructions for cross compiling nghttp2 for QNX are present at [qnx-ports](https://github.com/qnx-ports/build-files/tree/main/ports/nghttp2). A free QNX license can be obtained [here](https://www.qnx.com/products/everywhere/)
