### PR TITLE
nghttpx: Increase number of UDP packets to read

### DIFF
--- a/src/shrpx_quic.cc
+++ b/src/shrpx_quic.cc
@@ -419,4 +419,9 @@ std::span<uint64_t, 2> generate_siphash_key() {
   return key;
 }
 
+bool recv_pkt_time_threshold_exceeded(bool time_sensitive, size_t pktcnt,
+                                      ngtcp2_tstamp start, ngtcp2_tstamp now) {
+  return time_sensitive && pktcnt && now - start >= NGTCP2_MILLISECONDS;
+}
+
 } // namespace shrpx

--- a/src/shrpx_quic.h
+++ b/src/shrpx_quic.h
@@ -176,6 +176,9 @@ int generate_quic_connection_id_encryption_key(std::span<uint8_t> key,
 const QUICKeyingMaterial *
 select_quic_keying_material(const QUICKeyingMaterials &qkms, uint8_t km_id);
 
+bool recv_pkt_time_threshold_exceeded(bool time_sensitive, size_t pktcnt,
+                                      ngtcp2_tstamp start, ngtcp2_tstamp now);
+
 } // namespace shrpx
 
 #endif // !defined(SHRPX_QUIC_H)


### PR DESCRIPTION
It turns out that the limit of 10 packets per event loop is too small, that prevents an endpoint from consuming ACKs and other control frames (e.g., MAX_STREAM_DATA, MAX_STREAMS), resulting in the loss of throughput.  This change increases maximum number of packets to read to 64.  Meanwhile, BBR is very sensitive to event loop tick because its GSO burst is limited to 1ms window.  For BBR, keep reading packets until 1ms is passed or 64 packets are read.