### PR TITLE
Revert "nghttpx: No need to capitalize HTTP/1.1 field name"

### DIFF
--- a/integration-tests/nghttpx_http1_test.go
+++ b/integration-tests/nghttpx_http1_test.go
@@ -1714,7 +1714,7 @@ func TestH1H1ResponseUnknownTransferEncoding(t *testing.T) {
 
 	resp = resp[:resplen]
 
-	const expect = "HTTP/1.1 200 OK\r\ntransfer-encoding: foo\r\nconnection: close\r\nserver: nghttpx\r\nvia: 1.1 nghttpx\r\n\r\n"
+	const expect = "HTTP/1.1 200 OK\r\nTransfer-Encoding: foo\r\nConnection: close\r\nServer: nghttpx\r\nVia: 1.1 nghttpx\r\n\r\n"
 
 	if got, want := string(resp), expect; got != want {
 		t.Errorf("resp = %v, want %v", got, want)

--- a/src/http2.cc
+++ b/src/http2.cc
@@ -249,6 +249,17 @@ StringRef stringify_status(BlockAllocator &balloc, unsigned int status_code) {
   }
 }
 
+void capitalize(DefaultMemchunks *buf, const StringRef &s) {
+  buf->append(util::upcase(s[0]));
+  for (size_t i = 1; i < s.size(); ++i) {
+    if (s[i - 1] == '-') {
+      buf->append(util::upcase(s[i]));
+    } else {
+      buf->append(s[i]);
+    }
+  }
+}
+
 bool lws(const char *value) {
   for (; *value; ++value) {
     switch (*value) {
@@ -495,7 +506,7 @@ void build_http1_headers_from_headers(DefaultMemchunks *buf,
       it_via = it;
       break;
     }
-    buf->append(kv->name);
+    capitalize(buf, kv->name);
     buf->append(": "sv);
     buf->append(kv->value);
     buf->append("\r\n"sv);

--- a/src/http2.h
+++ b/src/http2.h
@@ -102,6 +102,8 @@ StringRef get_reason_phrase(unsigned int status_code);
 // Returns string version of |status_code|. (e.g., "404")
 StringRef stringify_status(BlockAllocator &balloc, unsigned int status_code);
 
+void capitalize(DefaultMemchunks *buf, const StringRef &s);
+
 // Returns true if |value| is LWS
 bool lws(const char *value);
 

--- a/src/http2_test.cc
+++ b/src/http2_test.cc
@@ -214,25 +214,25 @@ void test_http2_build_http1_headers_from_headers(void) {
   http2::build_http1_headers_from_headers(&buf, headers,
                                           http2::HDOP_STRIP_X_FORWARDED_FOR);
   auto hdrs = std::string(buf.head->pos, buf.head->last);
-  assert_stdstring_equal("alpha: 0\r\n"
-                         "bravo: 1\r\n"
-                         "delta: 4\r\n"
-                         "expect: 5\r\n"
-                         "foxtrot: 6\r\n"
-                         "tango: 7\r\n"
-                         "te: 8\r\n"
-                         "te: 9\r\n"
-                         "zulu: 12\r\n",
+  assert_stdstring_equal("Alpha: 0\r\n"
+                         "Bravo: 1\r\n"
+                         "Delta: 4\r\n"
+                         "Expect: 5\r\n"
+                         "Foxtrot: 6\r\n"
+                         "Tango: 7\r\n"
+                         "Te: 8\r\n"
+                         "Te: 9\r\n"
+                         "Zulu: 12\r\n",
                          hdrs);
 
   buf.reset();
 
   http2::build_http1_headers_from_headers(&buf, headers2, http2::HDOP_NONE);
   hdrs = std::string(buf.head->pos, buf.head->last);
-  assert_stdstring_equal("x-forwarded-for: xff1\r\n"
-                         "x-forwarded-proto: xfp1\r\n"
-                         "forwarded: fwd1\r\n"
-                         "via: via1\r\n",
+  assert_stdstring_equal("X-Forwarded-For: xff1\r\n"
+                         "X-Forwarded-Proto: xfp1\r\n"
+                         "Forwarded: fwd1\r\n"
+                         "Via: via1\r\n",
                          hdrs);
 
   buf.reset();

--- a/src/shrpx_http2_session.cc
+++ b/src/shrpx_http2_session.cc
@@ -705,12 +705,12 @@ int Http2Session::downstream_connect_proxy() {
     req += ':';
     req += util::utos(addr_->port);
   }
-  req += " HTTP/1.1\r\nhost: ";
+  req += " HTTP/1.1\r\nHost: ";
   req += addr_->host;
   req += "\r\n";
   const auto &proxy = get_config()->downstream_http_proxy;
   if (!proxy.userinfo.empty()) {
-    req += "proxy-authorization: Basic ";
+    req += "Proxy-Authorization: Basic ";
     req += base64::encode(proxy.userinfo);
     req += "\r\n";
   }

--- a/src/shrpx_http_downstream_connection.cc
+++ b/src/shrpx_http_downstream_connection.cc
@@ -527,7 +527,7 @@ int HttpDownstreamConnection::push_request_headers() {
   } else {
     buf->append(req.path);
   }
-  buf->append(" HTTP/1.1\r\nhost: "sv);
+  buf->append(" HTTP/1.1\r\nHost: "sv);
   buf->append(authority);
   buf->append("\r\n"sv);
 
@@ -549,7 +549,7 @@ int HttpDownstreamConnection::push_request_headers() {
 
   auto cookie = downstream_->assemble_request_cookie();
   if (!cookie.empty()) {
-    buf->append("cookie: "sv);
+    buf->append("Cookie: "sv);
     buf->append(cookie);
     buf->append("\r\n"sv);
   }
@@ -559,7 +559,7 @@ int HttpDownstreamConnection::push_request_headers() {
   if (req.method != HTTP_CONNECT && req.http2_expect_body &&
       req.fs.content_length == -1) {
     downstream_->set_chunked_request(true);
-    buf->append("transfer-encoding: chunked\r\n"sv);
+    buf->append("Transfer-Encoding: chunked\r\n"sv);
   }
 
   if (req.connect_proto == ConnectProto::WEBSOCKET) {
@@ -574,28 +574,28 @@ int HttpDownstreamConnection::push_request_headers() {
       auto key = as_string_ref(std::ranges::begin(iov), p);
       downstream_->set_ws_key(key);
 
-      buf->append("sec-websocket-key: "sv);
+      buf->append("Sec-Websocket-Key: "sv);
       buf->append(key);
       buf->append("\r\n"sv);
     }
 
-    buf->append("upgrade: websocket\r\nconnection: Upgrade\r\n"sv);
+    buf->append("Upgrade: websocket\r\nConnection: Upgrade\r\n"sv);
   } else if (!connect_method && req.upgrade_request) {
     auto connection = req.fs.header(http2::HD_CONNECTION);
     if (connection) {
-      buf->append("connection: "sv);
+      buf->append("Connection: "sv);
       buf->append((*connection).value);
       buf->append("\r\n"sv);
     }
 
     auto upgrade = req.fs.header(http2::HD_UPGRADE);
     if (upgrade) {
-      buf->append("upgrade: "sv);
+      buf->append("Upgrade: "sv);
       buf->append((*upgrade).value);
       buf->append("\r\n"sv);
     }
   } else if (req.connection_close) {
-    buf->append("connection: close\r\n"sv);
+    buf->append("Connection: close\r\n"sv);
   }
 
   auto upstream = downstream_->get_upstream();
@@ -606,7 +606,7 @@ int HttpDownstreamConnection::push_request_headers() {
   auto conn = handler->get_connection();
 
   if (conn->tls.ssl && !SSL_is_init_finished(conn->tls.ssl)) {
-    buf->append("early-data: 1\r\n"sv);
+    buf->append("Early-Data: 1\r\n"sv);
   }
 #endif // NGHTTP2_GENUINE_OPENSSL || NGHTTP2_OPENSSL_IS_BORINGSSL ||
        // NGHTTP2_OPENSSL_IS_WOLFSSL
@@ -626,7 +626,7 @@ int HttpDownstreamConnection::push_request_headers() {
       req.authority, req.scheme);
 
     if (fwd || !value.empty()) {
-      buf->append("forwarded: "sv);
+      buf->append("Forwarded: "sv);
       if (fwd) {
         buf->append(fwd->value);
 
@@ -638,7 +638,7 @@ int HttpDownstreamConnection::push_request_headers() {
       buf->append("\r\n"sv);
     }
   } else if (fwd) {
-    buf->append("forwarded: "sv);
+    buf->append("Forwarded: "sv);
     buf->append(fwd->value);
     buf->append("\r\n"sv);
   }
@@ -647,7 +647,7 @@ int HttpDownstreamConnection::push_request_headers() {
     xffconf.strip_incoming ? nullptr : req.fs.header(http2::HD_X_FORWARDED_FOR);
 
   if (xffconf.add) {
-    buf->append("x-forwarded-for: "sv);
+    buf->append("X-Forwarded-For: "sv);
     if (xff) {
       buf->append((*xff).value);
       buf->append(", "sv);
@@ -655,7 +655,7 @@ int HttpDownstreamConnection::push_request_headers() {
     buf->append(client_handler_->get_ipaddr());
     buf->append("\r\n"sv);
   } else if (xff) {
-    buf->append("x-forwarded-for: "sv);
+    buf->append("X-Forwarded-For: "sv);
     buf->append((*xff).value);
     buf->append("\r\n"sv);
   }
@@ -665,7 +665,7 @@ int HttpDownstreamConnection::push_request_headers() {
                  : req.fs.header(http2::HD_X_FORWARDED_PROTO);
 
     if (xfpconf.add) {
-      buf->append("x-forwarded-proto: "sv);
+      buf->append("X-Forwarded-Proto: "sv);
       if (xfp) {
         buf->append((*xfp).value);
         buf->append(", "sv);
@@ -674,7 +674,7 @@ int HttpDownstreamConnection::push_request_headers() {
       buf->append(req.scheme);
       buf->append("\r\n"sv);
     } else if (xfp) {
-      buf->append("x-forwarded-proto: "sv);
+      buf->append("X-Forwarded-Proto: "sv);
       buf->append((*xfp).value);
       buf->append("\r\n"sv);
     }
@@ -682,12 +682,12 @@ int HttpDownstreamConnection::push_request_headers() {
   auto via = req.fs.header(http2::HD_VIA);
   if (httpconf.no_via) {
     if (via) {
-      buf->append("via: "sv);
+      buf->append("Via: "sv);
       buf->append((*via).value);
       buf->append("\r\n"sv);
     }
   } else {
-    buf->append("via: "sv);
+    buf->append("Via: "sv);
     if (via) {
       buf->append((*via).value);
       buf->append(", "sv);


### PR DESCRIPTION
This reverts commit e0089070f5a42ab15e8de8c70030b1f74eaf6f26.

Revert the relevant commit due to compatibility concerns.