### PR TITLE
nghttpx: Provide frontend and backend stream timeouts

### DIFF
--- a/gennghttpxfun.py
+++ b/gennghttpxfun.py
@@ -207,6 +207,10 @@ OPTIONS = [
     "groups",
     "ech-config-file",
     "ech-retry-config-file",
+    "frontend-stream-read-timeout",
+    "frontend-stream-write-timeout",
+    "backend-stream-read-timeout",
+    "backend-stream-write-timeout",
 ]
 
 LOGVARS = [

--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -1689,6 +1689,8 @@ void fill_default_config(Config *config) {
   httpconf.xfp.strip_incoming = true;
   httpconf.early_data.strip_incoming = true;
   httpconf.timeout.header = 1_min;
+  httpconf.upstream.timeout.stream_write = 1_min;
+  httpconf.downstream.timeout.stream_write = 1_min;
 
   auto &http2conf = config->http2;
   {
@@ -1727,8 +1729,6 @@ void fill_default_config(Config *config) {
     nghttp2_option_set_max_deflate_dynamic_table_size(
       upstreamconf.alt_mode_option, upstreamconf.encoder_dynamic_table_size);
   }
-
-  http2conf.timeout.stream_write = 1_min;
 
   {
     auto &downstreamconf = http2conf.downstream;
@@ -2353,16 +2353,26 @@ Timeout:
               itself is left intact.
               Default: )"
       << util::duration_str(config->http.timeout.header) << R"(
-  --stream-read-timeout=<DURATION>
-              Specify  read timeout  for HTTP/2  streams.  0  means no
-              timeout.
+  --frontend-stream-read-timeout=<DURATION>
+              Specify read  timeout for  HTTP/2 and HTTP/3  streams in
+              the frontend connection.  0 means no timeout.
               Default: )"
-      << util::duration_str(config->http2.timeout.stream_read) << R"(
-  --stream-write-timeout=<DURATION>
-              Specify write  timeout for  HTTP/2 streams.  0  means no
-              timeout.
+      << util::duration_str(config->http.upstream.timeout.stream_read) << R"(
+  --frontend-stream-write-timeout=<DURATION>
+              Specify write  timeout for HTTP/2 and  HTTP/3 streams in
+              the frontend connection.  0 means no timeout.
               Default: )"
-      << util::duration_str(config->http2.timeout.stream_write) << R"(
+      << util::duration_str(config->http.upstream.timeout.stream_write) << R"(
+  --backend-stream-read-timeout=<DURATION>
+              Specify read  timeout for HTTP/2 streams  in the backend
+              connection.  0 means no timeout.
+              Default: )"
+      << util::duration_str(config->http.downstream.timeout.stream_read) << R"(
+  --backend-stream-write-timeout=<DURATION>
+              Specify write timeout for  HTTP/2 streams in the backend
+              connection.  0 means no timeout.
+              Default: )"
+      << util::duration_str(config->http.downstream.timeout.stream_write) << R"(
   --backend-read-timeout=<DURATION>
               Specify read timeout for backend connection.
               Default: )"
@@ -3993,6 +4003,14 @@ int main(int argc, char **argv) {
       {SHRPX_OPT_GROUPS.data(), required_argument, &flag, 197},
       {SHRPX_OPT_ECH_CONFIG_FILE.data(), required_argument, &flag, 198},
       {SHRPX_OPT_ECH_RETRY_CONFIG_FILE.data(), required_argument, &flag, 199},
+      {SHRPX_OPT_FRONTEND_STREAM_READ_TIMEOUT.data(), required_argument, &flag,
+       200},
+      {SHRPX_OPT_FRONTEND_STREAM_WRITE_TIMEOUT.data(), required_argument, &flag,
+       201},
+      {SHRPX_OPT_BACKEND_STREAM_READ_TIMEOUT.data(), required_argument, &flag,
+       202},
+      {SHRPX_OPT_BACKEND_STREAM_WRITE_TIMEOUT.data(), required_argument, &flag,
+       203},
       {nullptr, 0, nullptr, 0}};
 
     int option_index = 0;
