### PR TITLE
Make error handling robust

### DIFF
--- a/lib/includes/nghttp2/nghttp2.h
+++ b/lib/includes/nghttp2/nghttp2.h
@@ -2045,12 +2045,13 @@ typedef int (*nghttp2_on_header_callback2)(nghttp2_session *session,
  * The parameter and behaviour are similar to
  * :type:`nghttp2_on_header_callback`.  The difference is that this
  * callback is only invoked when a invalid header name/value pair is
- * received which is treated as stream error if this callback is not
- * set.  Only invalid regular header field are passed to this
- * callback.  In other words, invalid pseudo header field is not
- * passed to this callback.  Also header fields which includes upper
- * cased latter are also treated as error without passing them to this
- * callback.
+ * received which is treated as stream error if this callback returns
+ * :enum:`nghttp2_error.NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE` and
+ * :type:`nghttp2_on_invalid_header_callback2` is not set.  Only
+ * invalid regular header field are passed to this callback.  In other
+ * words, invalid pseudo header field is not passed to this callback.
+ * Also header fields which includes upper cased latter are also
+ * treated as error without passing them to this callback.
  *
  * This callback is only considered if HTTP messaging validation is
  * turned on (which is on by default, see
@@ -2082,11 +2083,12 @@ typedef int (*nghttp2_on_invalid_header_callback)(
  * The parameter and behaviour are similar to
  * :type:`nghttp2_on_header_callback2`.  The difference is that this
  * callback is only invoked when a invalid header name/value pair is
- * received which is silently ignored if this callback is not set.
- * Only invalid regular header field are passed to this callback.  In
- * other words, invalid pseudo header field is not passed to this
- * callback.  Also header fields which includes upper cased latter are
- * also treated as error without passing them to this callback.
+ * received which is silently ignored if neither this callback nor
+ * :type:`nghttp2_on_invalid_header_callback` is set.  Only invalid
+ * regular header field are passed to this callback.  In other words,
+ * invalid pseudo header field is not passed to this callback.  Also
+ * header fields which includes upper cased latter are also treated as
+ * error without passing them to this callback.
  *
  * This callback is only considered if HTTP messaging validation is
  * turned on (which is on by default, see

--- a/lib/nghttp2_int.h
+++ b/lib/nghttp2_int.h
@@ -52,7 +52,11 @@ typedef enum {
    * Unlike NGHTTP2_ERR_IGN_HTTP_HEADER, this does not invoke
    * nghttp2_on_invalid_header_callback.
    */
-  NGHTTP2_ERR_REMOVE_HTTP_HEADER = -106
+  NGHTTP2_ERR_REMOVE_HTTP_HEADER = -106,
+  /*
+   * Cancel pushed stream.
+   */
+  NGHTTP2_ERR_PUSH_CANCEL = -107,
 } nghttp2_internal_error;
 
 #endif /* NGHTTP2_INT_H */

--- a/src/shrpx_http2_upstream.cc
+++ b/src/shrpx_http2_upstream.cc
@@ -228,35 +228,6 @@ int on_header_callback2(nghttp2_session *session, const nghttp2_frame *frame,
 } // namespace
 
 namespace {
-int on_invalid_header_callback2(nghttp2_session *session,
-                                const nghttp2_frame *frame, nghttp2_rcbuf *name,
-                                nghttp2_rcbuf *value, uint8_t flags,
-                                void *user_data) {
-  auto upstream = static_cast<Http2Upstream *>(user_data);
-  auto downstream = static_cast<Downstream *>(
-    nghttp2_session_get_stream_user_data(session, frame->hd.stream_id));
-  if (!downstream) {
-    return 0;
-  }
-
-  if (LOG_ENABLED(INFO)) {
-    auto namebuf = nghttp2_rcbuf_get_buf(name);
-    auto valuebuf = nghttp2_rcbuf_get_buf(value);
-
-    ULOG(INFO, upstream) << "Invalid header field for stream_id="
-                         << frame->hd.stream_id << ": name=["
-                         << as_string_view(namebuf.base, namebuf.len)
-                         << "], value=["
-                         << as_string_view(valuebuf.base, valuebuf.len) << "]";
-  }
-
-  upstream->rst_stream(downstream, NGHTTP2_PROTOCOL_ERROR);
-
-  return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
-}
-} // namespace
-
-namespace {
 int on_begin_headers_callback(nghttp2_session *session,
                               const nghttp2_frame *frame, void *user_data) {
   auto upstream = static_cast<Http2Upstream *>(user_data);
@@ -980,9 +951,6 @@ nghttp2_session_callbacks *create_http2_upstream_callbacks() {
 
   nghttp2_session_callbacks_set_on_header_callback2(callbacks,
                                                     on_header_callback2);
-
-  nghttp2_session_callbacks_set_on_invalid_header_callback2(
-    callbacks, on_invalid_header_callback2);
 
   nghttp2_session_callbacks_set_on_begin_headers_callback(
     callbacks, on_begin_headers_callback);


### PR DESCRIPTION
Stream errors are now promoted to connection errors.  This means that an event that previously just resets a single stream now closes a connection entirely.  The promoted errors are mostly implementation errors.  Some involve HTTP fields, but they are already treated stream error.  People who care about that should have already raised any issues.  We do not have any outstanding related issues now, so it seems OK to treat it as connection error.

We have some contradictory specifications around
nghttp2_on_invalid_header and nghttp2_on_invalid_header2 callbacks. nghttp2_on_invalid_header says that if it is omitted, a stream is reset.  Meanwhile, nghttp2_on_invalid_header2 says that if it is omitted, invalid field is silently ignored.  In actual implementation, if both omitted, we treat it as stream error.  In practice, it is often required not to bail out if invalid header is received.  In this change, if both callbacks are omitted, invalid field is silently ignored as the documentation of nghttp2_on_invalid_header2 says.  The connection error promotion is applied here as well.  So if invalid field is received, and callback returns
NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE, it is treated as connection error.