### PR TITLE
Use allocator-aware free in failure path

### DIFF
--- a/lib/nghttp2_submit.c
+++ b/lib/nghttp2_submit.c
@@ -570,7 +570,7 @@ int nghttp2_submit_origin(nghttp2_session *session, uint8_t flags,
   return 0;
 
 fail_item_malloc:
-  free(ov_copy);
+  nghttp2_mem_free(mem, ov_copy);
 
   return rv;
 }


### PR DESCRIPTION
This change avoids [free(3)](https://man.openbsd.org/free.3) from stdlib in favor of `nghttp2_mem_free()` for freeing a buffer in an error path. The buffer is allocated with `nghttp2_mem_malloc()`.