@@ -4930,6 +4948,26 @@ int main(int argc, char **argv) {
       case 199:
         // --ech-retry-config-file
         cmdcfgs.emplace_back(SHRPX_OPT_ECH_RETRY_CONFIG_FILE,
+                             std::string_view{optarg});
+        break;
+      case 200:
+        // --frontend-stream-read-timeout
+        cmdcfgs.emplace_back(SHRPX_OPT_FRONTEND_STREAM_READ_TIMEOUT,
+                             std::string_view{optarg});
+        break;
+      case 201:
+        // --frontend-stream-write-timeout
+        cmdcfgs.emplace_back(SHRPX_OPT_FRONTEND_STREAM_WRITE_TIMEOUT,
+                             std::string_view{optarg});
+        break;
+      case 202:
+        // --backend-stream-read-timeout
+        cmdcfgs.emplace_back(SHRPX_OPT_BACKEND_STREAM_READ_TIMEOUT,
+                             std::string_view{optarg});
+        break;
+      case 203:
+        // --backend-stream-write-timeout
+        cmdcfgs.emplace_back(SHRPX_OPT_BACKEND_STREAM_WRITE_TIMEOUT,
                              std::string_view{optarg});
         break;
       default:

--- a/src/shrpx_config.cc
+++ b/src/shrpx_config.cc
@@ -2643,6 +2643,9 @@ int option_lookup_token(std::string_view name) {
       }
       break;
     case 't':
+      if (util::strieq("backend-stream-read-timeou"sv, name.substr(0, 26))) {
+        return SHRPX_OPTID_BACKEND_STREAM_READ_TIMEOUT;
+      }
       if (util::strieq("frontend-http2-idle-timeou"sv, name.substr(0, 26))) {
         return SHRPX_OPTID_FRONTEND_HTTP2_IDLE_TIMEOUT;
       }
@@ -2689,6 +2692,21 @@ int option_lookup_token(std::string_view name) {
     case 't':
       if (util::strieq("backend-connections-per-hos"sv, name.substr(0, 27))) {
         return SHRPX_OPTID_BACKEND_CONNECTIONS_PER_HOST;
+      }
+      if (util::strieq("backend-stream-write-timeou"sv, name.substr(0, 27))) {
+        return SHRPX_OPTID_BACKEND_STREAM_WRITE_TIMEOUT;
+      }
+      if (util::strieq("frontend-stream-read-timeou"sv, name.substr(0, 27))) {
+        return SHRPX_OPTID_FRONTEND_STREAM_READ_TIMEOUT;
+      }
+      break;
+    }
+    break;
+  case 29:
+    switch (name[28]) {
+    case 't':
+      if (util::strieq("frontend-stream-write-timeou"sv, name.substr(0, 28))) {
+        return SHRPX_OPTID_FRONTEND_STREAM_WRITE_TIMEOUT;
       }
       break;
     }
@@ -3231,12 +3249,22 @@ std::expected<void, Error> parse_config(
       config->conn.downstream->timeout.connect = r;
     });
   case SHRPX_OPTID_STREAM_READ_TIMEOUT:
+    Log{WARN} << opt
+              << ": deprecated.  Use --frontend-stream-read-timeout and "
+                 "--backend-stream-read-timeout";
+
     return parse_duration(opt, optarg).transform([config](auto &&r) {
-      config->http2.timeout.stream_read = r;
+      config->http.upstream.timeout.stream_read = r;
+      config->http.downstream.timeout.stream_read = r;
     });
   case SHRPX_OPTID_STREAM_WRITE_TIMEOUT:
+    Log{WARN} << opt
+              << ": deprecated.  Use --frontend-stream-write-timeout and "
+                 "--backend-stream-write-timeout";
+
     return parse_duration(opt, optarg).transform([config](auto &&r) {
-      config->http2.timeout.stream_write = r;
+      config->http.upstream.timeout.stream_write = r;
+      config->http.downstream.timeout.stream_write = r;
     });
   case SHRPX_OPTID_ACCESSLOG_FILE:
     config->logging.access.file = make_string_ref(config->balloc, optarg);
