### PR TITLE
src: Adopt nghttp3_conn_read_stream2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,8 +127,8 @@ following libraries are required:
   wolfSSL; or LibreSSL (does not support 0RTT); or aws-lc; or
   `BoringSSL <https://boringssl.googlesource.com/boringssl/>`_ (commit
   fa47b1d0f9d3d30601d7e5ed158d3055cbe6ff44); or OpenSSL >= 3.5.0
-* `ngtcp2 <https://github.com/ngtcp2/ngtcp2>`_ >= 1.15.0
-* `nghttp3 <https://github.com/ngtcp2/nghttp3>`_ >= 1.11.0
+* `ngtcp2 <https://github.com/ngtcp2/ngtcp2>`_ >= 1.16.0
+* `nghttp3 <https://github.com/ngtcp2/nghttp3>`_ >= 1.12.0
 
 Use ``--enable-http3`` configure option to enable HTTP/3 feature for
 h2load and nghttpx.

--- a/configure.ac
+++ b/configure.ac
@@ -532,7 +532,7 @@ fi
 # ngtcp2 (for src)
 have_libngtcp2=no
 if test "x${request_libngtcp2}" != "xno"; then
-  PKG_CHECK_MODULES([LIBNGTCP2], [libngtcp2 >= 1.15.0], [have_libngtcp2=yes],
+  PKG_CHECK_MODULES([LIBNGTCP2], [libngtcp2 >= 1.16.0], [have_libngtcp2=yes],
                     [have_libngtcp2=no])
   if test "x${have_libngtcp2}" = "xno"; then
     AC_MSG_NOTICE($LIBNGTCP2_PKG_ERRORS)
@@ -549,7 +549,7 @@ have_libngtcp2_crypto_wolfssl=no
 if test "x${have_wolfssl_quic}" = "xyes" &&
    test "x${request_libngtcp2}" != "xno"; then
   PKG_CHECK_MODULES([LIBNGTCP2_CRYPTO_WOLFSSL],
-                    [libngtcp2_crypto_wolfssl >= 1.15.0],
+                    [libngtcp2_crypto_wolfssl >= 1.16.0],
                     [have_libngtcp2_crypto_wolfssl=yes],
                     [have_libngtcp2_crypto_wolfssl=no])
   if test "x${have_libngtcp2_crypto_wolfssl}" = "xno"; then
@@ -573,7 +573,7 @@ if test "x${have_ssl_provide_quic_data}" = "xyes" &&
    test "x${have_boringssl_quic}" != "xyes" &&
    test "x${request_libngtcp2}" != "xno"; then
   PKG_CHECK_MODULES([LIBNGTCP2_CRYPTO_QUICTLS],
-                    [libngtcp2_crypto_quictls >= 1.15.0],
+                    [libngtcp2_crypto_quictls >= 1.16.0],
                     [have_libngtcp2_crypto_quictls=yes],
                     [have_libngtcp2_crypto_quictls=no])
   if test "x${have_libngtcp2_crypto_quictls}" = "xno"; then
@@ -598,7 +598,7 @@ if test "x${have_ssl_provide_quic_data}" = "xyes" &&
    test "x${have_libressl}" = "xyes" &&
    test "x${request_libngtcp2}" != "xno"; then
   PKG_CHECK_MODULES([LIBNGTCP2_CRYPTO_LIBRESSL],
-                    [libngtcp2_crypto_libressl >= 1.15.0],
+                    [libngtcp2_crypto_libressl >= 1.16.0],
                     [have_libngtcp2_crypto_libressl=yes],
                     [have_libngtcp2_crypto_libressl=no])
   if test "x${have_libngtcp2_crypto_libressl}" = "xno"; then
@@ -643,7 +643,7 @@ have_libngtcp2_crypto_ossl=no
 if test "x${have_ossl_quic}" = "xyes" &&
    test "x${request_libngtcp2}" != "xno"; then
   PKG_CHECK_MODULES([LIBNGTCP2_CRYPTO_OSSL],
-                    [libngtcp2_crypto_ossl >= 1.15.0],
+                    [libngtcp2_crypto_ossl >= 1.16.0],
                     [have_libngtcp2_crypto_ossl=yes],
                     [have_libngtcp2_crypto_ossl=no])
   if test "x${have_libngtcp2_crypto_ossl}" = "xno"; then
@@ -663,7 +663,7 @@ fi
 # nghttp3 (for src)
 have_libnghttp3=no
 if test "x${request_libnghttp3}" != "xno"; then
-  PKG_CHECK_MODULES([LIBNGHTTP3], [libnghttp3 >= 1.11.0], [have_libnghttp3=yes],
+  PKG_CHECK_MODULES([LIBNGHTTP3], [libnghttp3 >= 1.12.0], [have_libnghttp3=yes],
                     [have_libnghttp3=no])
   if test "x${have_libnghttp3}" = "xno"; then
     AC_MSG_NOTICE($LIBNGHTTP3_PKG_ERRORS)

--- a/src/h2load_http3_session.cc
+++ b/src/h2load_http3_session.cc
@@ -424,10 +424,11 @@ int Http3Session::init_conn() {
 
 ssize_t Http3Session::read_stream(uint32_t flags, int64_t stream_id,
                                   const uint8_t *data, size_t datalen) {
-  auto nconsumed = nghttp3_conn_read_stream(
-    conn_, stream_id, data, datalen, flags & NGTCP2_STREAM_DATA_FLAG_FIN);
+  auto nconsumed = nghttp3_conn_read_stream2(
+    conn_, stream_id, data, datalen, flags & NGTCP2_STREAM_DATA_FLAG_FIN,
+    ngtcp2_conn_get_timestamp(client_->quic.conn));
   if (nconsumed < 0) {
-    std::cerr << "nghttp3_conn_read_stream: "
+    std::cerr << "nghttp3_conn_read_stream2: "
               << nghttp3_strerror(static_cast<int>(nconsumed)) << std::endl;
     ngtcp2_ccerr_set_application_error(
       &client_->quic.last_error,

--- a/src/shrpx_http3_upstream.cc
+++ b/src/shrpx_http3_upstream.cc
@@ -309,11 +309,11 @@ int Http3Upstream::recv_stream_data(uint32_t flags, int64_t stream_id,
                                     std::span<const uint8_t> data) {
   assert(httpconn_);
 
-  auto nconsumed =
-    nghttp3_conn_read_stream(httpconn_, stream_id, data.data(), data.size(),
-                             flags & NGTCP2_STREAM_DATA_FLAG_FIN);
+  auto nconsumed = nghttp3_conn_read_stream2(
+    httpconn_, stream_id, data.data(), data.size(),
+    flags & NGTCP2_STREAM_DATA_FLAG_FIN, ngtcp2_conn_get_timestamp(conn_));
   if (nconsumed < 0) {
-    ULOG(ERROR, this) << "nghttp3_conn_read_stream: "
+    ULOG(ERROR, this) << "nghttp3_conn_read_stream2: "
                       << nghttp3_strerror(static_cast<int>(nconsumed));
     ngtcp2_ccerr_set_application_error(
       &last_error_,


### PR DESCRIPTION
Adopt nghttp3_conn_read_stream2 which requires nghttp3 v1.12.0.  To pass the current timestamp, ngtcp2_conn_get_timestamp is used, which requires ngtcp2 v1.16.0.