### PR TITLE
Rename root to nghttp2_stream_root

### DIFF
--- a/lib/nghttp2_session.c
+++ b/lib/nghttp2_session.c
@@ -41,7 +41,7 @@
 #include "nghttp2_debug.h"
 #include "nghttp2_submit.h"
 
-nghttp2_stream root;
+nghttp2_stream nghttp2_stream_root;
 
 /*
  * Returns non-zero if the number of outgoing opened streams is larger
@@ -7730,7 +7730,7 @@ int32_t nghttp2_session_get_last_proc_stream_id(nghttp2_session *session) {
 nghttp2_stream *nghttp2_session_find_stream(nghttp2_session *session,
                                             int32_t stream_id) {
   if (stream_id == 0) {
-    return &root;
+    return &nghttp2_stream_root;
   }
 
   return nghttp2_session_get_stream_raw(session, stream_id);
@@ -7739,7 +7739,7 @@ nghttp2_stream *nghttp2_session_find_stream(nghttp2_session *session,
 nghttp2_stream *nghttp2_session_get_root_stream(nghttp2_session *session) {
   (void)session;
 
-  return &root;
+  return &nghttp2_stream_root;
 }
 
 int nghttp2_session_check_server_session(nghttp2_session *session) {

--- a/lib/nghttp2_session.h
+++ b/lib/nghttp2_session.h
@@ -45,7 +45,7 @@
    preface handling. */
 extern int nghttp2_enable_strict_preface;
 
-extern nghttp2_stream root;
+extern nghttp2_stream nghttp2_stream_root;
 
 /*
  * Option flags.

--- a/lib/nghttp2_stream.c
+++ b/lib/nghttp2_stream.c
@@ -151,7 +151,7 @@ void nghttp2_stream_promise_fulfilled(nghttp2_stream *stream) {
 }
 
 nghttp2_stream_proto_state nghttp2_stream_get_state(nghttp2_stream *stream) {
-  if (stream == &root) {
+  if (stream == &nghttp2_stream_root) {
     return NGHTTP2_STREAM_STATE_IDLE;
   }
 


### PR DESCRIPTION
Rename root to nghttp2_stream_root to avoid potential name crash.

Fixes #2376 