### PR TITLE
src: constexpr fixup

### DIFF
--- a/src/base64.h
+++ b/src/base64.h
@@ -36,15 +36,13 @@ namespace nghttp2 {
 
 namespace base64 {
 
-namespace {
-constexpr char B64_CHARS[] = {
+inline constexpr char B64_CHARS[] = {
   'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
   'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
   'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
   'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
   '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/',
 };
-} // namespace
 
 constexpr size_t encode_length(size_t n) { return (n + 2) / 3 * 4; }
 
@@ -121,7 +119,7 @@ constexpr std::string encode(R &&r) {
   return res;
 }
 
-constinit const int B64_INDEX_TABLE[] = {
+inline constexpr int B64_INDEX_TABLE[] = {
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
   -1, -1, -1, -1, -1, 62, -1, -1, -1, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60,

--- a/src/h2load.h
+++ b/src/h2load.h
@@ -75,7 +75,7 @@ using namespace nghttp2;
 
 namespace h2load {
 
-constexpr auto BACKOFF_WRITE_BUFFER_THRES = 16_k;
+inline constexpr auto BACKOFF_WRITE_BUFFER_THRES = 16_k;
 
 class Session;
 struct Worker;

--- a/src/h2load_quic.h
+++ b/src/h2load_quic.h
@@ -32,7 +32,7 @@
 #include "h2load.h"
 
 namespace h2load {
-constexpr size_t QUIC_TX_DATALEN = 64_k;
+inline constexpr size_t QUIC_TX_DATALEN = 64_k;
 
 void quic_pkt_timeout_cb(struct ev_loop *loop, ev_timer *w, int revents);
 } // namespace h2load

--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -370,7 +370,7 @@ int save_pid() {
   std::array<char, STRERROR_BUFSIZE> errbuf;
   auto config = get_config();
 
-  constexpr auto SUFFIX = ".XXXXXX"sv;
+  static constexpr auto SUFFIX = ".XXXXXX"sv;
   auto &pid_file = config->pid_file;
 
   auto len = config->pid_file.size() + SUFFIX.size();

--- a/src/shrpx_api_downstream_connection.cc
+++ b/src/shrpx_api_downstream_connection.cc
@@ -115,9 +115,9 @@ int APIDownstreamConnection::send_reply(unsigned int http_status,
     assert(0);
   }
 
-  constexpr auto M1 = "{\"status\":\""sv;
-  constexpr auto M2 = "\",\"code\":"sv;
-  constexpr auto M3 = "}"sv;
+  static constexpr auto M1 = "{\"status\":\""sv;
+  static constexpr auto M2 = "\",\"code\":"sv;
+  static constexpr auto M3 = "}"sv;
 
   // 3 is the number of digits in http_status, assuming it is 3 digits
   // number.

--- a/src/shrpx_client_handler.cc
+++ b/src/shrpx_client_handler.cc
@@ -1190,10 +1190,11 @@ int ClientHandler::perform_http2_upgrade(HttpsUpstream *http) {
 
   input->remove(*output, input->rleft());
 
-  constexpr auto res = "HTTP/1.1 101 Switching Protocols\r\n"
-                       "Connection: Upgrade\r\n"
-                       "Upgrade: " NGHTTP2_CLEARTEXT_PROTO_VERSION_ID "\r\n"
-                       "\r\n"sv;
+  static constexpr auto res =
+    "HTTP/1.1 101 Switching Protocols\r\n"
+    "Connection: Upgrade\r\n"
+    "Upgrade: " NGHTTP2_CLEARTEXT_PROTO_VERSION_ID "\r\n"
+    "\r\n"sv;
 
   output->append(res);
   upstream_ = std::move(upstream);
@@ -1352,7 +1353,7 @@ int ClientHandler::proxy_protocol_read() {
 
   --end;
 
-  constexpr auto HEADER = "PROXY "sv;
+  static constexpr auto HEADER = "PROXY "sv;
 
   if (static_cast<size_t>(end - rb_.pos()) < HEADER.size()) {
     if (LOG_ENABLED(INFO)) {

--- a/src/shrpx_config.h
+++ b/src/shrpx_config.h
@@ -82,290 +82,311 @@ class CertLookupTree;
 
 } // namespace tls
 
-constexpr auto SHRPX_OPT_PRIVATE_KEY_FILE = "private-key-file"sv;
-constexpr auto SHRPX_OPT_PRIVATE_KEY_PASSWD_FILE = "private-key-passwd-file"sv;
-constexpr auto SHRPX_OPT_CERTIFICATE_FILE = "certificate-file"sv;
-constexpr auto SHRPX_OPT_DH_PARAM_FILE = "dh-param-file"sv;
-constexpr auto SHRPX_OPT_SUBCERT = "subcert"sv;
-constexpr auto SHRPX_OPT_BACKEND = "backend"sv;
-constexpr auto SHRPX_OPT_FRONTEND = "frontend"sv;
-constexpr auto SHRPX_OPT_WORKERS = "workers"sv;
-constexpr auto SHRPX_OPT_HTTP2_MAX_CONCURRENT_STREAMS =
+inline constexpr auto SHRPX_OPT_PRIVATE_KEY_FILE = "private-key-file"sv;
+inline constexpr auto SHRPX_OPT_PRIVATE_KEY_PASSWD_FILE =
+  "private-key-passwd-file"sv;
+inline constexpr auto SHRPX_OPT_CERTIFICATE_FILE = "certificate-file"sv;
+inline constexpr auto SHRPX_OPT_DH_PARAM_FILE = "dh-param-file"sv;
+inline constexpr auto SHRPX_OPT_SUBCERT = "subcert"sv;
+inline constexpr auto SHRPX_OPT_BACKEND = "backend"sv;
+inline constexpr auto SHRPX_OPT_FRONTEND = "frontend"sv;
+inline constexpr auto SHRPX_OPT_WORKERS = "workers"sv;
+inline constexpr auto SHRPX_OPT_HTTP2_MAX_CONCURRENT_STREAMS =
   "http2-max-concurrent-streams"sv;
-constexpr auto SHRPX_OPT_LOG_LEVEL = "log-level"sv;
-constexpr auto SHRPX_OPT_DAEMON = "daemon"sv;
-constexpr auto SHRPX_OPT_HTTP2_PROXY = "http2-proxy"sv;
-constexpr auto SHRPX_OPT_HTTP2_BRIDGE = "http2-bridge"sv;
-constexpr auto SHRPX_OPT_CLIENT_PROXY = "client-proxy"sv;
-constexpr auto SHRPX_OPT_ADD_X_FORWARDED_FOR = "add-x-forwarded-for"sv;
-constexpr auto SHRPX_OPT_STRIP_INCOMING_X_FORWARDED_FOR =
+inline constexpr auto SHRPX_OPT_LOG_LEVEL = "log-level"sv;
+inline constexpr auto SHRPX_OPT_DAEMON = "daemon"sv;
+inline constexpr auto SHRPX_OPT_HTTP2_PROXY = "http2-proxy"sv;
+inline constexpr auto SHRPX_OPT_HTTP2_BRIDGE = "http2-bridge"sv;
+inline constexpr auto SHRPX_OPT_CLIENT_PROXY = "client-proxy"sv;
+inline constexpr auto SHRPX_OPT_ADD_X_FORWARDED_FOR = "add-x-forwarded-for"sv;
+inline constexpr auto SHRPX_OPT_STRIP_INCOMING_X_FORWARDED_FOR =
   "strip-incoming-x-forwarded-for"sv;
-constexpr auto SHRPX_OPT_NO_VIA = "no-via"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HTTP2_READ_TIMEOUT =
+inline constexpr auto SHRPX_OPT_NO_VIA = "no-via"sv;
+inline constexpr auto SHRPX_OPT_FRONTEND_HTTP2_READ_TIMEOUT =
   "frontend-http2-read-timeout"sv;
-constexpr auto SHRPX_OPT_FRONTEND_READ_TIMEOUT = "frontend-read-timeout"sv;
-constexpr auto SHRPX_OPT_FRONTEND_WRITE_TIMEOUT = "frontend-write-timeout"sv;
-constexpr auto SHRPX_OPT_BACKEND_READ_TIMEOUT = "backend-read-timeout"sv;
-constexpr auto SHRPX_OPT_BACKEND_WRITE_TIMEOUT = "backend-write-timeout"sv;
-constexpr auto SHRPX_OPT_STREAM_READ_TIMEOUT = "stream-read-timeout"sv;
-constexpr auto SHRPX_OPT_STREAM_WRITE_TIMEOUT = "stream-write-timeout"sv;
-constexpr auto SHRPX_OPT_ACCESSLOG_FILE = "accesslog-file"sv;
-constexpr auto SHRPX_OPT_ACCESSLOG_SYSLOG = "accesslog-syslog"sv;
-constexpr auto SHRPX_OPT_ACCESSLOG_FORMAT = "accesslog-format"sv;
-constexpr auto SHRPX_OPT_ERRORLOG_FILE = "errorlog-file"sv;
-constexpr auto SHRPX_OPT_ERRORLOG_SYSLOG = "errorlog-syslog"sv;
-constexpr auto SHRPX_OPT_BACKEND_KEEP_ALIVE_TIMEOUT =
+inline constexpr auto SHRPX_OPT_FRONTEND_READ_TIMEOUT =
+  "frontend-read-timeout"sv;
+inline constexpr auto SHRPX_OPT_FRONTEND_WRITE_TIMEOUT =
+  "frontend-write-timeout"sv;
+inline constexpr auto SHRPX_OPT_BACKEND_READ_TIMEOUT = "backend-read-timeout"sv;
+inline constexpr auto SHRPX_OPT_BACKEND_WRITE_TIMEOUT =
+  "backend-write-timeout"sv;
+inline constexpr auto SHRPX_OPT_STREAM_READ_TIMEOUT = "stream-read-timeout"sv;
+inline constexpr auto SHRPX_OPT_STREAM_WRITE_TIMEOUT = "stream-write-timeout"sv;
+inline constexpr auto SHRPX_OPT_ACCESSLOG_FILE = "accesslog-file"sv;
+inline constexpr auto SHRPX_OPT_ACCESSLOG_SYSLOG = "accesslog-syslog"sv;
+inline constexpr auto SHRPX_OPT_ACCESSLOG_FORMAT = "accesslog-format"sv;
+inline constexpr auto SHRPX_OPT_ERRORLOG_FILE = "errorlog-file"sv;
+inline constexpr auto SHRPX_OPT_ERRORLOG_SYSLOG = "errorlog-syslog"sv;
+inline constexpr auto SHRPX_OPT_BACKEND_KEEP_ALIVE_TIMEOUT =
   "backend-keep-alive-timeout"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HTTP2_WINDOW_BITS =
+inline constexpr auto SHRPX_OPT_FRONTEND_HTTP2_WINDOW_BITS =
   "frontend-http2-window-bits"sv;
-constexpr auto SHRPX_OPT_BACKEND_HTTP2_WINDOW_BITS =
+inline constexpr auto SHRPX_OPT_BACKEND_HTTP2_WINDOW_BITS =
   "backend-http2-window-bits"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HTTP2_CONNECTION_WINDOW_BITS =
+inline constexpr auto SHRPX_OPT_FRONTEND_HTTP2_CONNECTION_WINDOW_BITS =
   "frontend-http2-connection-window-bits"sv;
-constexpr auto SHRPX_OPT_BACKEND_HTTP2_CONNECTION_WINDOW_BITS =
+inline constexpr auto SHRPX_OPT_BACKEND_HTTP2_CONNECTION_WINDOW_BITS =
   "backend-http2-connection-window-bits"sv;
-constexpr auto SHRPX_OPT_FRONTEND_NO_TLS = "frontend-no-tls"sv;
-constexpr auto SHRPX_OPT_BACKEND_NO_TLS = "backend-no-tls"sv;
-constexpr auto SHRPX_OPT_BACKEND_TLS_SNI_FIELD = "backend-tls-sni-field"sv;
-constexpr auto SHRPX_OPT_PID_FILE = "pid-file"sv;
-constexpr auto SHRPX_OPT_USER = "user"sv;
-constexpr auto SHRPX_OPT_SYSLOG_FACILITY = "syslog-facility"sv;
-constexpr auto SHRPX_OPT_BACKLOG = "backlog"sv;
-constexpr auto SHRPX_OPT_CIPHERS = "ciphers"sv;
-constexpr auto SHRPX_OPT_CLIENT = "client"sv;
-constexpr auto SHRPX_OPT_INSECURE = "insecure"sv;
-constexpr auto SHRPX_OPT_CACERT = "cacert"sv;
-constexpr auto SHRPX_OPT_BACKEND_IPV4 = "backend-ipv4"sv;
-constexpr auto SHRPX_OPT_BACKEND_IPV6 = "backend-ipv6"sv;
-constexpr auto SHRPX_OPT_BACKEND_HTTP_PROXY_URI = "backend-http-proxy-uri"sv;
-constexpr auto SHRPX_OPT_READ_RATE = "read-rate"sv;
-constexpr auto SHRPX_OPT_READ_BURST = "read-burst"sv;
-constexpr auto SHRPX_OPT_WRITE_RATE = "write-rate"sv;
-constexpr auto SHRPX_OPT_WRITE_BURST = "write-burst"sv;
-constexpr auto SHRPX_OPT_WORKER_READ_RATE = "worker-read-rate"sv;
-constexpr auto SHRPX_OPT_WORKER_READ_BURST = "worker-read-burst"sv;
-constexpr auto SHRPX_OPT_WORKER_WRITE_RATE = "worker-write-rate"sv;
-constexpr auto SHRPX_OPT_WORKER_WRITE_BURST = "worker-write-burst"sv;
-constexpr auto SHRPX_OPT_NPN_LIST = "npn-list"sv;
-constexpr auto SHRPX_OPT_TLS_PROTO_LIST = "tls-proto-list"sv;
-constexpr auto SHRPX_OPT_VERIFY_CLIENT = "verify-client"sv;
-constexpr auto SHRPX_OPT_VERIFY_CLIENT_CACERT = "verify-client-cacert"sv;
-constexpr auto SHRPX_OPT_CLIENT_PRIVATE_KEY_FILE = "client-private-key-file"sv;
-constexpr auto SHRPX_OPT_CLIENT_CERT_FILE = "client-cert-file"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HTTP2_DUMP_REQUEST_HEADER =
+inline constexpr auto SHRPX_OPT_FRONTEND_NO_TLS = "frontend-no-tls"sv;
+inline constexpr auto SHRPX_OPT_BACKEND_NO_TLS = "backend-no-tls"sv;
+inline constexpr auto SHRPX_OPT_BACKEND_TLS_SNI_FIELD =
+  "backend-tls-sni-field"sv;
+inline constexpr auto SHRPX_OPT_PID_FILE = "pid-file"sv;
+inline constexpr auto SHRPX_OPT_USER = "user"sv;
+inline constexpr auto SHRPX_OPT_SYSLOG_FACILITY = "syslog-facility"sv;
+inline constexpr auto SHRPX_OPT_BACKLOG = "backlog"sv;
+inline constexpr auto SHRPX_OPT_CIPHERS = "ciphers"sv;
+inline constexpr auto SHRPX_OPT_CLIENT = "client"sv;
+inline constexpr auto SHRPX_OPT_INSECURE = "insecure"sv;
+inline constexpr auto SHRPX_OPT_CACERT = "cacert"sv;
+inline constexpr auto SHRPX_OPT_BACKEND_IPV4 = "backend-ipv4"sv;
+inline constexpr auto SHRPX_OPT_BACKEND_IPV6 = "backend-ipv6"sv;
+inline constexpr auto SHRPX_OPT_BACKEND_HTTP_PROXY_URI =
+  "backend-http-proxy-uri"sv;
+inline constexpr auto SHRPX_OPT_READ_RATE = "read-rate"sv;
+inline constexpr auto SHRPX_OPT_READ_BURST = "read-burst"sv;
+inline constexpr auto SHRPX_OPT_WRITE_RATE = "write-rate"sv;
+inline constexpr auto SHRPX_OPT_WRITE_BURST = "write-burst"sv;
+inline constexpr auto SHRPX_OPT_WORKER_READ_RATE = "worker-read-rate"sv;
+inline constexpr auto SHRPX_OPT_WORKER_READ_BURST = "worker-read-burst"sv;
+inline constexpr auto SHRPX_OPT_WORKER_WRITE_RATE = "worker-write-rate"sv;
+inline constexpr auto SHRPX_OPT_WORKER_WRITE_BURST = "worker-write-burst"sv;
+inline constexpr auto SHRPX_OPT_NPN_LIST = "npn-list"sv;
+inline constexpr auto SHRPX_OPT_TLS_PROTO_LIST = "tls-proto-list"sv;
+inline constexpr auto SHRPX_OPT_VERIFY_CLIENT = "verify-client"sv;
+inline constexpr auto SHRPX_OPT_VERIFY_CLIENT_CACERT = "verify-client-cacert"sv;
+inline constexpr auto SHRPX_OPT_CLIENT_PRIVATE_KEY_FILE =
+  "client-private-key-file"sv;
+inline constexpr auto SHRPX_OPT_CLIENT_CERT_FILE = "client-cert-file"sv;
+inline constexpr auto SHRPX_OPT_FRONTEND_HTTP2_DUMP_REQUEST_HEADER =
   "frontend-http2-dump-request-header"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HTTP2_DUMP_RESPONSE_HEADER =
+inline constexpr auto SHRPX_OPT_FRONTEND_HTTP2_DUMP_RESPONSE_HEADER =
   "frontend-http2-dump-response-header"sv;
-constexpr auto SHRPX_OPT_HTTP2_NO_COOKIE_CRUMBLING =
+inline constexpr auto SHRPX_OPT_HTTP2_NO_COOKIE_CRUMBLING =
   "http2-no-cookie-crumbling"sv;
-constexpr auto SHRPX_OPT_FRONTEND_FRAME_DEBUG = "frontend-frame-debug"sv;
-constexpr auto SHRPX_OPT_PADDING = "padding"sv;
-constexpr auto SHRPX_OPT_ALTSVC = "altsvc"sv;
-constexpr auto SHRPX_OPT_ADD_REQUEST_HEADER = "add-request-header"sv;
-constexpr auto SHRPX_OPT_ADD_RESPONSE_HEADER = "add-response-header"sv;
-constexpr auto SHRPX_OPT_WORKER_FRONTEND_CONNECTIONS =
+inline constexpr auto SHRPX_OPT_FRONTEND_FRAME_DEBUG = "frontend-frame-debug"sv;
+inline constexpr auto SHRPX_OPT_PADDING = "padding"sv;
+inline constexpr auto SHRPX_OPT_ALTSVC = "altsvc"sv;
+inline constexpr auto SHRPX_OPT_ADD_REQUEST_HEADER = "add-request-header"sv;
+inline constexpr auto SHRPX_OPT_ADD_RESPONSE_HEADER = "add-response-header"sv;
+inline constexpr auto SHRPX_OPT_WORKER_FRONTEND_CONNECTIONS =
   "worker-frontend-connections"sv;
-constexpr auto SHRPX_OPT_NO_LOCATION_REWRITE = "no-location-rewrite"sv;
-constexpr auto SHRPX_OPT_NO_HOST_REWRITE = "no-host-rewrite"sv;
-constexpr auto SHRPX_OPT_BACKEND_HTTP1_CONNECTIONS_PER_HOST =
+inline constexpr auto SHRPX_OPT_NO_LOCATION_REWRITE = "no-location-rewrite"sv;
+inline constexpr auto SHRPX_OPT_NO_HOST_REWRITE = "no-host-rewrite"sv;
+inline constexpr auto SHRPX_OPT_BACKEND_HTTP1_CONNECTIONS_PER_HOST =
   "backend-http1-connections-per-host"sv;
-constexpr auto SHRPX_OPT_BACKEND_HTTP1_CONNECTIONS_PER_FRONTEND =
+inline constexpr auto SHRPX_OPT_BACKEND_HTTP1_CONNECTIONS_PER_FRONTEND =
   "backend-http1-connections-per-frontend"sv;
-constexpr auto SHRPX_OPT_LISTENER_DISABLE_TIMEOUT =
+inline constexpr auto SHRPX_OPT_LISTENER_DISABLE_TIMEOUT =
   "listener-disable-timeout"sv;
-constexpr auto SHRPX_OPT_TLS_TICKET_KEY_FILE = "tls-ticket-key-file"sv;
-constexpr auto SHRPX_OPT_RLIMIT_NOFILE = "rlimit-nofile"sv;
-constexpr auto SHRPX_OPT_BACKEND_REQUEST_BUFFER = "backend-request-buffer"sv;
-constexpr auto SHRPX_OPT_BACKEND_RESPONSE_BUFFER = "backend-response-buffer"sv;
-constexpr auto SHRPX_OPT_NO_SERVER_PUSH = "no-server-push"sv;
-constexpr auto SHRPX_OPT_BACKEND_HTTP2_CONNECTIONS_PER_WORKER =
+inline constexpr auto SHRPX_OPT_TLS_TICKET_KEY_FILE = "tls-ticket-key-file"sv;
+inline constexpr auto SHRPX_OPT_RLIMIT_NOFILE = "rlimit-nofile"sv;
+inline constexpr auto SHRPX_OPT_BACKEND_REQUEST_BUFFER =
+  "backend-request-buffer"sv;
+inline constexpr auto SHRPX_OPT_BACKEND_RESPONSE_BUFFER =
+  "backend-response-buffer"sv;
+inline constexpr auto SHRPX_OPT_NO_SERVER_PUSH = "no-server-push"sv;
+inline constexpr auto SHRPX_OPT_BACKEND_HTTP2_CONNECTIONS_PER_WORKER =
   "backend-http2-connections-per-worker"sv;
-constexpr auto SHRPX_OPT_FETCH_OCSP_RESPONSE_FILE =
+inline constexpr auto SHRPX_OPT_FETCH_OCSP_RESPONSE_FILE =
   "fetch-ocsp-response-file"sv;
-constexpr auto SHRPX_OPT_OCSP_UPDATE_INTERVAL = "ocsp-update-interval"sv;
-constexpr auto SHRPX_OPT_NO_OCSP = "no-ocsp"sv;
-constexpr auto SHRPX_OPT_HEADER_FIELD_BUFFER = "header-field-buffer"sv;
-constexpr auto SHRPX_OPT_MAX_HEADER_FIELDS = "max-header-fields"sv;
-constexpr auto SHRPX_OPT_INCLUDE = "include"sv;
-constexpr auto SHRPX_OPT_TLS_TICKET_KEY_CIPHER = "tls-ticket-key-cipher"sv;
-constexpr auto SHRPX_OPT_HOST_REWRITE = "host-rewrite"sv;
-constexpr auto SHRPX_OPT_TLS_SESSION_CACHE_MEMCACHED =
+inline constexpr auto SHRPX_OPT_OCSP_UPDATE_INTERVAL = "ocsp-update-interval"sv;
+inline constexpr auto SHRPX_OPT_NO_OCSP = "no-ocsp"sv;
+inline constexpr auto SHRPX_OPT_HEADER_FIELD_BUFFER = "header-field-buffer"sv;
+inline constexpr auto SHRPX_OPT_MAX_HEADER_FIELDS = "max-header-fields"sv;
+inline constexpr auto SHRPX_OPT_INCLUDE = "include"sv;
+inline constexpr auto SHRPX_OPT_TLS_TICKET_KEY_CIPHER =
+  "tls-ticket-key-cipher"sv;
+inline constexpr auto SHRPX_OPT_HOST_REWRITE = "host-rewrite"sv;
+inline constexpr auto SHRPX_OPT_TLS_SESSION_CACHE_MEMCACHED =
   "tls-session-cache-memcached"sv;
-constexpr auto SHRPX_OPT_TLS_TICKET_KEY_MEMCACHED =
+inline constexpr auto SHRPX_OPT_TLS_TICKET_KEY_MEMCACHED =
   "tls-ticket-key-memcached"sv;
-constexpr auto SHRPX_OPT_TLS_TICKET_KEY_MEMCACHED_INTERVAL =
+inline constexpr auto SHRPX_OPT_TLS_TICKET_KEY_MEMCACHED_INTERVAL =
   "tls-ticket-key-memcached-interval"sv;
-constexpr auto SHRPX_OPT_TLS_TICKET_KEY_MEMCACHED_MAX_RETRY =
+inline constexpr auto SHRPX_OPT_TLS_TICKET_KEY_MEMCACHED_MAX_RETRY =
   "tls-ticket-key-memcached-max-retry"sv;
-constexpr auto SHRPX_OPT_TLS_TICKET_KEY_MEMCACHED_MAX_FAIL =
+inline constexpr auto SHRPX_OPT_TLS_TICKET_KEY_MEMCACHED_MAX_FAIL =
   "tls-ticket-key-memcached-max-fail"sv;
-constexpr auto SHRPX_OPT_MRUBY_FILE = "mruby-file"sv;
-constexpr auto SHRPX_OPT_ACCEPT_PROXY_PROTOCOL = "accept-proxy-protocol"sv;
-constexpr auto SHRPX_OPT_FASTOPEN = "fastopen"sv;
-constexpr auto SHRPX_OPT_TLS_DYN_REC_WARMUP_THRESHOLD =
+inline constexpr auto SHRPX_OPT_MRUBY_FILE = "mruby-file"sv;
+inline constexpr auto SHRPX_OPT_ACCEPT_PROXY_PROTOCOL =
+  "accept-proxy-protocol"sv;
+inline constexpr auto SHRPX_OPT_FASTOPEN = "fastopen"sv;
+inline constexpr auto SHRPX_OPT_TLS_DYN_REC_WARMUP_THRESHOLD =
   "tls-dyn-rec-warmup-threshold"sv;
-constexpr auto SHRPX_OPT_TLS_DYN_REC_IDLE_TIMEOUT =
+inline constexpr auto SHRPX_OPT_TLS_DYN_REC_IDLE_TIMEOUT =
   "tls-dyn-rec-idle-timeout"sv;
-constexpr auto SHRPX_OPT_ADD_FORWARDED = "add-forwarded"sv;
-constexpr auto SHRPX_OPT_STRIP_INCOMING_FORWARDED =
+inline constexpr auto SHRPX_OPT_ADD_FORWARDED = "add-forwarded"sv;
+inline constexpr auto SHRPX_OPT_STRIP_INCOMING_FORWARDED =
   "strip-incoming-forwarded"sv;
-constexpr auto SHRPX_OPT_FORWARDED_BY = "forwarded-by"sv;
-constexpr auto SHRPX_OPT_FORWARDED_FOR = "forwarded-for"sv;
-constexpr auto SHRPX_OPT_REQUEST_HEADER_FIELD_BUFFER =
+inline constexpr auto SHRPX_OPT_FORWARDED_BY = "forwarded-by"sv;
+inline constexpr auto SHRPX_OPT_FORWARDED_FOR = "forwarded-for"sv;
+inline constexpr auto SHRPX_OPT_REQUEST_HEADER_FIELD_BUFFER =
   "request-header-field-buffer"sv;
-constexpr auto SHRPX_OPT_MAX_REQUEST_HEADER_FIELDS =
+inline constexpr auto SHRPX_OPT_MAX_REQUEST_HEADER_FIELDS =
   "max-request-header-fields"sv;
-constexpr auto SHRPX_OPT_RESPONSE_HEADER_FIELD_BUFFER =
+inline constexpr auto SHRPX_OPT_RESPONSE_HEADER_FIELD_BUFFER =
   "response-header-field-buffer"sv;
-constexpr auto SHRPX_OPT_MAX_RESPONSE_HEADER_FIELDS =
+inline constexpr auto SHRPX_OPT_MAX_RESPONSE_HEADER_FIELDS =
   "max-response-header-fields"sv;
-constexpr auto SHRPX_OPT_NO_HTTP2_CIPHER_BLOCK_LIST =
+inline constexpr auto SHRPX_OPT_NO_HTTP2_CIPHER_BLOCK_LIST =
   "no-http2-cipher-block-list"sv;
-constexpr auto SHRPX_OPT_NO_HTTP2_CIPHER_BLACK_LIST =
+inline constexpr auto SHRPX_OPT_NO_HTTP2_CIPHER_BLACK_LIST =
   "no-http2-cipher-black-list"sv;
-constexpr auto SHRPX_OPT_BACKEND_HTTP1_TLS = "backend-http1-tls"sv;
-constexpr auto SHRPX_OPT_TLS_SESSION_CACHE_MEMCACHED_TLS =
+inline constexpr auto SHRPX_OPT_BACKEND_HTTP1_TLS = "backend-http1-tls"sv;
+inline constexpr auto SHRPX_OPT_TLS_SESSION_CACHE_MEMCACHED_TLS =
   "tls-session-cache-memcached-tls"sv;
-constexpr auto SHRPX_OPT_TLS_SESSION_CACHE_MEMCACHED_CERT_FILE =
+inline constexpr auto SHRPX_OPT_TLS_SESSION_CACHE_MEMCACHED_CERT_FILE =
   "tls-session-cache-memcached-cert-file"sv;
-constexpr auto SHRPX_OPT_TLS_SESSION_CACHE_MEMCACHED_PRIVATE_KEY_FILE =
+inline constexpr auto SHRPX_OPT_TLS_SESSION_CACHE_MEMCACHED_PRIVATE_KEY_FILE =
   "tls-session-cache-memcached-private-key-file"sv;
-constexpr auto SHRPX_OPT_TLS_SESSION_CACHE_MEMCACHED_ADDRESS_FAMILY =
+inline constexpr auto SHRPX_OPT_TLS_SESSION_CACHE_MEMCACHED_ADDRESS_FAMILY =
   "tls-session-cache-memcached-address-family"sv;
-constexpr auto SHRPX_OPT_TLS_TICKET_KEY_MEMCACHED_TLS =
+inline constexpr auto SHRPX_OPT_TLS_TICKET_KEY_MEMCACHED_TLS =
   "tls-ticket-key-memcached-tls"sv;
-constexpr auto SHRPX_OPT_TLS_TICKET_KEY_MEMCACHED_CERT_FILE =
+inline constexpr auto SHRPX_OPT_TLS_TICKET_KEY_MEMCACHED_CERT_FILE =
   "tls-ticket-key-memcached-cert-file"sv;
-constexpr auto SHRPX_OPT_TLS_TICKET_KEY_MEMCACHED_PRIVATE_KEY_FILE =
+inline constexpr auto SHRPX_OPT_TLS_TICKET_KEY_MEMCACHED_PRIVATE_KEY_FILE =
   "tls-ticket-key-memcached-private-key-file"sv;
-constexpr auto SHRPX_OPT_TLS_TICKET_KEY_MEMCACHED_ADDRESS_FAMILY =
+inline constexpr auto SHRPX_OPT_TLS_TICKET_KEY_MEMCACHED_ADDRESS_FAMILY =
   "tls-ticket-key-memcached-address-family"sv;
-constexpr auto SHRPX_OPT_BACKEND_ADDRESS_FAMILY = "backend-address-family"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HTTP2_MAX_CONCURRENT_STREAMS =
+inline constexpr auto SHRPX_OPT_BACKEND_ADDRESS_FAMILY =
+  "backend-address-family"sv;
+inline constexpr auto SHRPX_OPT_FRONTEND_HTTP2_MAX_CONCURRENT_STREAMS =
   "frontend-http2-max-concurrent-streams"sv;
-constexpr auto SHRPX_OPT_BACKEND_HTTP2_MAX_CONCURRENT_STREAMS =
+inline constexpr auto SHRPX_OPT_BACKEND_HTTP2_MAX_CONCURRENT_STREAMS =
   "backend-http2-max-concurrent-streams"sv;
-constexpr auto SHRPX_OPT_BACKEND_CONNECTIONS_PER_FRONTEND =
+inline constexpr auto SHRPX_OPT_BACKEND_CONNECTIONS_PER_FRONTEND =
   "backend-connections-per-frontend"sv;
-constexpr auto SHRPX_OPT_BACKEND_TLS = "backend-tls"sv;
-constexpr auto SHRPX_OPT_BACKEND_CONNECTIONS_PER_HOST =
+inline constexpr auto SHRPX_OPT_BACKEND_TLS = "backend-tls"sv;
+inline constexpr auto SHRPX_OPT_BACKEND_CONNECTIONS_PER_HOST =
   "backend-connections-per-host"sv;
-constexpr auto SHRPX_OPT_ERROR_PAGE = "error-page"sv;
-constexpr auto SHRPX_OPT_NO_KQUEUE = "no-kqueue"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HTTP2_SETTINGS_TIMEOUT =
+inline constexpr auto SHRPX_OPT_ERROR_PAGE = "error-page"sv;
+inline constexpr auto SHRPX_OPT_NO_KQUEUE = "no-kqueue"sv;
+inline constexpr auto SHRPX_OPT_FRONTEND_HTTP2_SETTINGS_TIMEOUT =
   "frontend-http2-settings-timeout"sv;
-constexpr auto SHRPX_OPT_BACKEND_HTTP2_SETTINGS_TIMEOUT =
+inline constexpr auto SHRPX_OPT_BACKEND_HTTP2_SETTINGS_TIMEOUT =
   "backend-http2-settings-timeout"sv;
-constexpr auto SHRPX_OPT_API_MAX_REQUEST_BODY = "api-max-request-body"sv;
-constexpr auto SHRPX_OPT_BACKEND_MAX_BACKOFF = "backend-max-backoff"sv;
-constexpr auto SHRPX_OPT_SERVER_NAME = "server-name"sv;
-constexpr auto SHRPX_OPT_NO_SERVER_REWRITE = "no-server-rewrite"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HTTP2_OPTIMIZE_WRITE_BUFFER_SIZE =
+inline constexpr auto SHRPX_OPT_API_MAX_REQUEST_BODY = "api-max-request-body"sv;
+inline constexpr auto SHRPX_OPT_BACKEND_MAX_BACKOFF = "backend-max-backoff"sv;
+inline constexpr auto SHRPX_OPT_SERVER_NAME = "server-name"sv;
+inline constexpr auto SHRPX_OPT_NO_SERVER_REWRITE = "no-server-rewrite"sv;
+inline constexpr auto SHRPX_OPT_FRONTEND_HTTP2_OPTIMIZE_WRITE_BUFFER_SIZE =
   "frontend-http2-optimize-write-buffer-size"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HTTP2_OPTIMIZE_WINDOW_SIZE =
+inline constexpr auto SHRPX_OPT_FRONTEND_HTTP2_OPTIMIZE_WINDOW_SIZE =
   "frontend-http2-optimize-window-size"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HTTP2_WINDOW_SIZE =
+inline constexpr auto SHRPX_OPT_FRONTEND_HTTP2_WINDOW_SIZE =
   "frontend-http2-window-size"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HTTP2_CONNECTION_WINDOW_SIZE =
+inline constexpr auto SHRPX_OPT_FRONTEND_HTTP2_CONNECTION_WINDOW_SIZE =
   "frontend-http2-connection-window-size"sv;
-constexpr auto SHRPX_OPT_BACKEND_HTTP2_WINDOW_SIZE =
+inline constexpr auto SHRPX_OPT_BACKEND_HTTP2_WINDOW_SIZE =
   "backend-http2-window-size"sv;
-constexpr auto SHRPX_OPT_BACKEND_HTTP2_CONNECTION_WINDOW_SIZE =
+inline constexpr auto SHRPX_OPT_BACKEND_HTTP2_CONNECTION_WINDOW_SIZE =
   "backend-http2-connection-window-size"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HTTP2_ENCODER_DYNAMIC_TABLE_SIZE =
+inline constexpr auto SHRPX_OPT_FRONTEND_HTTP2_ENCODER_DYNAMIC_TABLE_SIZE =
   "frontend-http2-encoder-dynamic-table-size"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HTTP2_DECODER_DYNAMIC_TABLE_SIZE =
+inline constexpr auto SHRPX_OPT_FRONTEND_HTTP2_DECODER_DYNAMIC_TABLE_SIZE =
   "frontend-http2-decoder-dynamic-table-size"sv;
-constexpr auto SHRPX_OPT_BACKEND_HTTP2_ENCODER_DYNAMIC_TABLE_SIZE =
+inline constexpr auto SHRPX_OPT_BACKEND_HTTP2_ENCODER_DYNAMIC_TABLE_SIZE =
   "backend-http2-encoder-dynamic-table-size"sv;
-constexpr auto SHRPX_OPT_BACKEND_HTTP2_DECODER_DYNAMIC_TABLE_SIZE =
+inline constexpr auto SHRPX_OPT_BACKEND_HTTP2_DECODER_DYNAMIC_TABLE_SIZE =
   "backend-http2-decoder-dynamic-table-size"sv;
-constexpr auto SHRPX_OPT_ECDH_CURVES = "ecdh-curves"sv;
-constexpr auto SHRPX_OPT_TLS_SCT_DIR = "tls-sct-dir"sv;
-constexpr auto SHRPX_OPT_BACKEND_CONNECT_TIMEOUT = "backend-connect-timeout"sv;
-constexpr auto SHRPX_OPT_DNS_CACHE_TIMEOUT = "dns-cache-timeout"sv;
-constexpr auto SHRPX_OPT_DNS_LOOKUP_TIMEOUT = "dns-lookup-timeout"sv;
-constexpr auto SHRPX_OPT_DNS_MAX_TRY = "dns-max-try"sv;
-constexpr auto SHRPX_OPT_FRONTEND_KEEP_ALIVE_TIMEOUT =
+inline constexpr auto SHRPX_OPT_ECDH_CURVES = "ecdh-curves"sv;
+inline constexpr auto SHRPX_OPT_TLS_SCT_DIR = "tls-sct-dir"sv;
+inline constexpr auto SHRPX_OPT_BACKEND_CONNECT_TIMEOUT =
+  "backend-connect-timeout"sv;
+inline constexpr auto SHRPX_OPT_DNS_CACHE_TIMEOUT = "dns-cache-timeout"sv;
+inline constexpr auto SHRPX_OPT_DNS_LOOKUP_TIMEOUT = "dns-lookup-timeout"sv;
+inline constexpr auto SHRPX_OPT_DNS_MAX_TRY = "dns-max-try"sv;
+inline constexpr auto SHRPX_OPT_FRONTEND_KEEP_ALIVE_TIMEOUT =
   "frontend-keep-alive-timeout"sv;
-constexpr auto SHRPX_OPT_PSK_SECRETS = "psk-secrets"sv;
-constexpr auto SHRPX_OPT_CLIENT_PSK_SECRETS = "client-psk-secrets"sv;
-constexpr auto SHRPX_OPT_CLIENT_NO_HTTP2_CIPHER_BLOCK_LIST =
+inline constexpr auto SHRPX_OPT_PSK_SECRETS = "psk-secrets"sv;
+inline constexpr auto SHRPX_OPT_CLIENT_PSK_SECRETS = "client-psk-secrets"sv;
+inline constexpr auto SHRPX_OPT_CLIENT_NO_HTTP2_CIPHER_BLOCK_LIST =
   "client-no-http2-cipher-block-list"sv;
-constexpr auto SHRPX_OPT_CLIENT_NO_HTTP2_CIPHER_BLACK_LIST =
+inline constexpr auto SHRPX_OPT_CLIENT_NO_HTTP2_CIPHER_BLACK_LIST =
   "client-no-http2-cipher-black-list"sv;
-constexpr auto SHRPX_OPT_CLIENT_CIPHERS = "client-ciphers"sv;
-constexpr auto SHRPX_OPT_ACCESSLOG_WRITE_EARLY = "accesslog-write-early"sv;
-constexpr auto SHRPX_OPT_TLS_MIN_PROTO_VERSION = "tls-min-proto-version"sv;
-constexpr auto SHRPX_OPT_TLS_MAX_PROTO_VERSION = "tls-max-proto-version"sv;
-constexpr auto SHRPX_OPT_REDIRECT_HTTPS_PORT = "redirect-https-port"sv;
-constexpr auto SHRPX_OPT_FRONTEND_MAX_REQUESTS = "frontend-max-requests"sv;
-constexpr auto SHRPX_OPT_SINGLE_THREAD = "single-thread"sv;
-constexpr auto SHRPX_OPT_SINGLE_PROCESS = "single-process"sv;
-constexpr auto SHRPX_OPT_NO_ADD_X_FORWARDED_PROTO =
+inline constexpr auto SHRPX_OPT_CLIENT_CIPHERS = "client-ciphers"sv;
+inline constexpr auto SHRPX_OPT_ACCESSLOG_WRITE_EARLY =
+  "accesslog-write-early"sv;
+inline constexpr auto SHRPX_OPT_TLS_MIN_PROTO_VERSION =
+  "tls-min-proto-version"sv;
+inline constexpr auto SHRPX_OPT_TLS_MAX_PROTO_VERSION =
+  "tls-max-proto-version"sv;
+inline constexpr auto SHRPX_OPT_REDIRECT_HTTPS_PORT = "redirect-https-port"sv;
+inline constexpr auto SHRPX_OPT_FRONTEND_MAX_REQUESTS =
+  "frontend-max-requests"sv;
+inline constexpr auto SHRPX_OPT_SINGLE_THREAD = "single-thread"sv;
+inline constexpr auto SHRPX_OPT_SINGLE_PROCESS = "single-process"sv;
+inline constexpr auto SHRPX_OPT_NO_ADD_X_FORWARDED_PROTO =
   "no-add-x-forwarded-proto"sv;
-constexpr auto SHRPX_OPT_NO_STRIP_INCOMING_X_FORWARDED_PROTO =
+inline constexpr auto SHRPX_OPT_NO_STRIP_INCOMING_X_FORWARDED_PROTO =
   "no-strip-incoming-x-forwarded-proto"sv;
-constexpr auto SHRPX_OPT_OCSP_STARTUP = "ocsp-startup"sv;
-constexpr auto SHRPX_OPT_NO_VERIFY_OCSP = "no-verify-ocsp"sv;
-constexpr auto SHRPX_OPT_VERIFY_CLIENT_TOLERATE_EXPIRED =
+inline constexpr auto SHRPX_OPT_OCSP_STARTUP = "ocsp-startup"sv;
+inline constexpr auto SHRPX_OPT_NO_VERIFY_OCSP = "no-verify-ocsp"sv;
+inline constexpr auto SHRPX_OPT_VERIFY_CLIENT_TOLERATE_EXPIRED =
   "verify-client-tolerate-expired"sv;
-constexpr auto SHRPX_OPT_IGNORE_PER_PATTERN_MRUBY_ERROR =
+inline constexpr auto SHRPX_OPT_IGNORE_PER_PATTERN_MRUBY_ERROR =
   "ignore-per-pattern-mruby-error"sv;
-constexpr auto SHRPX_OPT_TLS_NO_POSTPONE_EARLY_DATA =
+inline constexpr auto SHRPX_OPT_TLS_NO_POSTPONE_EARLY_DATA =
   "tls-no-postpone-early-data"sv;
-constexpr auto SHRPX_OPT_TLS_MAX_EARLY_DATA = "tls-max-early-data"sv;
-constexpr auto SHRPX_OPT_TLS13_CIPHERS = "tls13-ciphers"sv;
-constexpr auto SHRPX_OPT_TLS13_CLIENT_CIPHERS = "tls13-client-ciphers"sv;
-constexpr auto SHRPX_OPT_NO_STRIP_INCOMING_EARLY_DATA =
+inline constexpr auto SHRPX_OPT_TLS_MAX_EARLY_DATA = "tls-max-early-data"sv;
+inline constexpr auto SHRPX_OPT_TLS13_CIPHERS = "tls13-ciphers"sv;
+inline constexpr auto SHRPX_OPT_TLS13_CLIENT_CIPHERS = "tls13-client-ciphers"sv;
+inline constexpr auto SHRPX_OPT_NO_STRIP_INCOMING_EARLY_DATA =
   "no-strip-incoming-early-data"sv;
-constexpr auto SHRPX_OPT_QUIC_BPF_PROGRAM_FILE = "quic-bpf-program-file"sv;
-constexpr auto SHRPX_OPT_NO_QUIC_BPF = "no-quic-bpf"sv;
-constexpr auto SHRPX_OPT_HTTP2_ALTSVC = "http2-altsvc"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HTTP3_READ_TIMEOUT =
+inline constexpr auto SHRPX_OPT_QUIC_BPF_PROGRAM_FILE =
+  "quic-bpf-program-file"sv;
+inline constexpr auto SHRPX_OPT_NO_QUIC_BPF = "no-quic-bpf"sv;
+inline constexpr auto SHRPX_OPT_HTTP2_ALTSVC = "http2-altsvc"sv;
+inline constexpr auto SHRPX_OPT_FRONTEND_HTTP3_READ_TIMEOUT =
   "frontend-http3-read-timeout"sv;
-constexpr auto SHRPX_OPT_FRONTEND_QUIC_IDLE_TIMEOUT =
+inline constexpr auto SHRPX_OPT_FRONTEND_QUIC_IDLE_TIMEOUT =
   "frontend-quic-idle-timeout"sv;
-constexpr auto SHRPX_OPT_FRONTEND_QUIC_DEBUG_LOG = "frontend-quic-debug-log"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HTTP3_WINDOW_SIZE =
+inline constexpr auto SHRPX_OPT_FRONTEND_QUIC_DEBUG_LOG =
+  "frontend-quic-debug-log"sv;
+inline constexpr auto SHRPX_OPT_FRONTEND_HTTP3_WINDOW_SIZE =
   "frontend-http3-window-size"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HTTP3_CONNECTION_WINDOW_SIZE =
+inline constexpr auto SHRPX_OPT_FRONTEND_HTTP3_CONNECTION_WINDOW_SIZE =
   "frontend-http3-connection-window-size"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HTTP3_MAX_WINDOW_SIZE =
+inline constexpr auto SHRPX_OPT_FRONTEND_HTTP3_MAX_WINDOW_SIZE =
   "frontend-http3-max-window-size"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HTTP3_MAX_CONNECTION_WINDOW_SIZE =
+inline constexpr auto SHRPX_OPT_FRONTEND_HTTP3_MAX_CONNECTION_WINDOW_SIZE =
   "frontend-http3-max-connection-window-size"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HTTP3_MAX_CONCURRENT_STREAMS =
+inline constexpr auto SHRPX_OPT_FRONTEND_HTTP3_MAX_CONCURRENT_STREAMS =
   "frontend-http3-max-concurrent-streams"sv;
-constexpr auto SHRPX_OPT_FRONTEND_QUIC_EARLY_DATA =
+inline constexpr auto SHRPX_OPT_FRONTEND_QUIC_EARLY_DATA =
   "frontend-quic-early-data"sv;
-constexpr auto SHRPX_OPT_FRONTEND_QUIC_QLOG_DIR = "frontend-quic-qlog-dir"sv;
-constexpr auto SHRPX_OPT_FRONTEND_QUIC_REQUIRE_TOKEN =
+inline constexpr auto SHRPX_OPT_FRONTEND_QUIC_QLOG_DIR =
+  "frontend-quic-qlog-dir"sv;
+inline constexpr auto SHRPX_OPT_FRONTEND_QUIC_REQUIRE_TOKEN =
   "frontend-quic-require-token"sv;
-constexpr auto SHRPX_OPT_FRONTEND_QUIC_CONGESTION_CONTROLLER =
+inline constexpr auto SHRPX_OPT_FRONTEND_QUIC_CONGESTION_CONTROLLER =
   "frontend-quic-congestion-controller"sv;
-constexpr auto SHRPX_OPT_QUIC_SERVER_ID = "quic-server-id"sv;
-constexpr auto SHRPX_OPT_FRONTEND_QUIC_SECRET_FILE =
+inline constexpr auto SHRPX_OPT_QUIC_SERVER_ID = "quic-server-id"sv;
+inline constexpr auto SHRPX_OPT_FRONTEND_QUIC_SECRET_FILE =
   "frontend-quic-secret-file"sv;
-constexpr auto SHRPX_OPT_RLIMIT_MEMLOCK = "rlimit-memlock"sv;
-constexpr auto SHRPX_OPT_MAX_WORKER_PROCESSES = "max-worker-processes"sv;
-constexpr auto SHRPX_OPT_WORKER_PROCESS_GRACE_SHUTDOWN_PERIOD =
+inline constexpr auto SHRPX_OPT_RLIMIT_MEMLOCK = "rlimit-memlock"sv;
+inline constexpr auto SHRPX_OPT_MAX_WORKER_PROCESSES = "max-worker-processes"sv;
+inline constexpr auto SHRPX_OPT_WORKER_PROCESS_GRACE_SHUTDOWN_PERIOD =
   "worker-process-grace-shutdown-period"sv;
-constexpr auto SHRPX_OPT_FRONTEND_QUIC_INITIAL_RTT =
+inline constexpr auto SHRPX_OPT_FRONTEND_QUIC_INITIAL_RTT =
   "frontend-quic-initial-rtt"sv;
-constexpr auto SHRPX_OPT_REQUIRE_HTTP_SCHEME = "require-http-scheme"sv;
-constexpr auto SHRPX_OPT_TLS_KTLS = "tls-ktls"sv;
-constexpr auto SHRPX_OPT_ALPN_LIST = "alpn-list"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HEADER_TIMEOUT = "frontend-header-timeout"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HTTP2_IDLE_TIMEOUT =
+inline constexpr auto SHRPX_OPT_REQUIRE_HTTP_SCHEME = "require-http-scheme"sv;
+inline constexpr auto SHRPX_OPT_TLS_KTLS = "tls-ktls"sv;
+inline constexpr auto SHRPX_OPT_ALPN_LIST = "alpn-list"sv;
+inline constexpr auto SHRPX_OPT_FRONTEND_HEADER_TIMEOUT =
+  "frontend-header-timeout"sv;
+inline constexpr auto SHRPX_OPT_FRONTEND_HTTP2_IDLE_TIMEOUT =
   "frontend-http2-idle-timeout"sv;
-constexpr auto SHRPX_OPT_FRONTEND_HTTP3_IDLE_TIMEOUT =
+inline constexpr auto SHRPX_OPT_FRONTEND_HTTP3_IDLE_TIMEOUT =
   "frontend-http3-idle-timeout"sv;
 
-constexpr size_t SHRPX_OBFUSCATED_NODE_LENGTH = 8;
+inline constexpr size_t SHRPX_OBFUSCATED_NODE_LENGTH = 8;
 
-constexpr auto DEFAULT_DOWNSTREAM_HOST = "127.0.0.1"sv;
-constexpr int16_t DEFAULT_DOWNSTREAM_PORT = 80;
+inline constexpr auto DEFAULT_DOWNSTREAM_HOST = "127.0.0.1"sv;
+inline constexpr int16_t DEFAULT_DOWNSTREAM_PORT = 80;
 
 enum class Proto {
   NONE,

--- a/src/shrpx_https_upstream.cc
+++ b/src/shrpx_https_upstream.cc
@@ -537,7 +537,7 @@ int htp_hdrs_completecb(llhttp_t *htp) {
     // Continue here to make the client happy.
     if (downstream->get_expect_100_continue()) {
       auto output = downstream->get_response_buf();
-      constexpr auto res = "HTTP/1.1 100 Continue\r\n\r\n"sv;
+      static constexpr auto res = "HTTP/1.1 100 Continue\r\n\r\n"sv;
       output->append(res);
       handler->signal_write();
     }

--- a/src/shrpx_memcached_connection.h
+++ b/src/shrpx_memcached_connection.h
@@ -86,8 +86,8 @@ struct MemcachedSendbuf {
   size_t left() const { return headbuf.rleft() + send_value_left; }
 };
 
-constexpr uint8_t MEMCACHED_REQ_MAGIC = 0x80;
-constexpr uint8_t MEMCACHED_RES_MAGIC = 0x81;
+inline constexpr uint8_t MEMCACHED_REQ_MAGIC = 0x80;
+inline constexpr uint8_t MEMCACHED_RES_MAGIC = 0x81;
 
 // MemcachedConnection implements part of memcached binary protocol.
 // This is not full brown implementation.  Just the part we need is

--- a/src/shrpx_process.h
+++ b/src/shrpx_process.h
@@ -29,8 +29,8 @@
 
 namespace shrpx {
 
-constexpr uint8_t SHRPX_IPC_REOPEN_LOG = 1;
-constexpr uint8_t SHRPX_IPC_GRACEFUL_SHUTDOWN = 2;
+inline constexpr uint8_t SHRPX_IPC_REOPEN_LOG = 1;
+inline constexpr uint8_t SHRPX_IPC_GRACEFUL_SHUTDOWN = 2;
 
 } // namespace shrpx
 

--- a/src/shrpx_quic.cc
+++ b/src/shrpx_quic.cc
@@ -372,14 +372,15 @@ int verify_token(std::span<const uint8_t> token, const sockaddr *sa,
 int generate_quic_connection_id_encryption_key(std::span<uint8_t> key,
                                                std::span<const uint8_t> secret,
                                                std::span<const uint8_t> salt) {
-  constexpr uint8_t info[] = "connection id encryption key";
+  static constexpr auto info = "connection id encryption key"sv;
   ngtcp2_crypto_md sha256;
   ngtcp2_crypto_md_init(
     &sha256, reinterpret_cast<void *>(const_cast<EVP_MD *>(EVP_sha256())));
 
   if (ngtcp2_crypto_hkdf(key.data(), key.size(), &sha256, secret.data(),
-                         secret.size(), salt.data(), salt.size(), info,
-                         str_size(info)) != 0) {
+                         secret.size(), salt.data(), salt.size(),
+                         reinterpret_cast<const uint8_t *>(info.data()),
+                         info.size()) != 0) {
     return -1;
   }
 

--- a/src/shrpx_quic.h
+++ b/src/shrpx_quic.h
@@ -76,23 +76,23 @@ struct UpstreamAddr;
 struct QUICKeyingMaterials;
 struct QUICKeyingMaterial;
 
-constexpr size_t SHRPX_QUIC_CID_WORKER_ID_OFFSET = 1;
-constexpr size_t SHRPX_QUIC_SERVER_IDLEN = 4;
-constexpr size_t SHRPX_QUIC_SOCK_IDLEN = 4;
-constexpr size_t SHRPX_QUIC_WORKER_IDLEN =
+inline constexpr size_t SHRPX_QUIC_CID_WORKER_ID_OFFSET = 1;
+inline constexpr size_t SHRPX_QUIC_SERVER_IDLEN = 4;
+inline constexpr size_t SHRPX_QUIC_SOCK_IDLEN = 4;
+inline constexpr size_t SHRPX_QUIC_WORKER_IDLEN =
   SHRPX_QUIC_SERVER_IDLEN + SHRPX_QUIC_SOCK_IDLEN;
-constexpr size_t SHRPX_QUIC_CLIENT_IDLEN = 8;
-constexpr size_t SHRPX_QUIC_DECRYPTED_DCIDLEN =
+inline constexpr size_t SHRPX_QUIC_CLIENT_IDLEN = 8;
+inline constexpr size_t SHRPX_QUIC_DECRYPTED_DCIDLEN =
   SHRPX_QUIC_WORKER_IDLEN + SHRPX_QUIC_CLIENT_IDLEN;
-constexpr size_t SHRPX_QUIC_SCIDLEN =
+inline constexpr size_t SHRPX_QUIC_SCIDLEN =
   SHRPX_QUIC_CID_WORKER_ID_OFFSET + SHRPX_QUIC_DECRYPTED_DCIDLEN;
-constexpr size_t SHRPX_QUIC_CID_ENCRYPTION_KEYLEN = 16;
-constexpr size_t SHRPX_QUIC_CONN_CLOSE_PKTLEN = 256;
-constexpr size_t SHRPX_QUIC_STATELESS_RESET_BURST = 100;
-constexpr size_t SHRPX_QUIC_SECRET_RESERVEDLEN = 4;
-constexpr size_t SHRPX_QUIC_SECRETLEN = 32;
-constexpr size_t SHRPX_QUIC_SALTLEN = 32;
-constexpr uint8_t SHRPX_QUIC_DCID_KM_ID_MASK = 0xe0;
+inline constexpr size_t SHRPX_QUIC_CID_ENCRYPTION_KEYLEN = 16;
+inline constexpr size_t SHRPX_QUIC_CONN_CLOSE_PKTLEN = 256;
+inline constexpr size_t SHRPX_QUIC_STATELESS_RESET_BURST = 100;
+inline constexpr size_t SHRPX_QUIC_SECRET_RESERVEDLEN = 4;
+inline constexpr size_t SHRPX_QUIC_SECRETLEN = 32;
+inline constexpr size_t SHRPX_QUIC_SALTLEN = 32;
+inline constexpr uint8_t SHRPX_QUIC_DCID_KM_ID_MASK = 0xe0;
 
 struct WorkerID {
   union {

--- a/src/shrpx_signal.h
+++ b/src/shrpx_signal.h
@@ -31,10 +31,10 @@
 
 namespace shrpx {
 
-constexpr int REOPEN_LOG_SIGNAL = SIGUSR1;
-constexpr int EXEC_BINARY_SIGNAL = SIGUSR2;
-constexpr int GRACEFUL_SHUTDOWN_SIGNAL = SIGQUIT;
-constexpr int RELOAD_SIGNAL = SIGHUP;
+inline constexpr int REOPEN_LOG_SIGNAL = SIGUSR1;
+inline constexpr int EXEC_BINARY_SIGNAL = SIGUSR2;
+inline constexpr int GRACEFUL_SHUTDOWN_SIGNAL = SIGQUIT;
+inline constexpr int RELOAD_SIGNAL = SIGHUP;
 
 // Blocks all signals.  The previous signal mask is stored into
 // |oldset| if it is not nullptr.  This function returns 0 if it

--- a/src/shrpx_tls.cc
+++ b/src/shrpx_tls.cc
@@ -505,7 +505,7 @@ namespace {
 int quic_alpn_select_proto_cb(SSL *ssl, const unsigned char **out,
                               unsigned char *outlen, const unsigned char *in,
                               unsigned int inlen, void *arg) {
-  constexpr std::string_view alpnlist[] = {
+  static constexpr std::string_view alpnlist[] = {
     "h3"sv,
     "h3-29"sv,
   };

--- a/src/shrpx_worker.h
+++ b/src/shrpx_worker.h
@@ -156,7 +156,7 @@ struct DownstreamAddr {
   bool queued;
 };
 
-constexpr uint32_t MAX_DOWNSTREAM_ADDR_WEIGHT = 256;
+inline constexpr uint32_t MAX_DOWNSTREAM_ADDR_WEIGHT = 256;
 
 struct DownstreamAddrEntry {
   DownstreamAddr *addr;

--- a/src/tls.h
+++ b/src/tls.h
@@ -49,7 +49,7 @@ namespace tls {
 // suites for TLSv1.2 by mozilla.
 //
 // https://wiki.mozilla.org/Security/Server_Side_TLS
-constexpr auto DEFAULT_CIPHER_LIST =
+inline constexpr auto DEFAULT_CIPHER_LIST =
   "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-"
   "AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-"
   "POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-"
@@ -59,7 +59,7 @@ constexpr auto DEFAULT_CIPHER_LIST =
 // for TLSv1.3 by mozilla.
 //
 // https://wiki.mozilla.org/Security/Server_Side_TLS
-constexpr auto DEFAULT_TLS13_CIPHER_LIST =
+inline constexpr auto DEFAULT_TLS13_CIPHER_LIST =
 #if defined(NGHTTP2_GENUINE_OPENSSL) ||                                        \
   defined(NGHTTP2_OPENSSL_IS_LIBRESSL) || defined(NGHTTP2_OPENSSL_IS_WOLFSSL)
   "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:"
@@ -69,11 +69,11 @@ constexpr auto DEFAULT_TLS13_CIPHER_LIST =
 #endif // !NGHTTP2_GENUINE_OPENSSL && !NGHTTP2_OPENSSL_IS_LIBRESSL
   ;
 
-constexpr auto NGHTTP2_TLS_MIN_VERSION = TLS1_VERSION;
+inline constexpr auto NGHTTP2_TLS_MIN_VERSION = TLS1_VERSION;
 #ifdef TLS1_3_VERSION
-constexpr auto NGHTTP2_TLS_MAX_VERSION = TLS1_3_VERSION;
+inline constexpr auto NGHTTP2_TLS_MAX_VERSION = TLS1_3_VERSION;
 #else  // !TLS1_3_VERSION
-constexpr auto NGHTTP2_TLS_MAX_VERSION = TLS1_2_VERSION;
+inline constexpr auto NGHTTP2_TLS_MAX_VERSION = TLS1_2_VERSION;
 #endif // !TLS1_3_VERSION
 
 std::string_view get_tls_protocol(SSL *ssl);
@@ -107,7 +107,7 @@ bool check_http2_requirement(SSL *ssl);
 // 0 if it succeeds, or -1.
 int ssl_ctx_set_proto_versions(SSL_CTX *ssl_ctx, int min, int max);
 
-constexpr uint16_t CERTIFICATE_COMPRESSION_ALGO_BROTLI = 2;
+inline constexpr uint16_t CERTIFICATE_COMPRESSION_ALGO_BROTLI = 2;
 
 #if defined(NGHTTP2_OPENSSL_IS_BORINGSSL) && defined(HAVE_LIBBROTLI)
 int cert_compress(SSL *ssl, CBB *out, const uint8_t *in, size_t in_len);

--- a/src/util.cc
+++ b/src/util.cc
@@ -136,7 +136,7 @@ O cpydig4(uint32_t n, O result) {
 } // namespace
 
 namespace {
-constinit const auto MONTH = std::to_array({
+constexpr auto MONTH = std::to_array({
   "Jan"sv,
   "Feb"sv,
   "Mar"sv,
@@ -151,7 +151,7 @@ constinit const auto MONTH = std::to_array({
   "Dec"sv,
 });
 
-constinit const auto WEEKDAY = std::to_array({
+constexpr auto WEEKDAY = std::to_array({
   "Sun"sv,
   "Mon"sv,
   "Tue"sv,


### PR DESCRIPTION
- Use inline constexpr for constexpr variable with external linkage
- Use static constexpr where they should
- Use consteval for functions to generate a lookup table