### PR TITLE
nghttpx: Add groups option

### DIFF
--- a/gennghttpxfun.py
+++ b/gennghttpxfun.py
@@ -204,6 +204,7 @@ OPTIONS = [
     "frontend-header-timeout",
     "frontend-http2-idle-timeout",
     "frontend-http3-idle-timeout",
+    "groups",
 ]
 
 LOGVARS = [

--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -1666,7 +1666,7 @@ void fill_default_config(Config *config) {
   tlsconf.max_proto_version =
     tls::proto_version_from_string(DEFAULT_TLS_MAX_PROTO_VERSION);
   tlsconf.max_early_data = 16_k;
-  tlsconf.ecdh_curves = "X25519:P-256:P-384:P-521"sv;
+  tlsconf.groups = "X25519:P-256:P-384:P-521"sv;
 
   auto &httpconf = config->http;
   httpconf.server_name = "nghttpx"sv;
@@ -2430,14 +2430,14 @@ SSL/TLS:
               --tls13-client-ciphers for TLSv1.2 or earlier.
               Default: )"
       << config->tls.client.tls13_ciphers << R"(
-  --ecdh-curves=<LIST>
-              Set  supported  curve  list  for  frontend  connections.
-              <LIST> is a  colon separated list of curve  NID or names
+  --groups=<LIST>
+              Set the  supported group list for  frontend connections.
+              <LIST> is a  colon separated list of group  NID or names
               in the preference order.  The supported curves depend on
               the  linked  OpenSSL  library.  This  function  requires
               OpenSSL >= 1.0.2.
               Default: )"
-      << config->tls.ecdh_curves << R"(
+      << config->tls.groups << R"(
   -k, --insecure
               Don't  verify backend  server's  certificate  if TLS  is
               enabled for backend connections.
@@ -3978,6 +3978,7 @@ int main(int argc, char **argv) {
        195},
       {SHRPX_OPT_FRONTEND_HTTP3_IDLE_TIMEOUT.data(), required_argument, &flag,
        196},
+      {SHRPX_OPT_GROUPS.data(), required_argument, &flag, 197},
       {nullptr, 0, nullptr, 0}};
 
     int option_index = 0;
@@ -4902,6 +4903,10 @@ int main(int argc, char **argv) {
         // --frontend-http3-idle-timeout
         cmdcfgs.emplace_back(SHRPX_OPT_FRONTEND_HTTP3_IDLE_TIMEOUT,
                              std::string_view{optarg});
+        break;
+      case 197:
+        // --groups
+        cmdcfgs.emplace_back(SHRPX_OPT_GROUPS, std::string_view{optarg});
         break;
       default:
         break;

--- a/src/shrpx_config.cc
+++ b/src/shrpx_config.cc
@@ -1793,6 +1793,11 @@ int option_lookup_token(const std::string_view &name) {
         return SHRPX_OPTID_DAEMON;
       }
       break;
+    case 's':
+      if (util::strieq("group"sv, name.substr(0, 5))) {
+        return SHRPX_OPTID_GROUPS;
+      }
+      break;
     case 't':
       if (util::strieq("cacer"sv, name.substr(0, 5))) {
         return SHRPX_OPTID_CACERT;
@@ -3906,7 +3911,11 @@ int parse_config(
     return parse_uint_with_unit(
       &config->http2.downstream.decoder_dynamic_table_size, opt, optarg);
   case SHRPX_OPTID_ECDH_CURVES:
-    config->tls.ecdh_curves = make_string_ref(config->balloc, optarg);
+    LOG(WARN) << opt << ": deprecated.  Use " << SHRPX_OPT_GROUPS
+              << " instead.";
+    // fall through
+  case SHRPX_OPTID_GROUPS:
+    config->tls.groups = make_string_ref(config->balloc, optarg);
     return 0;
   case SHRPX_OPTID_TLS_SCT_DIR:
 #if defined(NGHTTP2_GENUINE_OPENSSL) || defined(NGHTTP2_OPENSSL_IS_BORINGSSL)

--- a/src/shrpx_config.h
+++ b/src/shrpx_config.h
@@ -382,6 +382,7 @@ inline constexpr auto SHRPX_OPT_FRONTEND_HTTP2_IDLE_TIMEOUT =
   "frontend-http2-idle-timeout"sv;
 inline constexpr auto SHRPX_OPT_FRONTEND_HTTP3_IDLE_TIMEOUT =
   "frontend-http3-idle-timeout"sv;
+inline constexpr auto SHRPX_OPT_GROUPS = "groups"sv;
 
 inline constexpr size_t SHRPX_OBFUSCATED_NODE_LENGTH = 8;
 
@@ -731,7 +732,7 @@ struct TLSConfig {
   std::string_view dh_param_file;
   std::string_view ciphers;
   std::string_view tls13_ciphers;
-  std::string_view ecdh_curves;
+  std::string_view groups;
   std::string_view cacert;
   // The maximum amount of 0-RTT data that server accepts.
   uint32_t max_early_data;
@@ -1240,6 +1241,7 @@ enum {
   SHRPX_OPTID_FRONTEND_QUIC_SECRET_FILE,
   SHRPX_OPTID_FRONTEND_READ_TIMEOUT,
   SHRPX_OPTID_FRONTEND_WRITE_TIMEOUT,
+  SHRPX_OPTID_GROUPS,
   SHRPX_OPTID_HEADER_FIELD_BUFFER,
   SHRPX_OPTID_HOST_REWRITE,
   SHRPX_OPTID_HTTP2_ALTSVC,

--- a/src/shrpx_tls.cc
+++ b/src/shrpx_tls.cc
@@ -830,9 +830,8 @@ SSL_CTX *create_ssl_context(const char *private_key_file, const char *cert_file,
 #endif // NGHTTP2_GENUINE_OPENSSL || NGHTTP2_OPENSSL_IS_LIBRESSL ||
        // NGHTTP2_OPENSSL_IS_WOLFSSL
 
-  if (SSL_CTX_set1_groups_list(ssl_ctx, tlsconf.ecdh_curves.data()) != 1) {
-    LOG(FATAL) << "SSL_CTX_set1_groups_list " << tlsconf.ecdh_curves
-               << " failed";
+  if (SSL_CTX_set1_groups_list(ssl_ctx, tlsconf.groups.data()) != 1) {
+    LOG(FATAL) << "SSL_CTX_set1_groups_list " << tlsconf.groups << " failed";
     DIE();
   }
 
@@ -1113,9 +1112,8 @@ SSL_CTX *create_quic_ssl_context(const char *private_key_file,
 #  endif // NGHTTP2_GENUINE_OPENSSL || NGHTTP2_OPENSSL_IS_LIBRESSL ||
          // NGHTTP2_OPENSSL_IS_WOLFSSL
 
-  if (SSL_CTX_set1_groups_list(ssl_ctx, tlsconf.ecdh_curves.data()) != 1) {
-    LOG(FATAL) << "SSL_CTX_set1_groups_list " << tlsconf.ecdh_curves
-               << " failed";
+  if (SSL_CTX_set1_groups_list(ssl_ctx, tlsconf.groups.data()) != 1) {
+    LOG(FATAL) << "SSL_CTX_set1_groups_list " << tlsconf.groups << " failed";
     DIE();
   }
 


### PR DESCRIPTION
The groups option takes the list of the supported groups.  This deprecates ecdh-curves option.  If ecdh-curves option is used, it is treated as if groups option is specified.

See #2512 