### PR TITLE
Remove Memchunks::append return value

### DIFF
--- a/src/h2load_http2_session.cc
+++ b/src/h2load_http2_session.cc
@@ -168,7 +168,9 @@ nghttp2_ssize send_callback(nghttp2_session *session, const uint8_t *data,
     return NGHTTP2_ERR_WOULDBLOCK;
   }
 
-  return wb.append(data, length);
+  wb.append(data, length);
+
+  return length;
 }
 } // namespace
 


### PR DESCRIPTION
Make Memchunks::append return nothing because it always stores everything given.