### PR TITLE
nghttpx: Listen TCP and UNIX domain sockets on worker thread

### DIFF
--- a/src/shrpx_accept_handler.cc
+++ b/src/shrpx_accept_handler.cc
@@ -33,6 +33,7 @@
 #include "shrpx_connection_handler.h"
 #include "shrpx_config.h"
 #include "shrpx_log.h"
+#include "shrpx_worker.h"
 #include "util.h"
 
 using namespace nghttp2;
@@ -46,15 +47,15 @@ void acceptcb(struct ev_loop *loop, ev_io *w, int revent) {
 }
 } // namespace
 
-AcceptHandler::AcceptHandler(const UpstreamAddr *faddr, ConnectionHandler *h)
-  : conn_hnr_(h), faddr_(faddr) {
+AcceptHandler::AcceptHandler(Worker *worker, const UpstreamAddr *faddr)
+  : worker_(worker), faddr_(faddr) {
   ev_io_init(&wev_, acceptcb, faddr_->fd, EV_READ);
   wev_.data = this;
-  ev_io_start(conn_hnr_->get_loop(), &wev_);
+  ev_io_start(worker_->get_loop(), &wev_);
 }
 
 AcceptHandler::~AcceptHandler() {
-  ev_io_stop(conn_hnr_->get_loop(), &wev_);
+  ev_io_stop(worker_->get_loop(), &wev_);
   close(faddr_->fd);
 }
 
@@ -87,7 +88,7 @@ void AcceptHandler::accept_connection() {
     case ENFILE:
       LOG(WARN) << "acceptor: running out file descriptor; disable acceptor "
                    "temporarily";
-      conn_hnr_->sleep_acceptor(get_config()->conn.listener.timeout.sleep);
+      worker_->sleep_listener(get_config()->conn.listener.timeout.sleep);
       return;
     default:
       return;
@@ -99,12 +100,12 @@ void AcceptHandler::accept_connection() {
   util::make_socket_closeonexec(cfd);
 #endif // !HAVE_ACCEPT4
 
-  conn_hnr_->handle_connection(cfd, &sockaddr.sa, addrlen, faddr_);
+  worker_->handle_connection(cfd, &sockaddr.sa, addrlen, faddr_);
 }
 
-void AcceptHandler::enable() { ev_io_start(conn_hnr_->get_loop(), &wev_); }
+void AcceptHandler::enable() { ev_io_start(worker_->get_loop(), &wev_); }
 
-void AcceptHandler::disable() { ev_io_stop(conn_hnr_->get_loop(), &wev_); }
+void AcceptHandler::disable() { ev_io_stop(worker_->get_loop(), &wev_); }
 
 int AcceptHandler::get_fd() const { return faddr_->fd; }
 

--- a/src/shrpx_accept_handler.h
+++ b/src/shrpx_accept_handler.h
@@ -31,12 +31,12 @@
 
 namespace shrpx {
 
-class ConnectionHandler;
+class Worker;
 struct UpstreamAddr;
 
 class AcceptHandler {
 public:
-  AcceptHandler(const UpstreamAddr *faddr, ConnectionHandler *h);
+  AcceptHandler(Worker *worker, const UpstreamAddr *faddr);
   ~AcceptHandler();
   void accept_connection();
   void enable();
@@ -45,7 +45,7 @@ public:
 
 private:
   ev_io wev_;
-  ConnectionHandler *conn_hnr_;
+  Worker *worker_;
   const UpstreamAddr *faddr_;
 };
 

--- a/src/shrpx_config.cc
+++ b/src/shrpx_config.cc
@@ -4048,6 +4048,8 @@ int parse_config(Config *config, int optid, const StringRef &opt,
 
     return 0;
   case SHRPX_OPTID_OCSP_STARTUP:
+    LOG(WARN) << opt << ": deprecated.  It has no effect";
+
     config->tls.ocsp.startup = util::strieq("yes"_sr, optarg);
 
     return 0;

--- a/src/shrpx_connection_handler.h
+++ b/src/shrpx_connection_handler.h
@@ -67,7 +67,6 @@ namespace shrpx {
 
 class Http2Session;
 class ConnectBlocker;
-class AcceptHandler;
 class Worker;
 struct WorkerStat;
 struct TicketKeys;
@@ -141,8 +140,6 @@ class ConnectionHandler {
 public:
   ConnectionHandler(struct ev_loop *loop, std::mt19937 &gen);
   ~ConnectionHandler();
-  int handle_connection(int fd, sockaddr *addr, int addrlen,
-                        const UpstreamAddr *faddr);
   // Creates Worker object for single threaded configuration.
   int create_single_worker();
   // Creates |num| Worker objects for multi threaded configuration.
@@ -155,12 +152,6 @@ public:
   const std::shared_ptr<TicketKeys> &get_ticket_keys() const;
   struct ev_loop *get_loop() const;
   Worker *get_single_worker() const;
-  void add_acceptor(std::unique_ptr<AcceptHandler> h);
-  void delete_acceptor();
-  void enable_acceptor();
-  void disable_acceptor();
-  void sleep_acceptor(ev_tstamp t);
-  void accept_pending_connection();
   void graceful_shutdown_worker();
   void set_graceful_shutdown(bool f);
   bool get_graceful_shutdown() const;
@@ -250,8 +241,6 @@ public:
   void
   worker_replace_downstream(std::shared_ptr<DownstreamConfig> downstreamconf);
 
-  void set_enable_acceptor_on_ocsp_completion(bool f);
-
 private:
   // Stores all SSL_CTX objects.
   std::vector<SSL_CTX *> all_ssl_ctx_;
@@ -298,11 +287,9 @@ private:
   // Worker object.
   std::shared_ptr<TicketKeys> ticket_keys_;
   struct ev_loop *loop_;
-  std::vector<std::unique_ptr<AcceptHandler>> acceptors_;
 #ifdef HAVE_NEVERBLEED
   neverbleed_t *nb_;
 #endif // HAVE_NEVERBLEED
-  ev_timer disable_acceptor_timer_;
   ev_timer ocsp_timer_;
   ev_async thread_join_asyncev_;
   ev_async serial_event_asyncev_;
@@ -313,9 +300,6 @@ private:
   size_t tls_ticket_key_memcached_fail_count_;
   unsigned int worker_round_robin_cnt_;
   bool graceful_shutdown_;
-  // true if acceptors should be enabled after the initial ocsp update
-  // has finished.
-  bool enable_acceptor_on_ocsp_completion_;
 };
 
 } // namespace shrpx


### PR DESCRIPTION
Previously, nghttpx listens TCP and UNIX domain sockets on a dedicated thread, and then distributes the accepted connection to the one of worker threads.  With this commit, nghttpx listens those sockets on each worker thread.  For TCP sockets, SO_REUSEPORT is used to load balance the connections.  This removes the need for inheriting file descriptors via environment variables.  For UNIX domain sockets, because there is no SO_REUSEPORT equivalent for them, they are created as before, but they are handled per worker.

The support for legacy deprecated environment variables has been removed.

ocsp-startup option has been deprecated due to this change.  OCSP will be remove very soon.