### PR TITLE
nghttpx: Remove stream_closed_ from Http2DownstreamConnection

### DIFF
--- a/src/shrpx_http2_downstream_connection.cc
+++ b/src/shrpx_http2_downstream_connection.cc
@@ -51,8 +51,7 @@ Http2DownstreamConnection::Http2DownstreamConnection(Http2Session *http2session)
   : dlnext(nullptr),
     dlprev(nullptr),
     http2session_(http2session),
-    sd_(nullptr),
-    stream_closed_(false) {}
+    sd_(nullptr) {}
 
 Http2DownstreamConnection::~Http2DownstreamConnection() {
   if (LOG_ENABLED(INFO)) {
@@ -151,11 +150,6 @@ int Http2DownstreamConnection::submit_rst_stream(Downstream *downstream,
       return rv;
     default:
       break;
-    }
-
-    // If the stream has been closed, no need to submit RESET_STREAM.
-    if (stream_closed_) {
-      return rv;
     }
 
     if (LOG_ENABLED(INFO)) {
@@ -627,9 +621,5 @@ Http2DownstreamConnection::get_downstream_addr_group() const {
 }
 
 DownstreamAddr *Http2DownstreamConnection::get_addr() const { return nullptr; }
-
-void Http2DownstreamConnection::set_stream_closed(bool f) {
-  stream_closed_ = f;
-}
 
 } // namespace shrpx

--- a/src/shrpx_http2_downstream_connection.h
+++ b/src/shrpx_http2_downstream_connection.h
@@ -83,16 +83,11 @@ public:
   int submit_rst_stream(Downstream *downstream,
                         uint32_t error_code = NGHTTP2_INTERNAL_ERROR);
 
-  void set_stream_closed(bool f);
-
   Http2DownstreamConnection *dlnext, *dlprev;
 
 private:
   Http2Session *http2session_;
   StreamData *sd_;
-  // stream_closed_ is true if the stream is closed (i.e.,
-  // nghttp2_on_stream_close_callback is called).
-  bool stream_closed_;
 };
 
 } // namespace shrpx

--- a/src/shrpx_http2_session.cc
+++ b/src/shrpx_http2_session.cc
@@ -826,8 +826,6 @@ int on_stream_close_callback(nghttp2_session *session, int32_t stream_id,
     auto downstream = dconn->get_downstream();
     auto upstream = downstream->get_upstream();
 
-    dconn->set_stream_closed(true);
-
     if (downstream->get_downstream_stream_id() % 2 == 0 &&
         downstream->get_request_state() == DownstreamState::INITIAL) {
       // Downstream is canceled in backend before it is submitted in


### PR DESCRIPTION
Now RST_STREAM handling is improved in libnghttp2, we can just submit RST_STREAM, and let lbnghttp2 decide whether the frame should be sent or not.