### PR TITLE
nghttpx: Use std::unique_ptr for quic_keying_materials_

### DIFF
--- a/src/shrpx_config.cc
+++ b/src/shrpx_config.cc
@@ -257,18 +257,18 @@ read_tls_ticket_key_file(const std::vector<std::string_view> &files,
 }
 
 #ifdef ENABLE_HTTP3
-std::shared_ptr<QUICKeyingMaterials>
+std::expected<std::unique_ptr<QUICKeyingMaterials>, Error>
 read_quic_secret_file(std::string_view path) {
   constexpr size_t expectedlen =
     SHRPX_QUIC_SECRET_RESERVEDLEN + SHRPX_QUIC_SECRETLEN + SHRPX_QUIC_SALTLEN;
 
-  auto qkms = std::make_shared<QUICKeyingMaterials>();
+  auto qkms = std::make_unique<QUICKeyingMaterials>();
   auto &kms = qkms->keying_materials;
 
   std::ifstream f(path.data());
   if (!f) {
     Log{ERROR} << "frontend-quic-secret-file: could not open file " << path;
-    return nullptr;
+    return std::unexpected{Error::IO};
   }
 
   std::string line;
@@ -283,7 +283,7 @@ read_quic_secret_file(std::string_view path) {
     if (s.size() != expectedlen * 2 || !util::is_hex_string(s)) {
       Log{ERROR} << "frontend-quic-secret-file: each line must be a "
                  << expectedlen * 2 << " bytes hex encoded string";
-      return nullptr;
+      return std::unexpected{Error::INVALID_CONFIG};
     }
 
     kms.emplace_back();
@@ -312,14 +312,14 @@ read_quic_secret_file(std::string_view path) {
     Log{ERROR}
       << "frontend-quic-secret-file: error occurred while reading file "
       << path;
-    return nullptr;
+    return std::unexpected{Error::IO};
   }
 
   if (kms.empty()) {
     Log{WARN}
       << "frontend-quic-secret-file: no keying materials are present in file "
       << path;
-    return nullptr;
+    return std::unexpected{Error::INVALID_CONFIG};
   }
 
   return qkms;

--- a/src/shrpx_config.h
+++ b/src/shrpx_config.h
@@ -1434,7 +1434,7 @@ read_tls_ticket_key_file(const std::vector<std::string_view> &files,
                          const EVP_CIPHER *cipher, const EVP_MD *hmac);
 
 #ifdef ENABLE_HTTP3
-std::shared_ptr<QUICKeyingMaterials>
+std::expected<std::unique_ptr<QUICKeyingMaterials>, Error>
 read_quic_secret_file(std::string_view path);
 #endif // defined(ENABLE_HTTP3)
 

--- a/src/shrpx_connection_handler.cc
+++ b/src/shrpx_connection_handler.cc
@@ -604,7 +604,7 @@ std::expected<void, Error> ConnectionHandler::forward_quic_packet(
 }
 
 void ConnectionHandler::set_quic_keying_materials(
-  std::shared_ptr<QUICKeyingMaterials> qkms) {
+  std::unique_ptr<QUICKeyingMaterials> qkms) {
   quic_keying_materials_ = std::move(qkms);
 }
 

--- a/src/shrpx_connection_handler.h
+++ b/src/shrpx_connection_handler.h
@@ -166,7 +166,7 @@ public:
                       const Address &local_addr, const ngtcp2_pkt_info &pi,
                       const WorkerID &wid, std::span<const uint8_t> data);
 
-  void set_quic_keying_materials(std::shared_ptr<QUICKeyingMaterials> qkms);
+  void set_quic_keying_materials(std::unique_ptr<QUICKeyingMaterials> qkms);
 
   void set_worker_ids(std::vector<WorkerID> worker_ids);
   std::expected<Worker *, Error> find_worker(const WorkerID &wid) const;
@@ -227,7 +227,7 @@ private:
 #  ifdef HAVE_LIBBPF
   std::vector<BPFRef> quic_bpf_refs_;
 #  endif // defined(HAVE_LIBBPF)
-  std::shared_ptr<QUICKeyingMaterials> quic_keying_materials_;
+  std::unique_ptr<QUICKeyingMaterials> quic_keying_materials_;
   std::vector<SSL_CTX *> quic_all_ssl_ctx_;
   std::vector<std::vector<SSL_CTX *>> quic_indexed_ssl_ctx_;
 #endif // defined(ENABLE_HTTP3)

--- a/src/shrpx_worker.cc
+++ b/src/shrpx_worker.cc
@@ -1517,7 +1517,7 @@ Worker::find_quic_upstream_addr(const Address &local_addr) {
 }
 
 std::expected<void, Error> Worker::setup_quic_keying_materials(
-  const std::shared_ptr<QUICKeyingMaterials> &qkms) {
+  const std::unique_ptr<QUICKeyingMaterials> &qkms) {
   quic_keying_materials_ = std::make_unique<QUICKeyingMaterials>();
   quic_keying_materials_->keying_materials = qkms->keying_materials;
 

--- a/src/shrpx_worker.h
+++ b/src/shrpx_worker.h
@@ -398,7 +398,7 @@ public:
   find_quic_upstream_addr(const Address &local_addr);
 
   std::expected<void, Error>
-  setup_quic_keying_materials(const std::shared_ptr<QUICKeyingMaterials> &qkms);
+  setup_quic_keying_materials(const std::unique_ptr<QUICKeyingMaterials> &qkms);
 
   [[nodiscard]] const std::unique_ptr<QUICKeyingMaterials> &
   get_quic_keying_materials() const {

--- a/src/shrpx_worker_process.cc
+++ b/src/shrpx_worker_process.cc
@@ -558,17 +558,19 @@ worker_process_event_loop(WorkerProcessConfig *wpconf) {
 #ifdef ENABLE_HTTP3
   auto &quicconf = config->quic;
 
-  std::shared_ptr<QUICKeyingMaterials> qkms;
+  std::unique_ptr<QUICKeyingMaterials> qkms;
 
   if (!quicconf.upstream.secret_file.empty()) {
-    qkms = read_quic_secret_file(quicconf.upstream.secret_file);
-    if (!qkms) {
+    auto maybe_qkms = read_quic_secret_file(quicconf.upstream.secret_file);
+    if (!maybe_qkms) {
       Log{WARN} << "Use QUIC keying materials generated internally";
+    } else {
+      qkms = std::move(*maybe_qkms);
     }
   }
 
   if (!qkms) {
-    qkms = std::make_shared<QUICKeyingMaterials>();
+    qkms = std::make_unique<QUICKeyingMaterials>();
     qkms->keying_materials.resize(1);
 
     auto &qkm = qkms->keying_materials.front();


### PR DESCRIPTION
Use std::unique_ptr for quic_keying_materials_ because we do not copy it around.