### PR TITLE
Remove NGHTTP2_MAX_UINT64_DIGITS

### DIFF
--- a/src/shrpx_https_upstream.cc
+++ b/src/shrpx_https_upstream.cc
@@ -1071,7 +1071,7 @@ void HttpsUpstream::error_reply(unsigned int status_code) {
   output->append("\r\nServer: "sv);
   output->append(get_config()->http.server_name);
   output->append("\r\nContent-Length: "sv);
-  output->append(NGHTTP2_MAX_UINT64_DIGITS,
+  output->append(std::numeric_limits<decltype(html.size())>::digits10 + 1,
                  std::bind_front(util::UIntFormatter{}, html.size()));
   output->append("\r\nDate: "sv);
   auto lgconf = log_config();

--- a/src/shrpx_log.cc
+++ b/src/shrpx_log.cc
@@ -376,7 +376,7 @@ std::span<char> copy_hex_low(std::span<const uint8_t> src,
 namespace {
 template <std::unsigned_integral T>
 std::span<char> copy(T n, std::span<char> dest) {
-  if (dest.size() < NGHTTP2_MAX_UINT64_DIGITS) {
+  if (dest.size() < std::numeric_limits<T>::digits10 + 1) {
     return dest.first(0);
   }
 

--- a/src/util.h
+++ b/src/util.h
@@ -71,8 +71,6 @@ constexpr auto NGHTTP2_H2 = "h2"_sr;
 constexpr auto NGHTTP2_H1_1_ALPN = "\x8http/1.1"_sr;
 constexpr auto NGHTTP2_H1_1 = "http/1.1"_sr;
 
-constexpr size_t NGHTTP2_MAX_UINT64_DIGITS = str_size("18446744073709551615");
-
 namespace util {
 
 template <std::predicate<size_t> Pred>


### PR DESCRIPTION
Remove NGHTTP2_MAX_UINT64_DIGITS.  Rely on
std::numeric_limits<T>::digits10 instead.