### PR TITLE
nghttpx: Drop connection when frontend write rate is too low

### DIFF
--- a/gennghttpxfun.py
+++ b/gennghttpxfun.py
@@ -211,6 +211,9 @@ OPTIONS = [
     "frontend-stream-write-timeout",
     "backend-stream-read-timeout",
     "backend-stream-write-timeout",
+    "frontend-min-write-rate",
+    "frontend-initial-write-rate-timeout",
+    "frontend-max-write-rate-timeout",
 ]
 
 LOGVARS = [

--- a/src/shrpx.cc
+++ b/src/shrpx.cc
@@ -1688,6 +1688,8 @@ void fill_default_config(Config *config) {
   httpconf.early_data.strip_incoming = true;
   httpconf.timeout.header = 1_min;
   httpconf.upstream.timeout.stream_write = 1_min;
+  httpconf.upstream.timeout.initial_write_rate = 10_s;
+  httpconf.upstream.timeout.max_write_rate = 1_min;
   httpconf.downstream.timeout.stream_write = 1_min;
 
   auto &http2conf = config->http2;
@@ -2464,6 +2466,33 @@ Options:
               option caps its maximum value.
               Default: {})",
     util::duration_str(config->conn.downstream->timeout.max_backoff));
+
+  std::println(out, R"(  --frontend-min-write-rate=<SIZE>
+              Set the  minimum rate  of stream  data that  client must
+              read from frontend connection.  The <SIZE> specifies the
+              number of bytes per second.  If client is unable to read
+              at least the given rate,  the connection is closed.  The
+              implementation extends the timeout by the stream data to
+              send.    Use  --frontend-initial-write-rate-timeout   to
+              specify       the       initial      timeout.        Use
+              --frontend-max-write-rate-timeout  to  set  the  maximum
+              timeout.  Setting 0 disables this feature.
+              Default: {})",
+               util::utos_unit(config->http.upstream.min_write_rate));
+
+  std::println(
+    out, R"(  --frontend-initial-write-rate-timeout=<DURATION>
+              Set the initial timeout set by --frontend-min-write-rate
+              feature.
+              Default: {})",
+    util::duration_str(config->http.upstream.timeout.initial_write_rate));
+
+  std::println(
+    out, R"(  --frontend-max-write-rate-timeout=<DURATION>
+              Set the maximum timeout set by --frontend-min-write-rate
+              feature.
+              Default: {})",
+    util::duration_str(config->http.upstream.timeout.max_write_rate));
 
   std::println(out, "");
   std::println(out, "SSL/TLS:");
@@ -4189,6 +4218,11 @@ int main(int argc, char **argv) {
        202},
       {SHRPX_OPT_BACKEND_STREAM_WRITE_TIMEOUT.data(), required_argument, &flag,
        203},
+      {SHRPX_OPT_FRONTEND_MIN_WRITE_RATE.data(), required_argument, &flag, 204},
+      {SHRPX_OPT_FRONTEND_INITIAL_WRITE_RATE_TIMEOUT.data(), required_argument,
+       &flag, 205},
+      {SHRPX_OPT_FRONTEND_MAX_WRITE_RATE_TIMEOUT.data(), required_argument,
+       &flag, 206},
       {nullptr, 0, nullptr, 0}};
 
     int option_index = 0;
