### PR TITLE
Cancel sending RST_STREAM if stream is not found

### DIFF
--- a/lib/nghttp2_outbound_item.h
+++ b/lib/nghttp2_outbound_item.h
@@ -111,6 +111,12 @@ typedef struct {
   uint8_t flags;
 } nghttp2_goaway_aux_data;
 
+typedef struct {
+  /* nonzero if RST_STREAM should be sent even if stream is not
+     found. */
+  uint8_t continue_without_stream;
+} nghttp2_rst_stream_aux_data;
+
 /* struct used for extension frame */
 typedef struct {
   /* nonzero if this extension frame is serialized by library
@@ -123,6 +129,7 @@ typedef union {
   nghttp2_data_aux_data data;
   nghttp2_headers_aux_data headers;
   nghttp2_goaway_aux_data goaway;
+  nghttp2_rst_stream_aux_data rst_stream;
   nghttp2_ext_aux_data ext;
 } nghttp2_aux_data;
 


### PR DESCRIPTION
nghttp2_submit_rst_stream is intended to send RST_STREAM frame to the existing stream.  Actually, nghttp2_session_add_rst_stream_continue does not add RST_STREAM if the stream is not found.  There is a situation that the stream exists when nghttp2_submit_rst_stream is called, but it may be closed before actually sending RST_STREAM. Previously, we send the frame in this case hoping that this is noop on remote endpoint.  This commit checks stream existence just before sending RST_STREAM, and if the stream is not found, cancel RST_STREAM. This is the consistent behavior of nghttp2_submit_rst_stream and fixes race condition.