### PR TITLE
lib: Consistent conditional macro comments

### DIFF
--- a/lib/nghttp2_alpn.h
+++ b/lib/nghttp2_alpn.h
@@ -27,8 +27,8 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 
-#endif /* NGHTTP2_ALPN_H */
+#endif /* !defined(NGHTTP2_ALPN_H) */

--- a/lib/nghttp2_buf.h
+++ b/lib/nghttp2_buf.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 
@@ -409,4 +409,4 @@ int nghttp2_bufs_next_present(nghttp2_bufs *bufs);
  */
 size_t nghttp2_bufs_len(nghttp2_bufs *bufs);
 
-#endif /* NGHTTP2_BUF_H */
+#endif /* !defined(NGHTTP2_BUF_H) */

--- a/lib/nghttp2_callbacks.h
+++ b/lib/nghttp2_callbacks.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 
@@ -154,4 +154,4 @@ struct nghttp2_session_callbacks {
   nghttp2_rand_callback rand_callback;
 };
 
-#endif /* NGHTTP2_CALLBACKS_H */
+#endif /* !defined(NGHTTP2_CALLBACKS_H) */

--- a/lib/nghttp2_debug.c
+++ b/lib/nghttp2_debug.c
@@ -50,11 +50,11 @@ void nghttp2_set_debug_vprintf_callback(
   static_debug_vprintf_callback = debug_vprintf_callback;
 }
 
-#else /* !DEBUGBUILD */
+#else /* !defined(DEBUGBUILD) */
 
 void nghttp2_set_debug_vprintf_callback(
   nghttp2_debug_vprintf_callback debug_vprintf_callback) {
   (void)debug_vprintf_callback;
 }
 
-#endif /* !DEBUGBUILD */
+#endif /* !defined(DEBUGBUILD) */

--- a/lib/nghttp2_debug.h
+++ b/lib/nghttp2_debug.h
@@ -27,17 +27,17 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 
 #ifdef DEBUGBUILD
 #  define DEBUGF(...) nghttp2_debug_vprintf(__VA_ARGS__)
 void nghttp2_debug_vprintf(const char *format, ...);
-#else
+#else /* !defined(DEBUGBUILD) */
 #  define DEBUGF(...)                                                          \
     do {                                                                       \
     } while (0)
-#endif
+#endif /* !defined(DEBUGBUILD) */
 
-#endif /* NGHTTP2_DEBUG_H */
+#endif /* !defined(NGHTTP2_DEBUG_H) */

--- a/lib/nghttp2_extpri.h
+++ b/lib/nghttp2_extpri.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 
@@ -62,4 +62,4 @@ void nghttp2_extpri_from_uint8(nghttp2_extpri *extpri, uint8_t u8extpri);
  */
 #define nghttp2_extpri_uint8_inc(PRI) (((PRI) & NGHTTP2_EXTPRI_INC_MASK) != 0)
 
-#endif /* NGHTTP2_EXTPRI_H */
+#endif /* !defined(NGHTTP2_EXTPRI_H) */

--- a/lib/nghttp2_frame.h
+++ b/lib/nghttp2_frame.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 #include "nghttp2_hd.h"
@@ -634,4 +634,4 @@ int nghttp2_iv_check(const nghttp2_settings_entry *iv, size_t niv);
 void nghttp2_frame_add_pad(nghttp2_bufs *bufs, nghttp2_frame_hd *hd,
                            size_t padlen, int framehd_only);
 
-#endif /* NGHTTP2_FRAME_H */
+#endif /* !defined(NGHTTP2_FRAME_H) */