@@ -5146,6 +5180,21 @@ int main(int argc, char **argv) {
       case 203:
         // --backend-stream-write-timeout
         cmdcfgs.emplace_back(SHRPX_OPT_BACKEND_STREAM_WRITE_TIMEOUT,
+                             std::string_view{optarg});
+        break;
+      case 204:
+        // --frontend-min-write-rate
+        cmdcfgs.emplace_back(SHRPX_OPT_FRONTEND_MIN_WRITE_RATE,
+                             std::string_view{optarg});
+        break;
+      case 205:
+        // --frontend-initial-write-rate-timeout
+        cmdcfgs.emplace_back(SHRPX_OPT_FRONTEND_INITIAL_WRITE_RATE_TIMEOUT,
+                             std::string_view{optarg});
+        break;
+      case 206:
+        // --frontend-max-write-rate-timeout
+        cmdcfgs.emplace_back(SHRPX_OPT_FRONTEND_MAX_WRITE_RATE_TIMEOUT,
                              std::string_view{optarg});
         break;
       default:

--- a/src/shrpx_client_handler.cc
+++ b/src/shrpx_client_handler.cc
@@ -90,6 +90,16 @@ void shutdowncb(struct ev_loop *loop, ev_timer *w, int revents) {
 } // namespace
 
 namespace {
+void write_ratecb(struct ev_loop *loop, ev_timer *w, int revents) {
+  auto handler = static_cast<ClientHandler *>(w->data);
+
+  if (!handler->on_write_rate_timeout()) {
+    delete handler;
+  }
+}
+} // namespace
+
+namespace {
 void readcb(struct ev_loop *loop, ev_io *w, int revents) {
   auto conn = static_cast<Connection *>(w->data);
   auto handler = static_cast<ClientHandler *>(conn->data);
@@ -452,6 +462,10 @@ ClientHandler::ClientHandler(Worker *worker, int fd, SSL *ssl,
 
   reneg_shutdown_timer_.data = this;
 
+  ev_timer_init(&write_rate_timer_, write_ratecb, 0., 0.);
+
+  write_rate_timer_.data = this;
+
   if (!faddr->quic) {
     conn_.rlimit.startw();
   }
@@ -558,6 +572,7 @@ ClientHandler::~ClientHandler() {
     worker_->schedule_clear_mcpool();
   }
 
+  ev_timer_stop(conn_.loop, &write_rate_timer_);
   ev_timer_stop(conn_.loop, &reneg_shutdown_timer_);
 
   // TODO If backend is http/2, and it is in CONNECTED state, signal
@@ -1675,6 +1690,82 @@ void ClientHandler::set_local_hostport(const sockaddr *addr,
   }
 
   local_hostport_ = util::make_hostport(balloc_, host.data(), faddr_->port);
+}
+
+void ClientHandler::register_write_rate_timer(Downstream *downstream) {
+  if (get_config()->http.upstream.min_write_rate == 0 ||
+      downstream->is_upstream_write_rate_member()) {
+    return;
+  }
+
+  ++write_rate_member_count_;
+  downstream->set_upstream_write_rate_member(true);
+
+  auto config = get_config();
+  const auto &timeoutconf = config->http.upstream.timeout;
+
+  if (write_rate_member_count_ > 1 ||
+      (ev_is_active(&write_rate_timer_) &&
+       std::max(ev_timer_remaining(conn_.loop, &write_rate_timer_), 0.) >=
+         static_cast<double>(timeoutconf.initial_write_rate))) {
+    return;
+  }
+
+  write_rate_timer_.repeat = timeoutconf.initial_write_rate;
+  ev_timer_again(conn_.loop, &write_rate_timer_);
+}
+
+void ClientHandler::unregister_write_rate_timer(Downstream *downstream) {
+  if (!downstream->is_upstream_write_rate_member()) {
+    return;
+  }
+
+  downstream->set_upstream_write_rate_member(false);
+
+  assert(write_rate_member_count_);
+
+  if (--write_rate_member_count_) {
+    return;
+  }
+
+  // Keep timer running.  When it fires and there is no member, stop
+  // timer.  Frequently starting and stopping timer could bring
+  // performance penalty.
+}
+
+void ClientHandler::extend_write_rate_timer(size_t datalen) {
+  auto config = get_config();
+  const auto &httpconf = config->http;
+
+  if (httpconf.upstream.min_write_rate == 0) {
+    return;
+  }
+
+  auto repeat =
+    ev_is_active(&write_rate_timer_)
+      ? std::max(ev_timer_remaining(conn_.loop, &write_rate_timer_), 0.)
+      : httpconf.upstream.timeout.initial_write_rate;
+
+  repeat += static_cast<double>(datalen) /
+            static_cast<double>(httpconf.upstream.min_write_rate);
+
+  write_rate_timer_.repeat =
+    std::min(httpconf.upstream.timeout.max_write_rate, repeat);
+
+  ev_timer_again(conn_.loop, &write_rate_timer_);
+}
+
+std::expected<void, Error> ClientHandler::on_write_rate_timeout() {
+  if (write_rate_member_count_ == 0) {
+    ev_timer_stop(conn_.loop, &write_rate_timer_);
+    return {};
+  }
+
+  if (log_enabled(INFO)) {
+    Log{INFO, this} << "Close connection due to low write rate";
+  }
+
+  return std::unexpected{Error::NETWORK};
 }
 
 } // namespace shrpx

--- a/src/shrpx_client_handler.h
+++ b/src/shrpx_client_handler.h
@@ -206,6 +206,11 @@ public:
 
   void set_local_hostport(const sockaddr *addr, socklen_t addrlen);
 
+  void register_write_rate_timer(Downstream *downstream);
+  void unregister_write_rate_timer(Downstream *downstream);
+  void extend_write_rate_timer(size_t nwrite);
+  std::expected<void, Error> on_write_rate_timeout();
+
 private:
   // Allocator to allocate memory for connection-wide objects.  Make
   // sure that the allocations must be bounded, and not proportional
@@ -221,6 +226,7 @@ private:
   DefaultMemchunkBuffer rb_;
   Connection conn_;
   ev_timer reneg_shutdown_timer_;
+  ev_timer write_rate_timer_;
   std::unique_ptr<Upstream> upstream_;
   // IP address of client.  If UNIX domain socket is used, this is
   // "localhost".
@@ -251,6 +257,8 @@ private:
   bool should_close_after_write_{};
   // true if affinity_hash_ is computed
   bool affinity_hash_computed_{};
+  // the number of Downstreams participating to the write rate group.
+  size_t write_rate_member_count_{};
 };
 
 } // namespace shrpx

