### PR TITLE
util: add <fstream> include

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -46,6 +46,7 @@
 #include <algorithm>
 #include <memory>
 #include <chrono>
+#include <fstream>
 #include <unordered_map>
 #include <random>
 #include <ranges>


### PR DESCRIPTION
This shows up with GCC 17 where some transitive internal includes changed: it worked by chance before.