@@ -4352,6 +4380,22 @@ std::expected<void, Error> parse_config(
     return read_ech_config_file(config, opt, optarg);
   case SHRPX_OPTID_ECH_RETRY_CONFIG_FILE:
     return read_ech_config_file(config, opt, optarg, /* retry = */ true);
+  case SHRPX_OPTID_FRONTEND_STREAM_READ_TIMEOUT:
+    return parse_duration(opt, optarg).transform([config](auto &&r) {
+      config->http.upstream.timeout.stream_read = r;
+    });
+  case SHRPX_OPTID_FRONTEND_STREAM_WRITE_TIMEOUT:
+    return parse_duration(opt, optarg).transform([config](auto &&r) {
+      config->http.upstream.timeout.stream_write = r;
+    });
+  case SHRPX_OPTID_BACKEND_STREAM_READ_TIMEOUT:
+    return parse_duration(opt, optarg).transform([config](auto &&r) {
+      config->http.downstream.timeout.stream_read = r;
+    });
+  case SHRPX_OPTID_BACKEND_STREAM_WRITE_TIMEOUT:
+    return parse_duration(opt, optarg).transform([config](auto &&r) {
+      config->http.downstream.timeout.stream_write = r;
+    });
   case SHRPX_OPTID_CONF:
     Log{WARN} << "conf: ignored";
 

--- a/src/shrpx_config.h
+++ b/src/shrpx_config.h
@@ -388,6 +388,14 @@ inline constexpr auto SHRPX_OPT_GROUPS = "groups"sv;
 inline constexpr auto SHRPX_OPT_ECH_CONFIG_FILE = "ech-config-file"sv;
 inline constexpr auto SHRPX_OPT_ECH_RETRY_CONFIG_FILE =
   "ech-retry-config-file"sv;
+inline constexpr auto SHRPX_OPT_FRONTEND_STREAM_READ_TIMEOUT =
+  "frontend-stream-read-timeout"sv;
+inline constexpr auto SHRPX_OPT_FRONTEND_STREAM_WRITE_TIMEOUT =
+  "frontend-stream-write-timeout"sv;
+inline constexpr auto SHRPX_OPT_BACKEND_STREAM_READ_TIMEOUT =
+  "backend-stream-read-timeout"sv;
+inline constexpr auto SHRPX_OPT_BACKEND_STREAM_WRITE_TIMEOUT =
+  "backend-stream-write-timeout"sv;
 
 inline constexpr size_t SHRPX_OBFUSCATED_NODE_LENGTH = 8;
 
@@ -851,6 +859,18 @@ struct HttpConfig {
   struct {
     ev_tstamp header;
   } timeout;
+  struct {
+    struct {
+      ev_tstamp stream_read;
+      ev_tstamp stream_write;
+    } timeout;
+  } upstream;
+  struct {
+    struct {
+      ev_tstamp stream_read;
+      ev_tstamp stream_write;
+    } timeout;
+  } downstream;
   std::vector<AltSvc> altsvcs;
   // altsvcs serialized in a wire format.
   std::string_view altsvc_header_value;
@@ -913,10 +933,6 @@ struct Http2Config {
     int32_t connection_window_size;
     size_t max_concurrent_streams;
   } downstream;
-  struct {
-    ev_tstamp stream_read;
-    ev_tstamp stream_write;
-  } timeout;
   bool no_cookie_crumbling;
   bool no_server_push;
 };
@@ -1166,6 +1182,8 @@ enum {
   SHRPX_OPTID_BACKEND_READ_TIMEOUT,
   SHRPX_OPTID_BACKEND_REQUEST_BUFFER,
   SHRPX_OPTID_BACKEND_RESPONSE_BUFFER,
+  SHRPX_OPTID_BACKEND_STREAM_READ_TIMEOUT,
+  SHRPX_OPTID_BACKEND_STREAM_WRITE_TIMEOUT,
   SHRPX_OPTID_BACKEND_TLS,
   SHRPX_OPTID_BACKEND_TLS_SNI_FIELD,
   SHRPX_OPTID_BACKEND_WRITE_TIMEOUT,
@@ -1233,6 +1251,8 @@ enum {
   SHRPX_OPTID_FRONTEND_QUIC_REQUIRE_TOKEN,
   SHRPX_OPTID_FRONTEND_QUIC_SECRET_FILE,
   SHRPX_OPTID_FRONTEND_READ_TIMEOUT,
+  SHRPX_OPTID_FRONTEND_STREAM_READ_TIMEOUT,
+  SHRPX_OPTID_FRONTEND_STREAM_WRITE_TIMEOUT,
   SHRPX_OPTID_FRONTEND_WRITE_TIMEOUT,
   SHRPX_OPTID_GROUPS,
   SHRPX_OPTID_HEADER_FIELD_BUFFER,

--- a/src/shrpx_downstream.cc
+++ b/src/shrpx_downstream.cc
@@ -145,16 +145,14 @@ Downstream::Downstream(Upstream *upstream, MemchunkPool *mcpool,
 
   ev_timer_init(&header_timer_, header_timeoutcb, 0., httpconf.timeout.header);
 
-  auto &timeoutconf = config->http2.timeout;
-
   ev_timer_init(&upstream_rtimer_, &upstream_rtimeoutcb, 0.,
-                timeoutconf.stream_read);
+                httpconf.upstream.timeout.stream_read);
   ev_timer_init(&upstream_wtimer_, &upstream_wtimeoutcb, 0.,
-                timeoutconf.stream_write);
+                httpconf.upstream.timeout.stream_write);
   ev_timer_init(&downstream_rtimer_, &downstream_rtimeoutcb, 0.,
-                timeoutconf.stream_read);
+                httpconf.downstream.timeout.stream_read);
   ev_timer_init(&downstream_wtimer_, &downstream_wtimeoutcb, 0.,
-                timeoutconf.stream_write);
+                httpconf.downstream.timeout.stream_write);
 
   header_timer_.data = this;
   upstream_rtimer_.data = this;
