### PR TITLE
src: Avoid zero-argument std::println

### DIFF
--- a/src/deflatehd.cc
+++ b/src/deflatehd.cc
@@ -112,7 +112,7 @@ static void output_to_json(nghttp2_hd_deflater *deflater, const uint8_t *buf,
                         dump_deflate_header_table(deflater));
   }
   json_dumpf(obj, stdout, JSON_PRESERVE_ORDER | JSON_INDENT(2));
-  std::println();
+  std::println("");
   json_decref(obj);
 }
 

--- a/src/h2load.cc
+++ b/src/h2load.cc
@@ -3901,7 +3901,7 @@ int main(int argc, char **argv) {
                                   static_cast<double>(stats.bytes_head_decomp);
   }
 
-  std::println();
+  std::println("");
   std::println("finished in {}, {:.2f} req/s, {}B/s",
                util::format_duration(duration), rps,
                util::utos_funit(as_unsigned(bps)));

--- a/src/nghttp.cc
+++ b/src/nghttp.cc
@@ -967,7 +967,7 @@ HttpClient::on_upgrade_read(std::span<const uint8_t> data) {
   }
 
   if (config.verbose) {
-    std::println();
+    std::println("");
   }
 
   if (upgrade_response_status_code != 101) {


### PR DESCRIPTION
The zero-argument overload of std::println is C++26.  Use an empty format string so these line-separator prints remain valid with C++23 standard library implementations.

This fixes a build failure with Apple clang 16.0.0 (clang-1600.0.26.6) and the macOS 14.5 SDK, whose libc++ provides std::println(format, args...) but not std::println().