### PR TITLE
src/template.h: add missing `cstdint` include

### DIFF
--- a/src/template.h
+++ b/src/template.h
@@ -27,6 +27,7 @@
 
 #include "nghttp2_config.h"
 
+#include <cstdint>
 #include <cstring>
 #include <cstdio>
 #include <cstdlib>


### PR DESCRIPTION
Without the change build against upcoming gcc-16 fails as:

    template.h:457:9: error: ISO C++ forbids declaration of 'type name' with no type [-fpermissive]
      457 |   const uint8_t, N == std::dynamic_extent ? std::dynamic_extent : N * sizeof(T)>
          |         ^~~~~~~