@@ -986,7 +984,7 @@ void disable_timer(struct ev_loop *loop, ev_timer *w) {
 } // namespace
 
 void Downstream::reset_upstream_rtimer() {
-  if (get_config()->http2.timeout.stream_read == 0.) {
+  if (get_config()->http.upstream.timeout.stream_read == 0.) {
     return;
   }
   auto loop = upstream_->get_client_handler()->get_loop();
@@ -995,7 +993,7 @@ void Downstream::reset_upstream_rtimer() {
 
 void Downstream::reset_upstream_wtimer() {
   auto loop = upstream_->get_client_handler()->get_loop();
-  auto &timeoutconf = get_config()->http2.timeout;
+  const auto &timeoutconf = get_config()->http.upstream.timeout;
 
   if (timeoutconf.stream_write != 0.) {
     reset_timer(loop, &upstream_wtimer_);
@@ -1006,7 +1004,7 @@ void Downstream::reset_upstream_wtimer() {
 }
 
 void Downstream::ensure_upstream_wtimer() {
-  if (get_config()->http2.timeout.stream_write == 0.) {
+  if (get_config()->http.upstream.timeout.stream_write == 0.) {
     return;
   }
   auto loop = upstream_->get_client_handler()->get_loop();
@@ -1014,7 +1012,7 @@ void Downstream::ensure_upstream_wtimer() {
 }
 
 void Downstream::disable_upstream_rtimer() {
-  if (get_config()->http2.timeout.stream_read == 0.) {
+  if (get_config()->http.upstream.timeout.stream_read == 0.) {
     return;
   }
   auto loop = upstream_->get_client_handler()->get_loop();
@@ -1022,7 +1020,7 @@ void Downstream::disable_upstream_rtimer() {
 }
 
 void Downstream::disable_upstream_wtimer() {
-  if (get_config()->http2.timeout.stream_write == 0.) {
+  if (get_config()->http.upstream.timeout.stream_write == 0.) {
     return;
   }
   auto loop = upstream_->get_client_handler()->get_loop();
@@ -1030,7 +1028,7 @@ void Downstream::disable_upstream_wtimer() {
 }
 
 void Downstream::reset_downstream_rtimer() {
-  if (get_config()->http2.timeout.stream_read == 0.) {
+  if (get_config()->http.downstream.timeout.stream_read == 0.) {
     return;
   }
   auto loop = upstream_->get_client_handler()->get_loop();
@@ -1039,7 +1037,7 @@ void Downstream::reset_downstream_rtimer() {
 
 void Downstream::reset_downstream_wtimer() {
   auto loop = upstream_->get_client_handler()->get_loop();
-  auto &timeoutconf = get_config()->http2.timeout;
+  const auto &timeoutconf = get_config()->http.downstream.timeout;
 
   if (timeoutconf.stream_write != 0.) {
     reset_timer(loop, &downstream_wtimer_);
@@ -1050,7 +1048,7 @@ void Downstream::reset_downstream_wtimer() {
 }
 
 void Downstream::ensure_downstream_wtimer() {
-  if (get_config()->http2.timeout.stream_write == 0.) {
+  if (get_config()->http.downstream.timeout.stream_write == 0.) {
     return;
   }
   auto loop = upstream_->get_client_handler()->get_loop();
@@ -1058,7 +1056,7 @@ void Downstream::ensure_downstream_wtimer() {
 }
 
 void Downstream::disable_downstream_rtimer() {
-  if (get_config()->http2.timeout.stream_read == 0.) {
+  if (get_config()->http.downstream.timeout.stream_read == 0.) {
     return;
   }
   auto loop = upstream_->get_client_handler()->get_loop();
@@ -1066,7 +1064,7 @@ void Downstream::disable_downstream_rtimer() {
 }
 
 void Downstream::disable_downstream_wtimer() {
-  if (get_config()->http2.timeout.stream_write == 0.) {
+  if (get_config()->http.downstream.timeout.stream_write == 0.) {
     return;
   }
   auto loop = upstream_->get_client_handler()->get_loop();


### PR DESCRIPTION
Deprecate stream-read-timeout and stream-write-timeout options.  Add the following options to configure these timeouts for frontend and backend separately:

- frontend-stream-read-timeout
- frontend-stream-write-timeout
- backend-stream-read-timeout
- backend-stream-write-timeout

For backward compatibility, stream-read-timeout sets both frontend-stream-read-timeout and backend-stream-read-timeout. Likewise, stream-write-timeout sets both frontend-stream-write-timeout and backend-stream-write-timeout.