### PR TITLE
src: Move sgi _daemonize to util::daemonize

### DIFF
--- a/src/nghttpd.cc
+++ b/src/nghttpd.cc
@@ -24,10 +24,6 @@
  */
 #include "nghttp2_config.h"
 
-#ifdef __sgi
-#  define daemon _daemonize
-#endif // defined(__sgi)
-
 #ifdef HAVE_UNISTD_H
 #  include <unistd.h>
 #endif // defined(HAVE_UNISTD_H)
@@ -456,11 +452,7 @@ int main(int argc, char **argv) {
       std::cerr << "-d option must be specified when -D is used." << std::endl;
       exit(EXIT_FAILURE);
     }
-#ifdef __sgi
-    if (daemon(0, 0, 0, 0) == -1) {
-#else  // !defined(__sgi)
     if (util::daemonize(0, 0) == -1) {
-#endif // !defined(__sgi)
       perror("daemon");
       exit(EXIT_FAILURE);
     }

--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -1020,18 +1020,14 @@ int create_unix_domain_listener_socket(
 
 namespace {
 int call_daemon() {
-#ifdef __sgi
-  return _daemonize(0, 0, 0, 0);
-#else // !defined(__sgi)
-#  ifdef HAVE_LIBSYSTEMD
+#ifdef HAVE_LIBSYSTEMD
   if (sd_booted() && (getenv("NOTIFY_SOCKET") != nullptr)) {
     LOG(NOTICE) << "Daemonising disabled under systemd";
     chdir("/");
     return 0;
   }
-#  endif // defined(HAVE_LIBSYSTEMD)
+#endif // defined(HAVE_LIBSYSTEMD)
   return util::daemonize(0, 0);
-#endif   // !defined(__sgi)
 }
 } // namespace
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -1835,9 +1835,14 @@ int daemonize(int nochdir, int noclose) {
     }
   }
   return 0;
-#else  // !defined(__APPLE__)
+#elif defined(__sgi)
+  // TODO nochdir and noclose are ignored.  _daemonize is called with
+  // hard-coded zeros to preserve original behavior due to lack of a
+  // test environment.
+  return _daemonize(0, 0, 0, 0);
+#else  // !defined(__APPLE__) && !defined(__sgi)
   return daemon(nochdir, noclose);
-#endif // !defined(__APPLE__)
+#endif // !defined(__APPLE__) && !defined(__sgi)
 }
 
 std::string_view rstrip(BlockAllocator &balloc, const std::string_view &s) {


### PR DESCRIPTION
Move sgi _daemonize to util::daemonize so that we do not need to handle sgi case in the multiple places.  Because we have no test environment for sgi machine, the flags adjustment is omitted.  This is not a problem now because We only call util::daemonize with 0.