### PR TITLE
src: Rewrite util::split_str and its variants

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ endif()
 
 if(NOT ENABLE_LIB_ONLY)
   include(ExtractValidFlags)
-  foreach(_cxx1x_flag -std=c++20)
+  foreach(_cxx1x_flag -std=c++23)
     extract_valid_cxx_flags(_cxx1x_flag_supported ${_cxx1x_flag})
     if(_cxx1x_flag_supported)
       set(CXX1XCXXFLAGS ${_cxx1x_flag})

--- a/src/shrpx_config.cc
+++ b/src/shrpx_config.cc
@@ -1212,10 +1212,12 @@ int parse_mapping(
   Config *config, DownstreamAddrConfig &addr,
   std::unordered_map<std::string_view, size_t> &pattern_addr_indexer,
   std::string_view src_pattern, std::string_view src_params) {
-  // This returns at least 1 element (it could be empty string).  We
-  // will append '/' to all patterns, so it becomes catch-all pattern.
+  // This could include an empty string.  We will append '/' to all
+  // patterns, so it becomes catch-all pattern.
   auto mapping = util::split_str(src_pattern, ':');
-  assert(!mapping.empty());
+  if (mapping.empty()) {
+    mapping.emplace_back(""sv);
+  }
   auto &downstreamconf = *config->conn.downstream;
   auto &addr_groups = downstreamconf.addr_groups;
 
@@ -3520,18 +3522,13 @@ int parse_config(
   case SHRPX_OPTID_WORKER_WRITE_BURST:
     Log{WARN} << opt << ": not implemented yet";
     return 0;
-  case SHRPX_OPTID_TLS_PROTO_LIST: {
+  case SHRPX_OPTID_TLS_PROTO_LIST:
     Log{WARN} << opt
               << ": deprecated.  Use tls-min-proto-version and "
                  "tls-max-proto-version instead.";
-    auto list = util::split_str(optarg, ',');
-    config->tls.tls_proto_list.resize(list.size());
-    for (size_t i = 0; i < list.size(); ++i) {
-      config->tls.tls_proto_list[i] = make_string_ref(config->balloc, list[i]);
-    }
+    config->tls.tls_proto_list = util::split_str(config->balloc, optarg, ',');
 
     return 0;
-  }
   case SHRPX_OPTID_VERIFY_CLIENT:
     config->tls.client_verify.enabled = util::strieq("yes"sv, optarg);
 
@@ -4336,15 +4333,10 @@ int parse_config(
   case SHRPX_OPTID_NPN_LIST:
     Log{WARN} << opt << ": deprecated.  Use alpn-list instead.";
     // fall through
-  case SHRPX_OPTID_ALPN_LIST: {
-    auto list = util::split_str(optarg, ',');
-    config->tls.alpn_list.resize(list.size());
-    for (size_t i = 0; i < list.size(); ++i) {
-      config->tls.alpn_list[i] = make_string_ref(config->balloc, list[i]);
-    }
+  case SHRPX_OPTID_ALPN_LIST:
+    config->tls.alpn_list = util::split_str(config->balloc, optarg, ',');
 
     return 0;
-  }
   case SHRPX_OPTID_ECH_CONFIG_FILE:
     return read_ech_config_file(config, opt, optarg);
   case SHRPX_OPTID_ECH_RETRY_CONFIG_FILE:

--- a/src/util.cc
+++ b/src/util.cc
@@ -992,73 +992,52 @@ bool select_protocol(const unsigned char **out, unsigned char *outlen,
 }
 
 std::vector<std::string_view> split_str(std::string_view s, char delim) {
-  size_t len = 1;
-  auto last = std::ranges::end(s);
-  std::string_view::const_iterator d;
-  for (auto first = std::ranges::begin(s);
-       (d = std::ranges::find(first, last, delim)) != last;
-       ++len, first = d + 1)
-    ;
+  return s | std::ranges::views::split(delim) |
+         std::ranges::views::transform(
+           [](auto &&r) { return std::string_view{r}; }) |
+         std::ranges::to<std::vector>();
+}
 
-  auto list = std::vector<std::string_view>(len);
-
-  len = 0;
-  for (auto first = std::ranges::begin(s);; ++len) {
-    auto stop = std::ranges::find(first, last, delim);
-    list[len] = std::string_view{first, stop};
-    if (stop == last) {
-      break;
-    }
-    first = stop + 1;
-  }
-  return list;
+std::vector<std::string_view> split_str(BlockAllocator &balloc,
+                                        std::string_view s, char delim) {
+  return s | std::ranges::views::split(delim) |
+         std::ranges::views::transform(
+           [&balloc](auto &&r) { return make_string_ref(balloc, r); }) |
+         std::ranges::to<std::vector>();
 }
 
 std::vector<std::string_view> split_str(std::string_view s, char delim,
                                         size_t n) {
-  if (n == 0) {
-    return split_str(s, delim);
+  assert(n);
+
+  if (s.empty()) {
+    return {};
   }
 
   if (n == 1) {
     return {s};
   }
 
-  size_t len = 1;
-  auto last = std::ranges::end(s);
-  std::string_view::const_iterator d;
-  for (auto first = std::ranges::begin(s);
-       len < n && (d = std::ranges::find(first, last, delim)) != last;
-       ++len, first = d + 1)
-    ;
+  auto res = std::vector<std::string_view>{};
+  res.reserve(n);
 
-  auto list = std::vector<std::string_view>(len);
+  auto parts = std::ranges::views::split(s, delim);
+  auto it = std::ranges::begin(parts);
 
-  len = 0;
-  for (auto first = std::ranges::begin(s);; ++len) {
-    if (len == n - 1) {
-      list[len] = std::string_view{first, last};
-      break;
-    }
-
-    auto stop = std::ranges::find(first, last, delim);
-    list[len] = std::string_view{first, stop};
-    if (stop == last) {
-      break;
-    }
-    first = stop + 1;
+  for (; it != std::ranges::end(parts) && n > 1; ++it, --n) {
+    res.emplace_back(*it);
   }
-  return list;
+
+  if (it != std::ranges::end(parts)) {
+    res.emplace_back(it.base(), std::ranges::end(s));
+  }
+
+  return res;
 }
 
 std::vector<std::string> parse_config_str_list(std::string_view s, char delim) {
-  auto sublist = split_str(s, delim);
-  auto res = std::vector<std::string>();
-  res.reserve(sublist.size());
-  for (const auto &s : sublist) {
-    res.emplace_back(std::ranges::begin(s), std::ranges::end(s));
-  }
-  return res;
+  return s | std::ranges::views::split(delim) |
+         std::ranges::to<std::vector<std::string>>();
 }
 
 int make_socket_closeonexec(int fd) {

--- a/src/util.h
+++ b/src/util.h
@@ -1014,12 +1014,20 @@ std::vector<std::string> parse_config_str_list(std::string_view s,
 
 // Parses delimited strings in |s| and returns Substrings in |s|
 // delimited by |delim|.  The any white spaces around substring are
-// treated as a part of substring.
+// treated as a part of substring if |delim| is not a white space.  If
+// |s| is an empty string, this function returns an empty vector.
 std::vector<std::string_view> split_str(std::string_view s, char delim);
 
+// Behaves like split_str, but this variant allocates new string using
+// |balloc|.  The each element of the returned container is a view
+// over the allocated string.
+std::vector<std::string_view> split_str(BlockAllocator &balloc,
+                                        std::string_view s, char delim);
+
 // Behaves like split_str, but this variant splits at most |n| - 1
-// times and returns at most |n| sub-strings.  If |n| is zero, it
-// falls back to split_str.
+// times and returns at most |n| sub-strings.  |n| must be greater
+// than zero.  If |s| is an empty string, this function returns an
+// empty vector.
 std::vector<std::string_view> split_str(std::string_view s, char delim,
                                         size_t n);
 

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -799,8 +799,7 @@ void test_util_parse_config_str_list(void) {
   assert_stdstring_equal("", res[3]);
 
   res = util::parse_config_str_list(""sv);
-  assert_size(1, ==, res.size());
-  assert_stdstring_equal("", res[0]);
+  assert_true(res.empty());
 
   res = util::parse_config_str_list("alpha,bravo,charlie"sv);
   assert_size(3, ==, res.size());
@@ -978,8 +977,7 @@ void test_util_split_hostport(void) {
 }
 
 void test_util_split_str(void) {
-  assert_true(std::vector<std::string_view>{""sv} ==
-              util::split_str(""sv, ','));
+  assert_true(util::split_str(""sv, ',').empty());
   assert_true(std::vector<std::string_view>{"alpha"sv} ==
               util::split_str("alpha"sv, ','));
   assert_true((std::vector<std::string_view>{"alpha"sv, ""sv}) ==
@@ -989,21 +987,23 @@ void test_util_split_str(void) {
   assert_true(
     (std::vector<std::string_view>{"alpha"sv, "bravo"sv, "charlie"sv}) ==
     util::split_str("alpha,bravo,charlie"sv, ','));
+
+  BlockAllocator balloc(4096, 4096);
+
+  assert_true((std::vector<std::string_view>{"alpha"sv, "bravo"sv}) ==
+              util::split_str(balloc, "alpha,bravo"sv, ','));
+
   assert_true(
     (std::vector<std::string_view>{"alpha"sv, "bravo"sv, "charlie"sv}) ==
-    util::split_str("alpha,bravo,charlie"sv, ',', 0));
-  assert_true(std::vector<std::string_view>{""sv} ==
-              util::split_str(""sv, ',', 1));
-  assert_true(std::vector<std::string_view>{""sv} ==
-              util::split_str(""sv, ',', 2));
+    util::split_str("alpha,bravo,charlie"sv, ',', 3));
+  assert_true(util::split_str(""sv, ',', 1).empty());
+  assert_true(util::split_str(""sv, ',', 2).empty());
   assert_true((std::vector<std::string_view>{"alpha"sv, "bravo,charlie"sv}) ==
               util::split_str("alpha,bravo,charlie"sv, ',', 2));
   assert_true(std::vector<std::string_view>{"alpha"sv} ==
               util::split_str("alpha"sv, ',', 2));
   assert_true((std::vector<std::string_view>{"alpha"sv, ""sv}) ==
               util::split_str("alpha,"sv, ',', 2));
-  assert_true(std::vector<std::string_view>{"alpha"sv} ==
-              util::split_str("alpha"sv, ',', 0));
   assert_true(std::vector<std::string_view>{"alpha,bravo,charlie"sv} ==
               util::split_str("alpha,bravo,charlie"sv, ',', 1));
 }


### PR DESCRIPTION
Now these functions return an empty string if an empty string is given.  This breaking change is handled on the call sites.