### PR TITLE
nghttpd: Make the supported groups configurable

### DIFF
--- a/src/HttpServer.cc
+++ b/src/HttpServer.cc
@@ -79,6 +79,7 @@
 #endif // O_BINARY
 
 using namespace std::chrono_literals;
+using namespace std::string_literals;
 
 namespace nghttp2 {
 
@@ -101,6 +102,7 @@ void print_session_id(int64_t id) { std::cout << "[id=" << id << "] "; }
 
 Config::Config()
   : mime_types_file("/etc/mime.types"),
+    groups("X25519:P-256:P-384:P-521"sv),
     stream_read_timeout(1_min),
     stream_write_timeout(1_min),
     data_ptr(nullptr),
@@ -2159,13 +2161,11 @@ int HttpServer::run() {
     SSL_CTX_set_session_id_context(ssl_ctx, sid_ctx, sizeof(sid_ctx) - 1);
     SSL_CTX_set_session_cache_mode(ssl_ctx, SSL_SESS_CACHE_SERVER);
 
-#ifndef OPENSSL_NO_EC
-    if (SSL_CTX_set1_curves_list(ssl_ctx, "P-256") != 1) {
-      std::cerr << "SSL_CTX_set1_curves_list failed: "
+    if (SSL_CTX_set1_groups_list(ssl_ctx, config_->groups.data()) != 1) {
+      std::cerr << "SSL_CTX_set1_groups_list failed: "
                 << ERR_error_string(ERR_get_error(), nullptr);
       return -1;
     }
-#endif // OPENSSL_NO_EC
 
     if (!config_->dh_param_file.empty()) {
       // Read DH parameters from file

--- a/src/HttpServer.h
+++ b/src/HttpServer.h
@@ -36,6 +36,7 @@
 #include <vector>
 #include <unordered_map>
 #include <memory>
+#include <string_view>
 
 #include "ssl_compat.h"
 
@@ -70,6 +71,7 @@ struct Config {
   std::string dh_param_file;
   std::string address;
   std::string mime_types_file;
+  std::string_view groups;
   ev_tstamp stream_read_timeout;
   ev_tstamp stream_write_timeout;
   void *data_ptr;

--- a/src/nghttpd.cc
+++ b/src/nghttpd.cc
@@ -176,6 +176,10 @@ Options:
       << config.mime_types_file << R"(
   --no-content-length
               Don't send content-length header field.
+  --groups=<GROUPS>
+              Specify the supported groups.
+              Default: )"
+      << config.groups << R"(
   --ktls      Enable ktls.
   --version   Display version information and exit.
   -h, --help  Display this help and exit.
@@ -223,6 +227,7 @@ int main(int argc, char **argv) {
       {"encoder-header-table-size", required_argument, &flag, 11},
       {"ktls", no_argument, &flag, 12},
       {"no-rfc7540-pri", no_argument, &flag, 13},
+      {"groups", required_argument, &flag, 14},
       {nullptr, 0, nullptr, 0}};
     int option_index = 0;
     int c = getopt_long(argc, argv, "DVb:c:d:ehm:n:p:va:w:W:", long_options,
@@ -413,6 +418,10 @@ int main(int argc, char **argv) {
         // no-rfc7540-pri option
         std::cerr << "[WARNING]: --no-rfc7540-pri option has been deprecated."
                   << std::endl;
+        break;
+      case 14:
+        // groups option
+        config.groups = optarg;
         break;
       }
       break;


### PR DESCRIPTION
Use the same default list of groups as h2load.

See #2512 