--- a/src/shrpx_config.cc
+++ b/src/shrpx_config.cc
@@ -2492,6 +2492,9 @@ int option_lookup_token(std::string_view name) {
       if (util::strieq("client-private-key-fil"sv, name.substr(0, 22))) {
         return SHRPX_OPTID_CLIENT_PRIVATE_KEY_FILE;
       }
+      if (util::strieq("frontend-min-write-rat"sv, name.substr(0, 22))) {
+        return SHRPX_OPTID_FRONTEND_MIN_WRITE_RATE;
+      }
       if (util::strieq("private-key-passwd-fil"sv, name.substr(0, 22))) {
         return SHRPX_OPTID_PRIVATE_KEY_PASSWD_FILE;
       }
@@ -2751,6 +2754,10 @@ int option_lookup_token(std::string_view name) {
                        name.substr(0, 30))) {
         return SHRPX_OPTID_FRONTEND_HTTP2_SETTINGS_TIMEOUT;
       }
+      if (util::strieq("frontend-max-write-rate-timeou"sv,
+                       name.substr(0, 30))) {
+        return SHRPX_OPTID_FRONTEND_MAX_WRITE_RATE_TIMEOUT;
+      }
       break;
     }
     break;
@@ -2838,6 +2845,12 @@ int option_lookup_token(std::string_view name) {
       if (util::strieq("frontend-quic-congestion-controlle"sv,
                        name.substr(0, 34))) {
         return SHRPX_OPTID_FRONTEND_QUIC_CONGESTION_CONTROLLER;
+      }
+      break;
+    case 't':
+      if (util::strieq("frontend-initial-write-rate-timeou"sv,
+                       name.substr(0, 34))) {
+        return SHRPX_OPTID_FRONTEND_INITIAL_WRITE_RATE_TIMEOUT;
       }
       break;
     }
