### PR TITLE
lib: enable overriding NGHTTP2_INBOUND_BUFFER_LENGTH

### DIFF
--- a/lib/nghttp2_session.h
+++ b/lib/nghttp2_session.h
@@ -84,7 +84,9 @@ typedef struct {
 
 /* Buffer length for inbound raw byte stream used in
    nghttp2_session_recv(). */
-#define NGHTTP2_INBOUND_BUFFER_LENGTH 16384
+#ifndef NGHTTP2_INBOUND_BUFFER_LENGTH
+#  define NGHTTP2_INBOUND_BUFFER_LENGTH 16384
+#endif
 
 /* The default maximum number of incoming reserved streams */
 #define NGHTTP2_MAX_INCOMING_RESERVED_STREAMS 200


### PR DESCRIPTION
Making this adjustable eases integration with microcontrollers and other small systems whose stacks may be much smaller than the default inbound buffer length. 

Supports espressif/idf-extra-components#523