--- a/lib/nghttp2_hd.h
+++ b/lib/nghttp2_hd.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 
@@ -439,4 +439,4 @@ nghttp2_ssize nghttp2_hd_huff_decode(nghttp2_hd_huff_decode_context *ctx,
  */
 int nghttp2_hd_huff_decode_failure_state(nghttp2_hd_huff_decode_context *ctx);
 
-#endif /* NGHTTP2_HD_H */
+#endif /* !defined(NGHTTP2_HD_H) */

--- a/lib/nghttp2_hd_huffman.h
+++ b/lib/nghttp2_hd_huffman.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 
@@ -69,4 +69,4 @@ typedef struct {
 extern const nghttp2_huff_sym huff_sym_table[];
 extern const nghttp2_huff_decode huff_decode_table[][16];
 
-#endif /* NGHTTP2_HD_HUFFMAN_H */
+#endif /* !defined(NGHTTP2_HD_HUFFMAN_H) */

--- a/lib/nghttp2_helper.h
+++ b/lib/nghttp2_helper.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <string.h>
 #include <stddef.h>
@@ -142,4 +142,4 @@ int nghttp2_should_send_window_update(int32_t local_window_size,
  */
 uint8_t *nghttp2_cpymem(uint8_t *dest, const void *src, size_t len);
 
-#endif /* NGHTTP2_HELPER_H */
+#endif /* !defined(NGHTTP2_HELPER_H) */

--- a/lib/nghttp2_http.h
+++ b/lib/nghttp2_http.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 #include "nghttp2_session.h"
@@ -97,4 +97,4 @@ void nghttp2_http_record_request_method(nghttp2_stream *stream,
 int nghttp2_http_parse_priority(nghttp2_extpri *dest, const uint8_t *value,
                                 size_t valuelen);
 
-#endif /* NGHTTP2_HTTP_H */
+#endif /* !defined(NGHTTP2_HTTP_H) */

--- a/lib/nghttp2_int.h
+++ b/lib/nghttp2_int.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 
@@ -59,4 +59,4 @@ typedef enum {
   NGHTTP2_ERR_PUSH_CANCEL = -107,
 } nghttp2_internal_error;
 
-#endif /* NGHTTP2_INT_H */
+#endif /* !defined(NGHTTP2_INT_H) */

--- a/lib/nghttp2_mem.h
+++ b/lib/nghttp2_mem.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 
@@ -42,4 +42,4 @@ void nghttp2_mem_free2(nghttp2_free free_func, void *ptr, void *mem_user_data);
 void *nghttp2_mem_calloc(nghttp2_mem *mem, size_t nmemb, size_t size);
 void *nghttp2_mem_realloc(nghttp2_mem *mem, void *ptr, size_t size);
 
-#endif /* NGHTTP2_MEM_H */
+#endif /* !defined(NGHTTP2_MEM_H) */

--- a/lib/nghttp2_net.h
+++ b/lib/nghttp2_net.h
@@ -27,28 +27,28 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #ifdef HAVE_ARPA_INET_H
 #  include <arpa/inet.h>
-#endif /* HAVE_ARPA_INET_H */
+#endif /* defined(HAVE_ARPA_INET_H) */
 
 #ifdef HAVE_NETINET_IN_H
 #  include <netinet/in.h>
-#endif /* HAVE_NETINET_IN_H */
+#endif /* defined(HAVE_NETINET_IN_H) */
 
 #include <nghttp2/nghttp2.h>
 
-#if defined(WIN32)
+#ifdef WIN32
 /* Windows requires ws2_32 library for ntonl family functions.  We
    define inline functions for those function so that we don't have
    dependency on that lib. */
 
 #  ifdef _MSC_VER
 #    define STIN static __inline
-#  else
+#  else /* !defined(_MSC_VER) */
 #    define STIN static inline
-#  endif
+#  endif /* !defined(_MSC_VER) */
 
 STIN uint32_t htonl(uint32_t hostlong) {
   uint32_t res;
@@ -86,6 +86,6 @@ STIN uint16_t ntohs(uint16_t netshort) {
   return res;
 }
 
-#endif /* WIN32 */
+#endif /* defined(WIN32) */
 
-#endif /* NGHTTP2_NET_H */
+#endif /* !defined(NGHTTP2_NET_H) */

--- a/lib/nghttp2_option.h
+++ b/lib/nghttp2_option.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 
@@ -160,4 +160,4 @@ struct nghttp2_option {
   uint8_t user_recv_ext_types[32];
 };
 
-#endif /* NGHTTP2_OPTION_H */
+#endif /* !defined(NGHTTP2_OPTION_H) */

--- a/lib/nghttp2_outbound_item.h
+++ b/lib/nghttp2_outbound_item.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 #include "nghttp2_frame.h"
@@ -186,4 +186,4 @@ void nghttp2_outbound_queue_pop(nghttp2_outbound_queue *q);
 /* Returns the size of the queue */
 #define nghttp2_outbound_queue_size(Q) ((Q)->n)
 
-#endif /* NGHTTP2_OUTBOUND_ITEM_H */
+#endif /* !defined(NGHTTP2_OUTBOUND_ITEM_H) */

--- a/lib/nghttp2_pq.h
+++ b/lib/nghttp2_pq.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 #include "nghttp2_int.h"
@@ -121,4 +121,4 @@ int nghttp2_pq_each(nghttp2_pq *pq, nghttp2_pq_item_cb fun, void *arg);
  */
 void nghttp2_pq_remove(nghttp2_pq *pq, nghttp2_pq_entry *item);
 
-#endif /* NGHTTP2_PQ_H */
+#endif /* !defined(NGHTTP2_PQ_H) */

--- a/lib/nghttp2_priority_spec.h
+++ b/lib/nghttp2_priority_spec.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 
@@ -39,4 +39,4 @@
  */
 void nghttp2_priority_spec_normalize_weight(nghttp2_priority_spec *pri_spec);
 
-#endif /* NGHTTP2_PRIORITY_SPEC_H */
+#endif /* !defined(NGHTTP2_PRIORITY_SPEC_H) */

--- a/lib/nghttp2_queue.h
+++ b/lib/nghttp2_queue.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include "config.h"
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 
@@ -48,4 +48,4 @@ void *nghttp2_queue_front(nghttp2_queue *queue);
 void *nghttp2_queue_back(nghttp2_queue *queue);
 int nghttp2_queue_empty(nghttp2_queue *queue);
 
-#endif /* NGHTTP2_QUEUE_H */
+#endif /* !defined(NGHTTP2_QUEUE_H) */

--- a/lib/nghttp2_ratelim.h
+++ b/lib/nghttp2_ratelim.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 
@@ -54,4 +54,4 @@ void nghttp2_ratelim_update(nghttp2_ratelim *rl, uint64_t tstamp);
    succeeds, or -1. */
 int nghttp2_ratelim_drain(nghttp2_ratelim *rl, uint64_t n);
 
-#endif /* NGHTTP2_RATELIM_H */
+#endif /* !defined(NGHTTP2_RATELIM_H) */

--- a/lib/nghttp2_rcbuf.h
+++ b/lib/nghttp2_rcbuf.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 
@@ -77,4 +77,4 @@ int nghttp2_rcbuf_new2(nghttp2_rcbuf **rcbuf_ptr, const uint8_t *src,
  */
 void nghttp2_rcbuf_del(nghttp2_rcbuf *rcbuf);
 
-#endif /* NGHTTP2_RCBUF_H */
+#endif /* !defined(NGHTTP2_RCBUF_H) */

--- a/lib/nghttp2_session.c
+++ b/lib/nghttp2_session.c
@@ -5654,7 +5654,7 @@ nghttp2_ssize nghttp2_session_mem_recv2(nghttp2_session *session,
           DEBUGF("recv: WINDOW_UPDATE\n");
           break;
         }
-#endif /* DEBUGBUILD */
+#endif /* defined(DEBUGBUILD) */
 
         iframe->frame.hd.flags = NGHTTP2_FLAG_NONE;
 
@@ -6315,7 +6315,7 @@ nghttp2_ssize nghttp2_session_mem_recv2(nghttp2_session *session,
       } else {
         DEBUGF("recv: [IB_IGN_HEADER_BLOCK]\n");
       }
-#endif /* DEBUGBUILD */
+#endif /* defined(DEBUGBUILD) */
 
       readlen = inbound_frame_payload_readlen(iframe, in, last);
 
@@ -6547,7 +6547,7 @@ nghttp2_ssize nghttp2_session_mem_recv2(nghttp2_session *session,
       } else {
         fprintf(stderr, "recv: [IB_IGN_CONTINUATION]\n");
       }
-#endif /* DEBUGBUILD */
+#endif /* defined(DEBUGBUILD) */
 
       if (++session->num_continuations > session->max_continuations) {
         return NGHTTP2_ERR_TOO_MANY_CONTINUATIONS;

--- a/lib/nghttp2_session.h
+++ b/lib/nghttp2_session.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 #include "nghttp2_map.h"
@@ -892,4 +892,4 @@ int nghttp2_session_update_recv_stream_window_size(nghttp2_session *session,
                                                    size_t delta_size,
                                                    int send_window_update);
 
-#endif /* NGHTTP2_SESSION_H */
+#endif /* !defined(NGHTTP2_SESSION_H) */

--- a/lib/nghttp2_stream.h
+++ b/lib/nghttp2_stream.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 #include "nghttp2_outbound_item.h"
@@ -294,4 +294,4 @@ void nghttp2_stream_attach_item(nghttp2_stream *stream,
  */
 void nghttp2_stream_detach_item(nghttp2_stream *stream);
 
-#endif /* NGHTTP2_STREAM */
+#endif /* !defined(NGHTTP2_STREAM_H) */

--- a/lib/nghttp2_submit.h
+++ b/lib/nghttp2_submit.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 
@@ -37,4 +37,4 @@ int nghttp2_submit_data_shared(nghttp2_session *session, uint8_t flags,
                                int32_t stream_id,
                                const nghttp2_data_provider_wrap *dpw);
 
-#endif /* NGHTTP2_SUBMIT_H */
+#endif /* !defined(NGHTTP2_SUBMIT_H) */

--- a/lib/nghttp2_time.c
+++ b/lib/nghttp2_time.c
@@ -26,7 +26,7 @@
 
 #ifdef HAVE_WINDOWS_H
 #  include <windows.h>
-#endif /* HAVE_WINDOWS_H */
+#endif /* defined(HAVE_WINDOWS_H) */
 
 #include <time.h>
 
@@ -40,12 +40,11 @@ static uint64_t time_now_sec(void) {
 
   return (uint64_t)t;
 }
-#endif /* !HAVE_GETTICKCOUNT64 || __CYGWIN__ */
+#endif /* !defined(HAVE_GETTICKCOUNT64) || defined(__CYGWIN__) */
 
 #if defined(HAVE_GETTICKCOUNT64) && !defined(__CYGWIN__)
 uint64_t nghttp2_time_now_sec(void) { return GetTickCount64() / 1000; }
-#elif defined(HAVE_CLOCK_GETTIME) && defined(HAVE_DECL_CLOCK_MONOTONIC) &&     \
-  HAVE_DECL_CLOCK_MONOTONIC
+#elif defined(HAVE_CLOCK_GETTIME) && HAVE_DECL_CLOCK_MONOTONIC
 uint64_t nghttp2_time_now_sec(void) {
   struct timespec tp;
   int rv = clock_gettime(CLOCK_MONOTONIC, &tp);
@@ -56,8 +55,8 @@ uint64_t nghttp2_time_now_sec(void) {
 
   return (uint64_t)tp.tv_sec;
 }
-#else  /* (!HAVE_CLOCK_GETTIME || !HAVE_DECL_CLOCK_MONOTONIC) &&               \
-          (!HAVE_GETTICKCOUNT64 || __CYGWIN__)) */
+#else  /* (!defined(HAVE_GETTICKCOUNT64) || !defined(__CYGWIN__)) &&           \
+          (!defined(HAVE_CLOCK_GETTIME) || !HAVE_DECL_CLOCK_MONOTONIC) */
 uint64_t nghttp2_time_now_sec(void) { return time_now_sec(); }
-#endif /* (!HAVE_CLOCK_GETTIME || !HAVE_DECL_CLOCK_MONOTONIC) &&               \
-         (!HAVE_GETTICKCOUNT64 || __CYGWIN__)) */
+#endif /* (!defined(HAVE_GETTICKCOUNT64) || !defined(__CYGWIN__)) &&           \
+          (!defined(HAVE_CLOCK_GETTIME) || !HAVE_DECL_CLOCK_MONOTONIC) */

--- a/lib/nghttp2_time.h
+++ b/lib/nghttp2_time.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 
@@ -35,4 +35,4 @@
    timepoint.  If it is unable to get seconds, it returns 0. */
 uint64_t nghttp2_time_now_sec(void);
 
-#endif /* NGHTTP2_TIME_H */
+#endif /* !defined(NGHTTP2_TIME_H) */

--- a/lib/nghttp2_version.c
+++ b/lib/nghttp2_version.c
@@ -24,7 +24,7 @@
  */
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#endif /* defined(HAVE_CONFIG_H) */
 
 #include <nghttp2/nghttp2.h>
 


### PR DESCRIPTION
Make conditional macro comments consistent.

- Repeat condition in closing #endif.
- Use #ifdef for a single macro.  Do not use #if defined(...) in this case.  Use defined(...) form when repeating condition in #endif.
- Apply De Morgan when negating conditions in #else.