### PR TITLE
Use SSL_CTX_set1_groups_list

### DIFF
--- a/examples/libevent-server.c
+++ b/examples/libevent-server.c
@@ -136,8 +136,8 @@ static SSL_CTX *create_ssl_ctx(const char *key_file, const char *cert_file) {
                                  SSL_OP_NO_COMPRESSION |
                                  SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION);
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-  if (SSL_CTX_set1_curves_list(ssl_ctx, "P-256") != 1) {
-    errx(1, "SSL_CTX_set1_curves_list failed: %s",
+  if (SSL_CTX_set1_groups_list(ssl_ctx, "P-256") != 1) {
+    errx(1, "SSL_CTX_set1_groups_list failed: %s",
          ERR_error_string(ERR_get_error(), NULL));
   }
 #else  /* !(OPENSSL_VERSION_NUMBER >= 0x30000000L) */

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -3047,20 +3047,10 @@ int main(int argc, char **argv) {
 #endif // NGHTTP2_GENUINE_OPENSSL || NGHTTP2_OPENSSL_IS_LIBRESSL ||
        // NGHTTP2_OPENSSL_IS_WOLFSSL
 
-#ifdef NGHTTP2_OPENSSL_IS_WOLFSSL
-  // Passing X25519 to SSL_CTX_set1_groups_list fails for some reason.
-  if (SSL_CTX_set1_curves_list(
-        ssl_ctx, const_cast<char *>(config.groups.c_str())) != 1) {
-    std::cerr << "SSL_CTX_set1_curves_list failed: "
-              << ERR_error_string(ERR_get_error(), nullptr) << std::endl;
-    exit(EXIT_FAILURE);
-  }
-#else  // !NGHTTP2_OPENSSL_IS_WOLFSSL
   if (SSL_CTX_set1_groups_list(ssl_ctx, config.groups.c_str()) != 1) {
     std::cerr << "SSL_CTX_set1_groups_list failed" << std::endl;
     exit(EXIT_FAILURE);
   }
-#endif // !NGHTTP2_OPENSSL_IS_WOLFSSL
 
   std::vector<unsigned char> proto_list;
   for (const auto &proto : config.alpn_list) {

--- a/src/shrpx_tls.cc
+++ b/src/shrpx_tls.cc
@@ -830,13 +830,11 @@ SSL_CTX *create_ssl_context(const char *private_key_file, const char *cert_file,
 #endif // NGHTTP2_GENUINE_OPENSSL || NGHTTP2_OPENSSL_IS_LIBRESSL ||
        // NGHTTP2_OPENSSL_IS_WOLFSSL
 
-#ifndef OPENSSL_NO_EC
-  if (SSL_CTX_set1_curves_list(ssl_ctx, tlsconf.ecdh_curves.data()) != 1) {
-    LOG(FATAL) << "SSL_CTX_set1_curves_list " << tlsconf.ecdh_curves
+  if (SSL_CTX_set1_groups_list(ssl_ctx, tlsconf.ecdh_curves.data()) != 1) {
+    LOG(FATAL) << "SSL_CTX_set1_groups_list " << tlsconf.ecdh_curves
                << " failed";
     DIE();
   }
-#endif // OPENSSL_NO_EC
 
   if (!tlsconf.dh_param_file.empty()) {
     // Read DH parameters from file
@@ -1115,13 +1113,11 @@ SSL_CTX *create_quic_ssl_context(const char *private_key_file,
 #  endif // NGHTTP2_GENUINE_OPENSSL || NGHTTP2_OPENSSL_IS_LIBRESSL ||
          // NGHTTP2_OPENSSL_IS_WOLFSSL
 
-#  ifndef OPENSSL_NO_EC
-  if (SSL_CTX_set1_curves_list(ssl_ctx, tlsconf.ecdh_curves.data()) != 1) {
-    LOG(FATAL) << "SSL_CTX_set1_curves_list " << tlsconf.ecdh_curves
+  if (SSL_CTX_set1_groups_list(ssl_ctx, tlsconf.ecdh_curves.data()) != 1) {
+    LOG(FATAL) << "SSL_CTX_set1_groups_list " << tlsconf.ecdh_curves
                << " failed";
     DIE();
   }
-#  endif // OPENSSL_NO_EC
 
   if (!tlsconf.dh_param_file.empty()) {
     // Read DH parameters from file


### PR DESCRIPTION
Replace SSL_CTX_set1_curves_list with SSL_CTX_set1_groups_list. Remove the workaround for wolfSSL because the bug has been fixed.