### PR TITLE
Provide fallback ssize_t type choice as SSIZE_T on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,7 +340,11 @@ check_type_size("ssize_t" SIZEOF_SSIZE_T)
 if(SIZEOF_SSIZE_T STREQUAL "")
   # ssize_t is a signed type in POSIX storing at least -1.
   # Set it to "int" to match the behavior of AC_TYPE_SSIZE_T (autotools).
-  set(ssize_t int)
+  if (MSVC)
+    set(ssize_t SSIZE_T)
+  else()
+    set(ssize_t int)
+  endif()
 endif()
 # AC_TYPE_UINT8_T
 # AC_TYPE_UINT16_T

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,7 +340,7 @@ check_type_size("ssize_t" SIZEOF_SSIZE_T)
 if(SIZEOF_SSIZE_T STREQUAL "")
   # ssize_t is a signed type in POSIX storing at least -1.
   # Set it to "int" to match the behavior of AC_TYPE_SSIZE_T (autotools).
-  if (MSVC)
+  if (MSVC AND ENABLE_SSIZE_T_FALLBACK)
     set(ssize_t SSIZE_T)
   else()
     set(ssize_t int)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,8 +340,8 @@ check_type_size("ssize_t" SIZEOF_SSIZE_T)
 if(SIZEOF_SSIZE_T STREQUAL "")
   # ssize_t is a signed type in POSIX storing at least -1.
   # Set it to "int" to match the behavior of AC_TYPE_SSIZE_T (autotools).
-  if (MSVC AND ENABLE_SSIZE_T_FALLBACK)
-    set(ssize_t SSIZE_T)
+  if (MSVC AND ENABLE_LONG_LONG_FALLBACK)
+    set(ssize_t "long long")
   else()
     set(ssize_t int)
   endif()


### PR DESCRIPTION
MSVC has already a special type of SSIZE_T.
So, we need to use this.

This is because when using nghttp2 as static library with MSVC, we got:

```
nghttp2.h(981): error C2628: 'ptrdiff_t' followed by 'int' is illegal (did you forget a ';'?) 
```

After I use SSIZE_T in fallback mechanism instead,
cl.exe was able to compile in that part of nghttp2.

A system of Windows data types has `SSIZE_T`:

https://learn.microsoft.com/en-us/windows/win32/winprog/windows-data-types