### PR TITLE
nghttpx: Fix Forwarded By

### DIFF
--- a/src/shrpx_client_handler.h
+++ b/src/shrpx_client_handler.h
@@ -204,6 +204,8 @@ public:
 
   void set_alpn_from_conn();
 
+  void set_local_hostport(const sockaddr *addr, socklen_t addrlen);
+
 private:
   // Allocator to allocate memory for connection-wide objects.  Make
   // sure that the allocations must be bounded, and not proportional
@@ -224,6 +226,11 @@ private:
   StringRef forwarded_for_;
   // lowercased TLS SNI which client sent.
   StringRef sni_;
+  // The host and port of local address where the connection is
+  // accepted.  For QUIC connection, the local address may change due
+  // to client address migration, but this value stays the same for
+  // now.
+  StringRef local_hostport_;
   std::function<int(ClientHandler &)> read_, write_;
   std::function<int(ClientHandler &)> on_read_, on_write_;
   // Address of frontend listening socket

--- a/src/shrpx_quic_connection_handler.cc
+++ b/src/shrpx_quic_connection_handler.cc
@@ -419,6 +419,12 @@ ClientHandler *QUICConnectionHandler::handle_new_connection(
     worker_, faddr->fd, ssl, StringRef{host.data()}, StringRef{service.data()},
     remote_addr.su.sa.sa_family, faddr);
 
+  auto &fwdconf = config->http.forwarded;
+
+  if (fwdconf.params & FORWARDED_BY) {
+    handler->set_local_hostport(&local_addr.su.sa, local_addr.len);
+  }
+
   auto upstream = std::make_unique<Http3Upstream>(handler.get());
   if (upstream->init(faddr, remote_addr, local_addr, hd, odcid, token,
                      token_type) != 0) {


### PR DESCRIPTION
Previously, the value sent with Forward By parameter is the address assigned to the listening socket.  This does not work expected if the assigned address is wild card, (e.g., ::, 0.0.0.0).

This commit fixes this issue by using the local address that the connection is accepted.  For QUIC, it is the local address that handshake is performed, and it stays the same even after client address migration occurred.