### PR TITLE
nghttpx: Tweak DNS timeout and retry

### DIFF
--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -2200,9 +2200,9 @@ void fill_default_config(Config *config) {
   {
     auto &timeoutconf = dnsconf.timeout;
     timeoutconf.cache = 10_s;
-    timeoutconf.lookup = 5_s;
+    timeoutconf.lookup = 250_ms;
   }
-  dnsconf.max_try = 2;
+  dnsconf.max_try = 3;
 }
 
 } // namespace


### PR DESCRIPTION
Decrease DNS timeout to 250ms, which is the minimum duration allowed in c-ares.  The number of retries is 3, which is the default value of c-ares.