### PR TITLE
lib: Rewrite integer decoder in http

### DIFF
--- a/lib/nghttp2_http.c
+++ b/lib/nghttp2_http.c
@@ -52,27 +52,39 @@ static int memieq(const void *a, const void *b, size_t n) {
 #define lstrieq(A, B, N)                                                       \
   (nghttp2_strlen_lit((A)) == (N) && memieq((A), (B), (N)))
 
+static int32_t parse_status_code(const uint8_t *s, size_t len) {
+  if (len != 3 || '1' > s[0] || s[0] > '9' || '0' > s[1] || s[1] > '9' ||
+      '0' > s[2] || s[2] > '9') {
+    return -1;
+  }
+
+  return (s[0] - '0') * 100 + (s[1] - '0') * 10 + (s[2] - '0');
+}
+
 static int64_t parse_uint(const uint8_t *s, size_t len) {
-  int64_t n = 0;
+  uint64_t n = 0;
+  uint32_t c;
   size_t i;
+
   if (len == 0) {
     return -1;
   }
+
   for (i = 0; i < len; ++i) {
-    if ('0' <= s[i] && s[i] <= '9') {
-      if (n > INT64_MAX / 10) {
-        return -1;
-      }
-      n *= 10;
-      if (n > INT64_MAX - (s[i] - '0')) {
-        return -1;
-      }
-      n += s[i] - '0';
-      continue;
+    if ('0' > s[i] || s[i] > '9') {
+      return -1;
     }
-    return -1;
+
+    c = s[i] - '0';
+
+    if (n > ((uint64_t)INT64_MAX - c) / 10) {
+      return -1;
+    }
+
+    n = n * 10 + c;
   }
-  return n;
+
+  return (int64_t)n;
 }
 
 static int check_pseudo_header(nghttp2_stream *stream, const nghttp2_hd_nv *nv,
@@ -247,10 +259,7 @@ static int http_response_on_header(nghttp2_stream *stream, nghttp2_hd_nv *nv,
     if (!check_pseudo_header(stream, nv, NGHTTP2_HTTP_FLAG__STATUS)) {
       return NGHTTP2_ERR_HTTP_HEADER;
     }
-    if (nv->value->len != 3) {
-      return NGHTTP2_ERR_HTTP_HEADER;
-    }
-    stream->status_code = (int16_t)parse_uint(nv->value->base, nv->value->len);
+    stream->status_code = parse_status_code(nv->value->base, nv->value->len);
     if (stream->status_code == -1 || stream->status_code == 101) {
       return NGHTTP2_ERR_HTTP_HEADER;
     }

--- a/lib/nghttp2_stream.h
+++ b/lib/nghttp2_stream.h
@@ -179,7 +179,7 @@ struct nghttp2_stream {
   /* This is unpaid penalty (offset) when calculating cycle. */
   uint32_t pending_penalty;
   /* status code from remote server */
-  int16_t status_code;
+  int32_t status_code;
   /* Bitwise OR of zero or more NGHTTP2_HTTP_FLAG_* values */
   uint32_t http_flags;
   /* This is bitwise-OR of 0 or more of NGHTTP2_STREAM_FLAG_*

--- a/tests/nghttp2_session_test.c
+++ b/tests/nghttp2_session_test.c
@@ -10973,6 +10973,16 @@ void test_nghttp2_http_mandatory_headers(void) {
     MAKE_NV(":method", "CONNECT"),
     MAKE_NV(":authority", "localhost"),
   };
+  /* response header contains status code that includes the leading
+     zero. */
+  static const nghttp2_nv lzstatus_resnv[] = {
+    MAKE_NV(":status", "022"),
+  };
+  /* response header contains status code that consists of 2
+     digits. */
+  static const nghttp2_nv twodigstatus_resnv[] = {
+    MAKE_NV(":status", "20"),
+  };
   check_http_opts opts = {0};
 
   /* response header lacks :status */
@@ -11127,6 +11137,14 @@ void test_nghttp2_http_mandatory_headers(void) {
      SETTINGS_CONNECT_PROTOCOL */
   check_nghttp2_http_recv_headers_ok(opts, -1, regularconnect_reqnv,
                                      ARRLEN(regularconnect_reqnv));
+
+  /* HTTP status code with the leading zero is not permitted. */
+  check_nghttp2_http_recv_headers_fail(opts, -1, lzstatus_resnv,
+                                       ARRLEN(lzstatus_resnv));
+
+  /* HTTP status code consisting of 2 digits is not permitted. */
+  check_nghttp2_http_recv_headers_fail(opts, -1, twodigstatus_resnv,
+                                       ARRLEN(twodigstatus_resnv));
 }
 
 void test_nghttp2_http_content_length(void) {
@@ -11169,7 +11187,7 @@ void test_nghttp2_http_content_length(void) {
   assert_ptrdiff((nghttp2_ssize)nghttp2_buf_len(&bufs.head->buf), ==, rv);
   assert_null(nghttp2_session_get_next_ob_item(session));
   assert_int64(9000000000LL, ==, stream->content_length);
-  assert_int16(200, ==, stream->status_code);
+  assert_int32(200, ==, stream->status_code);
 
   nghttp2_hd_deflate_free(&deflater);
 
@@ -12032,7 +12050,7 @@ void test_nghttp2_http_push_promise(void) {
 
   assert_null(nghttp2_session_get_next_ob_item(session));
 
-  assert_int16(200, ==, stream->status_code);
+  assert_int32(200, ==, stream->status_code);
 
   nghttp2_bufs_reset(&bufs);
 


### PR DESCRIPTION
This effectively tightens up HTTP status code validation by allowing 3 digits only.  Make nghttp2_stream.status_code of type int32_t because int16_t does not give us any advantage.