### PR TITLE
nghttpx: Ensure resetting downstream h2 stream

### DIFF
--- a/src/shrpx_http2_downstream_connection.h
+++ b/src/shrpx_http2_downstream_connection.h
@@ -83,11 +83,16 @@ public:
   int submit_rst_stream(Downstream *downstream,
                         uint32_t error_code = NGHTTP2_INTERNAL_ERROR);
 
+  void set_stream_closed(bool f);
+
   Http2DownstreamConnection *dlnext, *dlprev;
 
 private:
   Http2Session *http2session_;
   StreamData *sd_;
+  // stream_closed_ is true if the stream is closed (i.e.,
+  // nghttp2_on_stream_close_callback is called).
+  bool stream_closed_;
 };
 
 } // namespace shrpx

--- a/src/shrpx_http2_session.cc
+++ b/src/shrpx_http2_session.cc
@@ -826,6 +826,8 @@ int on_stream_close_callback(nghttp2_session *session, int32_t stream_id,
     auto downstream = dconn->get_downstream();
     auto upstream = downstream->get_upstream();
 
+    dconn->set_stream_closed(true);
+
     if (downstream->get_downstream_stream_id() % 2 == 0 &&
         downstream->get_request_state() == DownstreamState::INITIAL) {
       // Downstream is canceled in backend before it is submitted in


### PR DESCRIPTION
Ensure resetting downstream h2 stream if Http2DownstreamConnection is not closed via nghttp2_on_stream_close_callback.