### PR TITLE
fix(msvc): exclude MSVC from ssize_t undef to prevent build errors

### DIFF
--- a/lib/includes/nghttp2/nghttp2.h
+++ b/lib/includes/nghttp2/nghttp2.h
@@ -72,7 +72,7 @@ extern "C" {
 #  endif /* !BUILDING_NGHTTP2 */
 #endif   /* !defined(WIN32) */
 
-#ifdef BUILDING_NGHTTP2
+#if defined(BUILDING_NGHTTP2) && !defined(_MSC_VER)
 #  undef NGHTTP2_NO_SSIZE_T
 #endif /* BUILDING_NGHTTP2 */
 


### PR DESCRIPTION
This seems to cause issues when building the library under `msvc` as seen in the log output below.


```
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(979): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(979): error C2065: 'nghttp2_data_source_read_callback': undeclared identifier
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(979): error C2513: 'int': no variable declared before '='
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(979): error C2143: syntax error: missing ';' before '('
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(980): error C2143: syntax error: missing ')' before '*'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(980): error C2143: syntax error: missing ';' before '*'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(980): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(980): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(980): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(980): error C2377: 'int32_t': redefinition; typedef cannot be overloaded with any other symbol
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\stdint.h(20): note: see declaration of 'int32_t'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(980): error C2146: syntax error: missing ';' before identifier 'stream_id'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(981): error C2059: syntax error: ')'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1049): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1049): error C2146: syntax error: missing ')' before identifier 'stream_id'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1071): error C3646: 'read_callback': unknown override specifier
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1071): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1158): error C3646: 'stream_id': unknown override specifier
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1158): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1162): error C3646: 'weight': unknown override specifier
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1162): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1255): error C3646: 'settings_id': unknown override specifier
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1255): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1308): error C3646: 'promised_stream_id': unknown override specifier
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1308): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1345): error C3646: 'last_stream_id': unknown override specifier
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1345): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1378): error C3646: 'window_size_increment': unknown override specifier
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1378): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1496): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1497): error C2059: syntax error: 'const'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1533): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1534): error C2059: syntax error: 'const'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1579): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1580): error C2065: 'frame': undeclared identifier
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1580): error C2275: 'nghttp2_frame': expected an expression instead of a type
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1581): error C2059: syntax error: 'const'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1616): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1616): error C2065: 'buf': undeclared identifier
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1616): error C2275: 'uint8_t': expected an expression instead of a type
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1617): error C2275: 'size_t': expected an expression instead of a type
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1617): error C2146: syntax error: missing ')' before identifier 'length'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1648): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1649): error C2065: 'buf': undeclared identifier
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1649): error C2275: 'uint8_t': expected an expression instead of a type
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1649): error C2275: 'size_t': expected an expression instead of a type
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1649): error C2146: syntax error: missing ')' before identifier 'length'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1681): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1682): error C2059: syntax error: 'const'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1711): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1711): error C2059: syntax error: 'const'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1745): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1746): error C2275: 'uint8_t': expected an expression instead of a type
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1746): error C2146: syntax error: missing ')' before identifier 'flags'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1778): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1779): error C2059: syntax error: 'const'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1798): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1799): error C2059: syntax error: 'const'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1824): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1825): error C2059: syntax error: 'const'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1853): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1854): error C2146: syntax error: missing ')' before identifier 'stream_id'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1922): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(1923): error C2059: syntax error: 'const'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(2007): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(2008): error C2059: syntax error: 'const'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(2033): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(2034): error C2059: syntax error: 'const'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(2072): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(2072): error C2059: syntax error: 'const'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(2105): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(2105): error C2059: syntax error: 'const'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(2132): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(2133): error C2059: syntax error: 'const'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(2158): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(2158): error C2059: syntax error: 'const'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(2193): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(2193): error C2275: 'uint8_t': expected an expression instead of a type
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(2193): error C2146: syntax error: missing ')' before identifier 'frame_type'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(2225): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(2225): error C2275: 'uint8_t': expected an expression instead of a type
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(2225): error C2146: syntax error: missing ')' before identifier 'frame_type'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\lib\includes\nghttp2/nghttp2.h(2252): error C2297: '*': not valid as right operand has type 'int *'
C:\Users\nitan\CLionProjects\ProjectExample\cmake-build-release\_deps\nghttp2-src\l
```