### PR TITLE
Remove session_update_glitch_ratelim called from deep inside the chain

### DIFF
--- a/lib/nghttp2_session.c
+++ b/lib/nghttp2_session.c
@@ -3409,11 +3409,6 @@ static int session_handle_invalid_stream2(nghttp2_session *session,
                                           int lib_error_code) {
   int rv;
 
-  rv = session_update_glitch_ratelim(session);
-  if (rv != 0) {
-    return rv;
-  }
-
   rv = nghttp2_session_add_rst_stream(
     session, stream_id, get_error_code_from_lib_error_code(lib_error_code));
   if (rv != 0) {


### PR DESCRIPTION
Calling session_update_glitch_ratelim from
session_handle_invalid_stream2 makes handling error quite difficult because it might be called in nested function calls.  It seems to me that adding that is accidental.