### PR TITLE
src: Avoid std::chrono::high_resolution_clock

### DIFF
--- a/src/shrpx_client_handler.cc
+++ b/src/shrpx_client_handler.cc
@@ -1219,19 +1219,18 @@ void ClientHandler::write_accesslog(Downstream *downstream) {
     req.tstamp = lgconf->tstamp;
   }
 
-  upstream_accesslog(
-    config->logging.access.format,
-    LogSpec{
-      downstream,
-      ipaddr_,
-      alpn_,
-      sni_,
-      conn_.tls.ssl,
-      std::chrono::high_resolution_clock::now(), // request_end_time
-      port_,
-      faddr_->port,
-      config->pid,
-    });
+  upstream_accesslog(config->logging.access.format,
+                     LogSpec{
+                       downstream,
+                       ipaddr_,
+                       alpn_,
+                       sni_,
+                       conn_.tls.ssl,
+                       std::chrono::steady_clock::now(), // request_end_time
+                       port_,
+                       faddr_->port,
+                       config->pid,
+                     });
 }
 
 ClientHandler::ReadBuf *ClientHandler::get_rb() { return &rb_; }

--- a/src/shrpx_downstream.cc
+++ b/src/shrpx_downstream.cc
@@ -138,7 +138,7 @@ Downstream::Downstream(Upstream *upstream, MemchunkPool *mcpool,
     balloc_(1024, 1024),
     req_(balloc_),
     resp_(balloc_),
-    request_start_time_(std::chrono::high_resolution_clock::now()),
+    request_start_time_(std::chrono::steady_clock::now()),
     blocked_request_buf_(mcpool),
     request_buf_(mcpool),
     response_buf_(mcpool),
@@ -619,11 +619,11 @@ void FieldStore::erase_content_length_and_transfer_encoding() {
 }
 
 void Downstream::set_request_start_time(
-  std::chrono::high_resolution_clock::time_point time) {
+  std::chrono::steady_clock::time_point time) {
   request_start_time_ = time;
 }
 
-std::chrono::high_resolution_clock::time_point
+std::chrono::steady_clock::time_point
 Downstream::get_request_start_time() const {
   return request_start_time_;
 }

--- a/src/shrpx_downstream.h
+++ b/src/shrpx_downstream.h
@@ -381,9 +381,8 @@ public:
   // crumble_request_cookie().
   std::string_view assemble_request_cookie();
 
-  void
-  set_request_start_time(std::chrono::high_resolution_clock::time_point time);
-  std::chrono::high_resolution_clock::time_point get_request_start_time() const;
+  void set_request_start_time(std::chrono::steady_clock::time_point time);
+  std::chrono::steady_clock::time_point get_request_start_time() const;
   int push_request_headers();
   bool get_chunked_request() const;
   void set_chunked_request(bool f);
@@ -548,7 +547,7 @@ private:
   Request req_;
   Response resp_;
 
-  std::chrono::high_resolution_clock::time_point request_start_time_;
+  std::chrono::steady_clock::time_point request_start_time_;
 
   // host we requested to downstream.  This is used to rewrite
   // location header field to decide the location should be rewritten

--- a/src/shrpx_log.h
+++ b/src/shrpx_log.h
@@ -299,7 +299,7 @@ struct LogSpec {
   std::string_view alpn;
   std::string_view sni;
   SSL *ssl;
-  std::chrono::high_resolution_clock::time_point request_end_time;
+  std::chrono::steady_clock::time_point request_end_time;
   std::string_view remote_port;
   uint16_t server_port;
   pid_t pid;


### PR DESCRIPTION
std::chrono::high_resolution_clock is not guaranteed to be steady, that makes it not suitable for our use.