### PR TITLE
Disallow array to substitute R &&

### DIFF
--- a/src/allocator.h
+++ b/src/allocator.h
@@ -211,6 +211,7 @@ StringRef make_string_ref(BlockAllocator &alloc, I first, I last) {
 // Makes a copy of |r| as StringRef.  The resulting string will be
 // NULL-terminated.
 template <std::ranges::input_range R>
+requires(!std::is_array_v<std::remove_cvref_t<R>>)
 StringRef make_string_ref(BlockAllocator &alloc, R &&r) {
   return make_string_ref(alloc, std::ranges::begin(r), std::ranges::end(r));
 }
@@ -223,6 +224,7 @@ constexpr size_t concat_string_ref_count(size_t acc) { return acc; }
 // the sum of length of given arguments.  The calculated length is
 // accumulated, and passed to the next function.
 template <std::ranges::input_range R, std::ranges::input_range... Args>
+requires(!std::is_array_v<std::remove_cvref_t<R>>)
 constexpr size_t concat_string_ref_count(size_t acc, R &&r, Args &&...args) {
   return concat_string_ref_count(acc + std::ranges::distance(r), args...);
 }
@@ -236,6 +238,7 @@ inline uint8_t *concat_string_ref_copy(uint8_t *p) { return p; }
 // and returned.  In the end, return value points to the location one
 // beyond the last byte written.
 template <std::ranges::input_range R, std::ranges::input_range... Args>
+requires(!std::is_array_v<std::remove_cvref_t<R>>)
 uint8_t *concat_string_ref_copy(uint8_t *p, R &&r, Args &&...args) {
   return concat_string_ref_copy(std::ranges::copy(std::forward<R>(r), p).out,
                                 std::forward<Args>(args)...);

--- a/src/app_helper.cc
+++ b/src/app_helper.cc
@@ -329,7 +329,7 @@ void print_frame(print_type ptype, const nghttp2_frame *frame) {
   case NGHTTP2_PING:
     print_frame_attr_indent();
     fprintf(outfile, "(opaque_data=%s)\n",
-            util::format_hex(frame->ping.opaque_data).c_str());
+            util::format_hex(std::span{frame->ping.opaque_data}).c_str());
     break;
   case NGHTTP2_GOAWAY:
     print_frame_attr_indent();

--- a/src/base64.h
+++ b/src/base64.h
@@ -97,12 +97,15 @@ constexpr O encode(I first, I last, O result) {
 }
 
 template <std::ranges::input_range R, std::weakly_incrementable O>
-requires(std::indirectly_writable<O, char>)
+requires(std::indirectly_writable<O, char> &&
+         !std::is_array_v<std::remove_cvref_t<R>>)
 constexpr O encode(R &&r, O result) {
   return encode(std::ranges::begin(r), std::ranges::end(r), std::move(result));
 }
 
-template <std::ranges::input_range R> constexpr std::string encode(R &&r) {
+template <std::ranges::input_range R>
+requires(!std::is_array_v<std::remove_cvref_t<R>>)
+constexpr std::string encode(R &&r) {
   std::string res;
   auto len = std::ranges::size(r);
   if (len == 0) {
@@ -173,6 +176,7 @@ constexpr O decode(I first, I last, O result) {
 }
 
 template <std::ranges::input_range R>
+requires(!std::is_array_v<std::remove_cvref_t<R>>)
 std::span<const uint8_t> decode(BlockAllocator &balloc, R &&r) {
   auto len = std::ranges::size(r);
   if (len % 4 != 0) {

--- a/src/memchunk.h
+++ b/src/memchunk.h
@@ -206,7 +206,9 @@ template <typename Memchunk> struct Memchunks {
     auto s = static_cast<const uint8_t *>(src);
     return append(s, s + count);
   }
-  template <std::ranges::input_range R> size_t append(R &&r) {
+  template <std::ranges::input_range R>
+  requires(!std::is_array_v<std::remove_cvref_t<R>>)
+  size_t append(R &&r) {
     return append(std::ranges::begin(r), std::ranges::end(r));
   }
   size_t copy(Memchunks &dest) {

--- a/src/shrpx_log.cc
+++ b/src/shrpx_log.cc
@@ -361,6 +361,7 @@ void dec(Log &log) { log.set_flags(Log::fmt_dec); }
 
 namespace {
 template <std::ranges::input_range R>
+requires(!std::is_array_v<std::remove_cvref_t<R>>)
 std::span<char> copy(R &&src, std::span<char> dest) {
   auto nwrite =
     std::min(std::ranges::distance(src), std::ranges::distance(dest));

--- a/src/shrpx_log.h
+++ b/src/shrpx_log.h
@@ -139,7 +139,9 @@ public:
     func(*this);
     return *this;
   }
-  template <std::ranges::input_range R> void write_seq(R &&r) {
+  template <std::ranges::input_range R>
+  requires(!std::is_array_v<std::remove_cvref_t<R>>)
+  void write_seq(R &&r) {
     if (full_) {
       return;
     }

--- a/src/template.h
+++ b/src/template.h
@@ -285,7 +285,9 @@ private:
     return res;
   }
 
-  template <std::ranges::input_range R> constexpr const char *copystr(R &&r) {
+  template <std::ranges::input_range R>
+  requires(!std::is_array_v<std::remove_cvref_t<R>>)
+  constexpr const char *copystr(R &&r) {
     return copystr(std::ranges::begin(r), std::ranges::end(r));
   }
 
@@ -456,6 +458,7 @@ as_writable_uint8_span(std::span<T, N> s) noexcept {
 template <typename R>
 requires(std::ranges::contiguous_range<R> && std::ranges::sized_range<R> &&
          std::ranges::borrowed_range<R> &&
+         !std::is_array_v<std::remove_cvref_t<R>> &&
          sizeof(std::ranges::range_value_t<R>) ==
            sizeof(std::string_view::value_type))
 [[nodiscard]] std::string_view as_string_view(R &&r) {
@@ -477,6 +480,7 @@ requires(sizeof(std::iter_value_t<I>) == sizeof(std::string_view::value_type))
 template <typename R>
 requires(std::ranges::contiguous_range<R> && std::ranges::sized_range<R> &&
          std::ranges::borrowed_range<R> &&
+         !std::is_array_v<std::remove_cvref_t<R>> &&
          sizeof(std::ranges::range_value_t<R>) == sizeof(StringRef::value_type))
 [[nodiscard]] StringRef as_string_ref(R &&r) {
   return StringRef{


### PR DESCRIPTION
C array is sometimes very dangerous for this purpose, for example, if it contains NULL terminated string.  In such case, passing entire array is unacceptable.