### PR TITLE
examples: avoid libev header collisions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -285,10 +285,6 @@ the sample command like this:
     $ ./configure
     $ make
 
-If you want to compile the applications under ``examples/``, you need
-to remove or rename the ``event.h`` from libev's installation, because
-it conflicts with libevent's installation.
-
 Notes for installation on Linux systems
 --------------------------------------------
 After installing nghttp2 tool suite with ``make install`` one might experience a similar error:

--- a/examples/libevent-client.c
+++ b/examples/libevent-client.c
@@ -58,7 +58,8 @@ char *strndup(const char *s, size_t size);
 #include <openssl/err.h>
 #include <openssl/conf.h>
 
-#include <event.h>
+#include <event2/buffer.h>
+#include <event2/bufferevent.h>
 #include <event2/event.h>
 #include <event2/bufferevent_ssl.h>
 #include <event2/dns.h>

--- a/examples/libevent-server.c
+++ b/examples/libevent-server.c
@@ -66,7 +66,8 @@
 #include <openssl/err.h>
 #include <openssl/conf.h>
 
-#include <event.h>
+#include <event2/buffer.h>
+#include <event2/bufferevent.h>
 #include <event2/event.h>
 #include <event2/bufferevent_ssl.h>
 #include <event2/listener.h>


### PR DESCRIPTION
Fixes #2832.

Both libevent examples include `<event.h>`, which can resolve to libev's compatibility header when its include directory precedes libevent's. Including `<event2/event.h>` afterwards then produces conflicting declarations.

Use `<event2/buffer.h>` and `<event2/bufferevent.h>` directly for the APIs previously obtained through `<event.h>`. Remove the README workaround requiring users to remove or rename libev's header.

Validation: reproduced the original compile errors with libev 4.33 ahead of libevent 2.1.13 in the header search path. With this change, both examples and the full configured build pass with `ENABLE_WERROR=ON`; all 195 library tests and 5 allocation-failure tests pass. A local TLS HTTP/2 request between the two examples returns status 200 and a byte-identical response body.

AI assistance was used to investigate the issue, prepare the patch, and run local validation.
