### PR TITLE
Do not submit RST_STREAM more than once

### DIFF
--- a/lib/nghttp2_session.c
+++ b/lib/nghttp2_session.c
@@ -1092,6 +1092,15 @@ int nghttp2_session_add_item(nghttp2_session *session,
 
 int nghttp2_session_add_rst_stream(nghttp2_session *session, int32_t stream_id,
                                    uint32_t error_code) {
+  return nghttp2_session_add_rst_stream_continue(
+    session, stream_id, error_code,
+    /* continue_without_stream = */ 1);
+}
+
+int nghttp2_session_add_rst_stream_continue(nghttp2_session *session,
+                                            int32_t stream_id,
+                                            uint32_t error_code,
+                                            int continue_without_stream) {
   int rv;
   nghttp2_outbound_item *item;
   nghttp2_frame *frame;
@@ -1146,6 +1155,12 @@ int nghttp2_session_add_rst_stream(nghttp2_session *session, int32_t stream_id,
         return 0;
       }
     }
+  }
+
+  /* To keep the old behaviour, do not fail if stream was not
+     found. */
+  if (!continue_without_stream && !stream) {
+    return 0;
   }
 
   item = nghttp2_mem_malloc(mem, sizeof(nghttp2_outbound_item));

--- a/lib/nghttp2_session.h
+++ b/lib/nghttp2_session.h
@@ -403,13 +403,22 @@ int nghttp2_session_add_item(nghttp2_session *session,
                              nghttp2_outbound_item *item);
 
 /*
+ * This function wraps around nghttp2_session_add_rst_stream_continue
+ * with continue_without_stream = 1.
+ */
+int nghttp2_session_add_rst_stream(nghttp2_session *session, int32_t stream_id,
+                                   uint32_t error_code);
+
+/*
  * Adds RST_STREAM frame for the stream |stream_id| with the error
  * code |error_code|. This is a convenient function built on top of
  * nghttp2_session_add_frame() to add RST_STREAM easily.
  *
  * This function simply returns 0 without adding RST_STREAM frame if
  * given stream is in NGHTTP2_STREAM_CLOSING state, because multiple
- * RST_STREAM for a stream is redundant.
+ * RST_STREAM for a stream is redundant.  It also returns 0 without
+ * adding the frame if |continue_without_stream| is nonzero, and
+ * stream was already gone.
  *
  * This function returns 0 if it succeeds, or one of the following
  * negative error codes:
@@ -417,8 +426,10 @@ int nghttp2_session_add_item(nghttp2_session *session,
  * NGHTTP2_ERR_NOMEM
  *     Out of memory.
  */
-int nghttp2_session_add_rst_stream(nghttp2_session *session, int32_t stream_id,
-                                   uint32_t error_code);
+int nghttp2_session_add_rst_stream_continue(nghttp2_session *session,
+                                            int32_t stream_id,
+                                            uint32_t error_code,
+                                            int continue_without_stream);
 
 /*
  * Adds PING frame. This is a convenient function built on top of

--- a/lib/nghttp2_submit.c
+++ b/lib/nghttp2_submit.c
@@ -185,7 +185,8 @@ int nghttp2_submit_rst_stream(nghttp2_session *session, uint8_t flags,
     return NGHTTP2_ERR_INVALID_ARGUMENT;
   }
 
-  return nghttp2_session_add_rst_stream(session, stream_id, error_code);
+  return nghttp2_session_add_rst_stream_continue(
+    session, stream_id, error_code, /* continue_without_stream = */ 0);
 }
 
 int nghttp2_submit_goaway(nghttp2_session *session, uint8_t flags,


### PR DESCRIPTION
Do not submit RST_STREAM more than once for a same stream with nghttp2_submit_rst_stream.  Historically, nghttp2_submit_rst_stream allows this.  nghttp2 also allows receiving multiple RST_STREAM frames.  To keep compatibility, nghttp2_submit_rst_stream does not fail if it attempts to submit RST_STREAM to already closed stream.

Fixes #2354 