### PR TITLE
Fix CMake existence check for GetTickCount64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,7 +369,7 @@ check_function_exists(clock_gettime HAVE_CLOCK_GETTIME)
 check_function_exists(mkostemp  HAVE_MKOSTEMP)
 check_function_exists(pipe2     HAVE_PIPE2)
 
-check_symbol_exists(GetTickCount64 sysinfoapi.h HAVE_GETTICKCOUNT64)
+check_symbol_exists(GetTickCount64 "windows.h;sysinfoapi.h" HAVE_GETTICKCOUNT64)
 
 include(CheckSymbolExists)
 # XXX does this correctly detect initgroups (un)availability on cygwin?


### PR DESCRIPTION
The CMake check for `GetTickCount64` on Windows only includes `<sysinfoapi.h>`.  If you check MSDN, it does say that `<sysinfoapi.h>` is the correct header, but it *also* says (include Windows.h).  Presently, the current check will fail 100% of the time because if you include sysinfoapi.h without including windows.h it's a compilation failure.  But if you do include windows.h, then it is not necessary to include sysinfoapi.h.

So the fix here is to simply change sysinfoapi.h to windows.h.  I confirmed after this patch that `HAVE_GETTICKCOUNT64` will be 1 on Windows, whereas before it would be undefined.