### PR TITLE
nghttp: put pseudo headers before normal headers

### DIFF
--- a/src/nghttp.cc
+++ b/src/nghttp.cc
@@ -441,6 +441,8 @@ submit_request(HttpClient *client, const Headers &headers, Request *req) {
     build_headers.emplace_back(kv.name, kv.value, kv.no_index);
   }
 
+  std::ranges::stable_partition(build_headers, [](auto &&nv) { return nv.name.starts_with(':'); });
+
   auto nva = std::vector<nghttp2_nv>();
   nva.reserve(build_headers.size());
 


### PR DESCRIPTION
To support :protocol for the rfc says pseudo headers must be put before normal headers.