@@ -4395,6 +4408,18 @@ std::expected<void, Error> parse_config(
   case SHRPX_OPTID_BACKEND_STREAM_WRITE_TIMEOUT:
     return parse_duration(opt, optarg).transform([config](auto &&r) {
       config->http.downstream.timeout.stream_write = r;
+    });
+  case SHRPX_OPTID_FRONTEND_MIN_WRITE_RATE:
+    return parse_uint_with_unit<size_t>(opt, optarg)
+      .transform(
+        [config](auto &&r) { config->http.upstream.min_write_rate = r; });
+  case SHRPX_OPTID_FRONTEND_INITIAL_WRITE_RATE_TIMEOUT:
+    return parse_duration(opt, optarg).transform([config](auto &&r) {
+      config->http.upstream.timeout.initial_write_rate = r;
+    });
+  case SHRPX_OPTID_FRONTEND_MAX_WRITE_RATE_TIMEOUT:
+    return parse_duration(opt, optarg).transform([config](auto &&r) {
+      config->http.upstream.timeout.max_write_rate = r;
     });
   case SHRPX_OPTID_CONF:
     Log{WARN} << "conf: ignored";

--- a/src/shrpx_config.h
+++ b/src/shrpx_config.h
@@ -396,6 +396,12 @@ inline constexpr auto SHRPX_OPT_BACKEND_STREAM_READ_TIMEOUT =
   "backend-stream-read-timeout"sv;
 inline constexpr auto SHRPX_OPT_BACKEND_STREAM_WRITE_TIMEOUT =
   "backend-stream-write-timeout"sv;
+inline constexpr auto SHRPX_OPT_FRONTEND_MIN_WRITE_RATE =
+  "frontend-min-write-rate"sv;
+inline constexpr auto SHRPX_OPT_FRONTEND_INITIAL_WRITE_RATE_TIMEOUT =
+  "frontend-initial-write-rate-timeout"sv;
+inline constexpr auto SHRPX_OPT_FRONTEND_MAX_WRITE_RATE_TIMEOUT =
+  "frontend-max-write-rate-timeout"sv;
 
 inline constexpr size_t SHRPX_OBFUSCATED_NODE_LENGTH = 8;
 
@@ -863,7 +869,10 @@ struct HttpConfig {
     struct {
       ev_tstamp stream_read;
       ev_tstamp stream_write;
+      ev_tstamp initial_write_rate;
+      ev_tstamp max_write_rate;
     } timeout;
+    size_t min_write_rate;
   } upstream;
   struct {
     struct {
@@ -1239,8 +1248,11 @@ enum {
   SHRPX_OPTID_FRONTEND_HTTP3_MAX_WINDOW_SIZE,
   SHRPX_OPTID_FRONTEND_HTTP3_READ_TIMEOUT,
   SHRPX_OPTID_FRONTEND_HTTP3_WINDOW_SIZE,
+  SHRPX_OPTID_FRONTEND_INITIAL_WRITE_RATE_TIMEOUT,
   SHRPX_OPTID_FRONTEND_KEEP_ALIVE_TIMEOUT,
   SHRPX_OPTID_FRONTEND_MAX_REQUESTS,
+  SHRPX_OPTID_FRONTEND_MAX_WRITE_RATE_TIMEOUT,
+  SHRPX_OPTID_FRONTEND_MIN_WRITE_RATE,
   SHRPX_OPTID_FRONTEND_NO_TLS,
   SHRPX_OPTID_FRONTEND_QUIC_CONGESTION_CONTROLLER,
   SHRPX_OPTID_FRONTEND_QUIC_DEBUG_LOG,

--- a/src/shrpx_downstream.cc
+++ b/src/shrpx_downstream.cc
@@ -173,7 +173,11 @@ Downstream::~Downstream() {
 
   // check nullptr for unittest
   if (upstream_) {
-    auto loop = upstream_->get_client_handler()->get_loop();
+    auto handler = upstream_->get_client_handler();
+
+    handler->unregister_write_rate_timer(this);
+
+    auto loop = handler->get_loop();
 
     ev_timer_stop(loop, &upstream_rtimer_);
     ev_timer_stop(loop, &upstream_wtimer_);
@@ -182,7 +186,6 @@ Downstream::~Downstream() {
     ev_timer_stop(loop, &header_timer_);
 
 #ifdef HAVE_MRUBY
-    auto handler = upstream_->get_client_handler();
     auto worker = handler->get_worker();
     auto mruby_ctx = worker->get_mruby_context();
 
@@ -1069,6 +1072,14 @@ void Downstream::disable_downstream_wtimer() {
   }
   auto loop = upstream_->get_client_handler()->get_loop();
   disable_timer(loop, &downstream_wtimer_);
+}
+
+void Downstream::register_upstream_write_rate_timer() {
+  upstream_->get_client_handler()->register_write_rate_timer(this);
+}
+
+void Downstream::unregister_upstream_write_rate_timer() {
+  upstream_->get_client_handler()->unregister_write_rate_timer(this);
 }
 
 bool Downstream::accesslog_ready() const {

--- a/src/shrpx_downstream.h
+++ b/src/shrpx_downstream.h
@@ -455,6 +455,9 @@ public:
   void disable_downstream_rtimer();
   void disable_downstream_wtimer();
 
+  void register_upstream_write_rate_timer();
+  void unregister_upstream_write_rate_timer();
+
   // Returns true if accesslog can be written for this downstream.
   bool accesslog_ready() const;
 
@@ -510,6 +513,14 @@ public:
 
   size_t get_buffered_request_body_length() const {
     return blocked_request_buf_.rleft() + request_buf_.rleft();
+  }
+
+  void set_upstream_write_rate_member(bool b) {
+    upstream_write_rate_member_ = b;
+  }
+
+  bool is_upstream_write_rate_member() const {
+    return upstream_write_rate_member_;
   }
 
   enum {
@@ -611,6 +622,7 @@ private:
   // true if request contains "expect: 100-continue" header field.
   bool expect_100_continue_{};
   bool stop_reading_{};
+  bool upstream_write_rate_member_{};
 };
 
 } // namespace shrpx

--- a/src/shrpx_http2_upstream.cc
+++ b/src/shrpx_http2_upstream.cc
@@ -802,6 +802,7 @@ int send_data_callback(nghttp2_session *session, nghttp2_frame *frame,
                        nghttp2_data_source *source, void *user_data) {
   auto downstream = static_cast<Downstream *>(source->ptr);
   auto upstream = static_cast<Http2Upstream *>(downstream->get_upstream());
+  auto handler = upstream->get_client_handler();
   auto body = downstream->get_response_buf();
 
   auto wb = upstream->get_response_buf();
@@ -820,8 +821,10 @@ int send_data_callback(nghttp2_session *session, nghttp2_frame *frame,
 
   if (body->rleft() == 0) {
     downstream->disable_upstream_wtimer();
+    downstream->unregister_upstream_write_rate_timer();
   } else {
     downstream->reset_upstream_wtimer();
+    handler->extend_write_rate_timer(length);
   }
 
   if (length > 0 && !downstream->resume_read(SHRPX_NO_BUFFER, length)) {
@@ -1543,6 +1546,7 @@ Http2Upstream::send_reply(Downstream *downstream,
 
   if (data_prd_ptr) {
     downstream->reset_upstream_wtimer();
+    downstream->register_upstream_write_rate_timer();
   }
 
   return {};
@@ -1598,6 +1602,7 @@ Http2Upstream::error_reply(Downstream *downstream, unsigned int status_code) {
   }
 
   downstream->reset_upstream_wtimer();
+  downstream->register_upstream_write_rate_timer();
 
   return {};
 }
@@ -1903,6 +1908,7 @@ Http2Upstream::on_downstream_body(Downstream *downstream,
       session_, static_cast<int32_t>(downstream->get_stream_id()));
 
     downstream->ensure_upstream_wtimer();
+    downstream->register_upstream_write_rate_timer();
   }
 
   return {};
@@ -1927,6 +1933,7 @@ Http2Upstream::on_downstream_body_complete(Downstream *downstream) {
   nghttp2_session_resume_data(
     session_, static_cast<int32_t>(downstream->get_stream_id()));
   downstream->ensure_upstream_wtimer();
+  downstream->register_upstream_write_rate_timer();
 
   return {};
 }

--- a/src/shrpx_https_upstream.cc
+++ b/src/shrpx_https_upstream.cc
@@ -560,6 +560,9 @@ int htp_hdrs_completecb(llhttp_t *htp) {
       auto output = downstream->get_response_buf();
       static constexpr auto res = "HTTP/1.1 100 Continue\r\n\r\n"sv;
       output->append(res);
+
+      downstream->register_upstream_write_rate_timer();
+
       handler->signal_write();
     }
   }
@@ -1070,6 +1073,8 @@ HttpsUpstream::send_reply(Downstream *downstream,
 
   downstream->set_response_state(DownstreamState::MSG_COMPLETE);
 
+  downstream->register_upstream_write_rate_timer();
+
   return {};
 }
 
@@ -1120,6 +1125,8 @@ void HttpsUpstream::error_reply(unsigned int status_code) {
   }
 
   downstream->set_response_state(DownstreamState::MSG_COMPLETE);
+
+  downstream->register_upstream_write_rate_timer();
 }
 
 void HttpsUpstream::attach_downstream(std::unique_ptr<Downstream> downstream) {
@@ -1366,6 +1373,8 @@ HttpsUpstream::on_downstream_header_complete(Downstream *downstream) {
     log_response_headers(buf);
   }
 
+  downstream->register_upstream_write_rate_timer();
+
   return {};
 }
 
@@ -1388,6 +1397,9 @@ HttpsUpstream::on_downstream_body(Downstream *downstream,
   if (downstream->get_chunked_response()) {
     output->append("\r\n"sv);
   }
+
+  downstream->register_upstream_write_rate_timer();
+
   return {};
 }
 
@@ -1407,6 +1419,8 @@ HttpsUpstream::on_downstream_body_complete(Downstream *downstream) {
                                               http2::HDOP_STRIP_ALL);
       output->append("\r\n"sv);
     }
+
+    downstream->register_upstream_write_rate_timer();
   }
   if (log_enabled(INFO)) {
     Log{INFO, downstream} << "HTTP response completed";
@@ -1587,6 +1601,12 @@ void HttpsUpstream::response_drain(size_t n) {
   auto buf = downstream_->get_response_buf();
 
   buf->drain(n);
+
+  handler_->extend_write_rate_timer(n);
+
+  if (buf->rleft() == 0) {
+    downstream_->unregister_upstream_write_rate_timer();
+  }
 }
 
 bool HttpsUpstream::response_empty() const {


### PR DESCRIPTION
HTTP/3 support will be added in the upcoming PR because it requires new API that is not available in the released nghttp3 versions.