### PR TITLE
GHA: Cancel stale job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,10 @@ on: [push, pull_request]
 
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   LIBBPF_VERSION: v1.6.2
   OPENSSL1_VERSION: 1_1_1w+quic


### PR DESCRIPTION
We have severely limited resources in terms of GitHub Actions.  We cannot run full 2 build workflows at the same time.  To speed up the latest build, we need to cancel the previous jobs, but it is too tedious.  Let's cancel those stale jobs automatically.  No need to cancel jobs on main because they should finish once committed.